### PR TITLE
Use Doctrine's paginator to iterate entities and get total count

### DIFF
--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -218,7 +218,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements
         $this->limitQuery($qb, $query);
         $qb->addOrderBy("$entityClass.id", $query['sort_order']);
 
-        $paginator = new Paginator($qb);
+        $paginator = new Paginator($qb, false);
         $representations = [];
         foreach ($paginator as $entity) {
             if (is_array($entity)) {


### PR DESCRIPTION
I forgot why we initially decided to forgo Doctrine's paginator, but I do remember it being problematic. Now it seems to work.

I'm not sure if the `$qb->groupBy("$entityClass.id")` is needed since it appears the paginator works without it.

A fortunate side-effect of this is that aliasing a SELECT expression (i.e. `SELECT {something} AS {alias}`) now works as expected. Whereas before it resulted in a `'{alias}' is not defined.` error.