### PR TITLE
Empty SiteSettings's cache when site is changed

### DIFF
--- a/application/src/Settings/SiteSettings.php
+++ b/application/src/Settings/SiteSettings.php
@@ -19,13 +19,17 @@ class SiteSettings extends AbstractSettings
      */
     public function setSite($site)
     {
+        $siteId = null;
         if ($site instanceof Site) {
-            $this->siteId = $site->getId();
+            $siteId = $site->getId();
         } else if ($site instanceof SiteRepresentation) {
-            $this->siteId = $site->id();
-        } else {
-            $this->siteId = null;
+            $siteId = $site->id();
         }
+
+        if ($siteId !== $this->siteId) {
+            $this->cache = null;
+        }
+        $this->siteId = $siteId;
     }
 
     protected function setCache()

--- a/application/src/Test/DbTestCase.php
+++ b/application/src/Test/DbTestCase.php
@@ -36,7 +36,7 @@ class DbTestCase extends TestCase
      */
     public function tearDown()
     {
-        self::getApplication()->getServiceManager()->get('Omeka\qEntityManager')
+        self::getApplication()->getServiceManager()->get('Omeka\EntityManager')
             ->getConnection()->rollback();
     }
 

--- a/application/test/OmekaTest/Settings/SiteSettingsTest.php
+++ b/application/test/OmekaTest/Settings/SiteSettingsTest.php
@@ -2,7 +2,6 @@
 
 namespace OmekaTest\Settings;
 
-use Omeka\Settings\SiteSettings;
 use Omeka\Test\DbTestCase;
 
 class SiteSettingsTest extends DbTestCase

--- a/application/test/OmekaTest/Settings/SiteSettingsTest.php
+++ b/application/test/OmekaTest/Settings/SiteSettingsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace OmekaTest\Settings;
+
+use Omeka\Settings\SiteSettings;
+use Omeka\Test\DbTestCase;
+
+class SiteSettingsTest extends DbTestCase
+{
+    protected $site1;
+    protected $site2;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $serviceLocator = $this->getServiceLocator();
+        $api = $serviceLocator->get('Omeka\ApiManager');
+
+        // Trigger the creation of ModuleManager since it's the only place where
+        // Omeka\Mvc\Status::setIsInstalled is called
+        // (isInstalled is checked in Omeka\Settings\AbstractSettings)
+        $moduleManager = $serviceLocator->get('Omeka\ModuleManager');
+
+        $this->site1 = $api->create('sites', [
+            'o:title' => 'Site 1',
+            'o:slug' => 'site1',
+            'o:theme' => 'default',
+            'o:is_public' => 1,
+        ])->getContent();
+        $this->site2 = $api->create('sites', [
+            'o:title' => 'Site 2',
+            'o:slug' => 'site2',
+            'o:theme' => 'default',
+            'o:is_public' => 1,
+        ])->getContent();
+    }
+
+    public function testCache()
+    {
+        $siteSettings = $this->getSiteSettings();
+
+        $siteSettings->setSite($this->site1);
+        $siteSettings->set('site_title', $this->site1->title());
+        $this->assertEquals($siteSettings->get('site_title'), $this->site1->title());
+        $siteSettings->setSite($this->site2);
+        $siteSettings->set('site_title', $this->site2->title());
+        $this->assertEquals($siteSettings->get('site_title'), $this->site2->title());
+
+        $siteSettings->setSite($this->site1);
+        $this->assertEquals($siteSettings->get('site_title'), $this->site1->title());
+    }
+
+    protected function getServiceLocator()
+    {
+        return self::getApplication()->getServiceManager();
+    }
+
+    protected function getSiteSettings()
+    {
+        return $this->getServiceLocator()->get('Omeka\SiteSettings');
+    }
+}


### PR DESCRIPTION
The cache is not refreshed after setSite is called. It can cause problems if one try to get/set settings for several sites in the same request.