### PR TITLE
Data types should fall back gracefully

### DIFF
--- a/application/asset/js/resource-form.js
+++ b/application/asset/js/resource-form.js
@@ -123,7 +123,11 @@
         if (typeof type !== 'string') {
             type = valueObj['type'];
         }
-        var value = $('fieldset.value.template[data-data-type="' + type + '"]').clone(true);
+        var value = $('fieldset.value.template[data-data-type="' + type + '"]');
+        if (!value.length) {
+            value = $('fieldset.value.template[data-data-type="literal"]');
+        }
+        value = value.clone(true);
         value.removeClass('template');
 
         // Prepare the value node.

--- a/application/src/DataType/Fallback.php
+++ b/application/src/DataType/Fallback.php
@@ -1,0 +1,20 @@
+<?php
+namespace Omeka\DataType;
+
+class Fallback extends Literal
+{
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getLabel()
+    {
+        return sprintf('%s [%s]', 'Unknown', $this->name); // @translate
+    }
+}

--- a/application/src/DataType/Manager.php
+++ b/application/src/DataType/Manager.php
@@ -30,6 +30,15 @@ class Manager extends AbstractPluginManager
         return $instance;
     }
 
+    public function get($name, $options = [], $usePeeringServiceManagers = true) {
+        try {
+            $instance = parent::get($name, $options, $usePeeringServiceManagers);
+        } catch (ServiceNotFoundException $e) {
+            $instance = new Fallback($name);
+        }
+        return $instance;
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Adds a data type Fallback class that the manager instantiates when the requested data type isn't found. Also, adds fallback logic to resource-form.js.

fixes #683