### PR TITLE
Add user defined numeric functions to Doctrine

### DIFF
--- a/application/src/Db/Udf/Acos.php
+++ b/application/src/Db/Udf/Acos.php
@@ -1,0 +1,25 @@
+<?php
+namespace Omeka\Db\Udf;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+class Acos extends FunctionNode
+{
+    public $expression;
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->expression = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return sprintf('ACOS(%s)', $this->expression->dispatch($sqlWalker));
+    }
+}

--- a/application/src/Db/Udf/Cos.php
+++ b/application/src/Db/Udf/Cos.php
@@ -1,0 +1,25 @@
+<?php
+namespace Omeka\Db\Udf;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+class Cos extends FunctionNode
+{
+    public $expression;
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->expression = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return sprintf('COS(%s)', $this->expression->dispatch($sqlWalker));
+    }
+}

--- a/application/src/Db/Udf/Radians.php
+++ b/application/src/Db/Udf/Radians.php
@@ -1,0 +1,25 @@
+<?php
+namespace Omeka\Db\Udf;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+class Radians extends FunctionNode
+{
+    public $expression;
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->expression = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return sprintf('RADIANS(%s)', $this->expression->dispatch($sqlWalker));
+    }
+}

--- a/application/src/Db/Udf/Sin.php
+++ b/application/src/Db/Udf/Sin.php
@@ -1,0 +1,25 @@
+<?php
+namespace Omeka\Db\Udf;
+
+use Doctrine\ORM\Query\AST\Functions\FunctionNode;
+use Doctrine\ORM\Query\Lexer;
+use Doctrine\ORM\Query\Parser;
+use Doctrine\ORM\Query\SqlWalker;
+
+class Sin extends FunctionNode
+{
+    public $expression;
+
+    public function parse(Parser $parser)
+    {
+        $parser->match(Lexer::T_IDENTIFIER);
+        $parser->match(Lexer::T_OPEN_PARENTHESIS);
+        $this->expression = $parser->ArithmeticPrimary();
+        $parser->match(Lexer::T_CLOSE_PARENTHESIS);
+    }
+
+    public function getSql(SqlWalker $sqlWalker)
+    {
+        return sprintf('SIN(%s)', $this->expression->dispatch($sqlWalker));
+    }
+}

--- a/application/src/Service/EntityManagerFactory.php
+++ b/application/src/Service/EntityManagerFactory.php
@@ -54,6 +54,11 @@ class EntityManagerFactory implements FactoryInterface
         );
         $emConfig->setProxyDir(OMEKA_PATH . '/data/doctrine-proxies');
         $emConfig->addFilter('visibility', 'Omeka\Db\Filter\VisibilityFilter');
+        // Add user defined functions.
+        $emConfig->addCustomNumericFunction('acos', 'Omeka\Db\Udf\Acos');
+        $emConfig->addCustomNumericFunction('cos', 'Omeka\Db\Udf\Cos');
+        $emConfig->addCustomNumericFunction('radians', 'Omeka\Db\Udf\Radians');
+        $emConfig->addCustomNumericFunction('sin', 'Omeka\Db\Udf\Sin');
         // Use the underscore naming strategy to preempt potential compatibility
         // issues with the case sensitivity of various operating systems.
         // @see http://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html


### PR DESCRIPTION
The Mapping module needs these MySQL functions to [calculate distance](https://github.com/omeka-s-modules/Mapping/compare/query-by-radius#diff-3448ba26cfe85a4057bc96e5942d0246R119), but I think they should be available in core code for wider use.

In addition, we may want to compare the functions [shipped with Doctrine](https://github.com/doctrine/doctrine2/tree/master/lib/Doctrine/ORM/Query/AST/Functions) with the ones [MySQL provides](http://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html) and add the missing ones. (The question arises: should we add the missing string and date/time functions as well? That's a lot of functions.)