### PR TITLE
Pass page to block layout form method

### DIFF
--- a/application/src/Controller/SiteAdmin/PageController.php
+++ b/application/src/Controller/SiteAdmin/PageController.php
@@ -107,9 +107,14 @@ class PageController extends AbstractActionController
 
     public function blockAction()
     {
+        $site = $this->currentSite();
+        $page = $this->api()->read('site_pages', [
+            'slug' => $this->params('page-slug'),
+            'site' => $site->id(),
+        ])->getContent();
+
         $content = $this->viewHelpers()->get('blockLayout')->form(
-            $this->params()->fromPost('layout'),
-            $this->currentSite()
+            $this->params()->fromPost('layout'), $site, $page
         );
 
         $response = $this->getResponse();

--- a/application/src/Site/BlockLayout/BlockLayoutInterface.php
+++ b/application/src/Site/BlockLayout/BlockLayoutInterface.php
@@ -2,6 +2,7 @@
 namespace Omeka\Site\BlockLayout;
 
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Omeka\Entity\SitePageBlock;
 use Omeka\Stdlib\ErrorStore;
@@ -47,11 +48,12 @@ interface BlockLayoutInterface
      *
      * @param PhpRenderer $view
      * @param SiteRepresentation $site
+     * @param SitePageRepresentation $page
      * @param null|SitePageBlockRepresentation $block
      * @return string
      */
     public function form(PhpRenderer $view, SiteRepresentation $site,
-        SitePageBlockRepresentation $block = null);
+        SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null);
 
     /**
      * Render the provided block.

--- a/application/src/Site/BlockLayout/BrowsePreview.php
+++ b/application/src/Site/BlockLayout/BrowsePreview.php
@@ -2,6 +2,7 @@
 namespace Omeka\Site\BlockLayout;
 
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Zend\Form\Element\Text;
 use Zend\View\Renderer\PhpRenderer;
@@ -14,7 +15,7 @@ class BrowsePreview extends AbstractBlockLayout
     }
 
     public function form(PhpRenderer $view, SiteRepresentation $site,
-        SitePageBlockRepresentation $block = null
+        SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null
     ) {
         $text = new Text("o:block[__blockIndex__][o:data][query]");
         $heading = new Text("o:block[__blockIndex__][o:data][heading]");

--- a/application/src/Site/BlockLayout/Fallback.php
+++ b/application/src/Site/BlockLayout/Fallback.php
@@ -2,6 +2,7 @@
 namespace Omeka\Site\BlockLayout;
 
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Zend\View\Renderer\PhpRenderer;
 
@@ -32,7 +33,7 @@ class Fallback extends AbstractBlockLayout
      * {@inheritDoc}
      */
     public function form(PhpRenderer $view, SiteRepresentation $site,
-        SitePageBlockRepresentation $block = null
+        SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null
     ) {
         return $view->translate('This layout is invalid.');
     }

--- a/application/src/Site/BlockLayout/Html.php
+++ b/application/src/Site/BlockLayout/Html.php
@@ -2,6 +2,7 @@
 namespace Omeka\Site\BlockLayout;
 
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Omeka\Entity\SitePageBlock;
 use Omeka\Service\HtmlPurifier;
@@ -35,7 +36,7 @@ class Html extends AbstractBlockLayout
     }
 
     public function form(PhpRenderer $view, SiteRepresentation $site,
-        SitePageBlockRepresentation $block = null
+        SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null
     ) {
         $textarea = new Textarea("o:block[__blockIndex__][o:data][html]");
         $textarea->setAttribute('class', 'block-html full wysiwyg');

--- a/application/src/Site/BlockLayout/ItemShowcase.php
+++ b/application/src/Site/BlockLayout/ItemShowcase.php
@@ -2,6 +2,7 @@
 namespace Omeka\Site\BlockLayout;
 
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Zend\View\Renderer\PhpRenderer;
 
@@ -13,7 +14,7 @@ class ItemShowcase extends AbstractBlockLayout
     }
 
     public function form(PhpRenderer $view, SiteRepresentation $site,
-        SitePageBlockRepresentation $block = null
+        SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null
     ) {
         $html = '';
         $html .= $view->blockAttachmentsForm($block);

--- a/application/src/Site/BlockLayout/ItemWithMetadata.php
+++ b/application/src/Site/BlockLayout/ItemWithMetadata.php
@@ -2,6 +2,7 @@
 namespace Omeka\Site\BlockLayout;
 
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Zend\View\Renderer\PhpRenderer;
 
@@ -13,7 +14,7 @@ class ItemWithMetadata extends AbstractBlockLayout
     }
 
     public function form(PhpRenderer $view, SiteRepresentation $site,
-        SitePageBlockRepresentation $block = null
+        SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null
     ) {
         return $view->blockAttachmentsForm($block);
     }

--- a/application/src/Site/BlockLayout/LineBreak.php
+++ b/application/src/Site/BlockLayout/LineBreak.php
@@ -3,6 +3,7 @@ namespace Omeka\Site\BlockLayout;
 
 use Zend\Form\Element\Select;
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Zend\View\Renderer\PhpRenderer;
 
@@ -14,7 +15,7 @@ class LineBreak extends AbstractBlockLayout
     }
 
     public function form(PhpRenderer $view, SiteRepresentation $site,
-        SitePageBlockRepresentation $block = null
+        SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null
     ) {
         return $this->breakTypeSelect($view, $site, $block);
     }

--- a/application/src/Site/BlockLayout/Media.php
+++ b/application/src/Site/BlockLayout/Media.php
@@ -3,6 +3,7 @@ namespace Omeka\Site\BlockLayout;
 
 use Zend\Form\Element\Select;
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Zend\View\Renderer\PhpRenderer;
 
@@ -14,7 +15,7 @@ class Media extends AbstractBlockLayout
     }
 
     public function form(PhpRenderer $view, SiteRepresentation $site,
-        SitePageBlockRepresentation $block = null
+        SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null
     ) {
         $html = '';
         $html .= $view->blockAttachmentsForm($block);

--- a/application/src/Site/BlockLayout/PageTitle.php
+++ b/application/src/Site/BlockLayout/PageTitle.php
@@ -2,6 +2,7 @@
 namespace Omeka\Site\BlockLayout;
 
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Zend\View\Renderer\PhpRenderer;
 
@@ -13,9 +14,9 @@ class PageTitle extends AbstractBlockLayout
     }
 
     public function form(PhpRenderer $view, SiteRepresentation $site,
-        SitePageBlockRepresentation $block = null
+        SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null
     ) {
-        return $block->page()->title();
+        return $page->title();
     }
 
     public function render(PhpRenderer $view, SitePageBlockRepresentation $block)

--- a/application/src/Site/BlockLayout/TableOfContents.php
+++ b/application/src/Site/BlockLayout/TableOfContents.php
@@ -2,6 +2,7 @@
 namespace Omeka\Site\BlockLayout;
 
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
 use Omeka\Api\Representation\SitePageBlockRepresentation;
 use Zend\Navigation\Navigation;
 use Zend\Form\Element\Number;
@@ -15,7 +16,7 @@ class TableOfContents extends AbstractBlockLayout
     }
 
     public function form(PhpRenderer $view, SiteRepresentation $site,
-        SitePageBlockRepresentation $block = null
+        SitePageRepresentation $page = null, SitePageBlockRepresentation $block = null
     ) {
         $depth = new Number("o:block[__blockIndex__][o:data][depth]");
 

--- a/application/src/View/Helper/BlockLayout.php
+++ b/application/src/View/Helper/BlockLayout.php
@@ -74,14 +74,17 @@ class BlockLayout extends AbstractHelper
      * @param null|SiteRepresentation $site This layout/block's site
      * @return string
      */
-    public function form($layout, SiteRepresentation $site = null)
+    public function form($layout, SiteRepresentation $site = null,
+        SitePageRepresentation $page = null
+    )
     {
         $view = $this->getView();
         $block = null;
         if ($layout instanceof SitePageBlockRepresentation) {
             $block = $layout;
             $layout = $block->layout();
-            $site = $block->page()->site();
+            $page = $block->page();
+            $site = $page->site();
         }
         return '
 <div class="block value" data-block-layout="' . $view->escapeHtml($layout) . '">
@@ -96,7 +99,7 @@ class BlockLayout extends AbstractHelper
     </div>
     <div class="block-content">
     <input type="hidden" name="o:block[__blockIndex__][o:layout]" value="' . $layout . '">' .
-    $this->manager->get($layout)->form($this->getView(), $site, $block) .
+    $this->manager->get($layout)->form($this->getView(), $site, $page, $block) .
     '</div>
 </div>';
     }


### PR DESCRIPTION
Before, BlockLayoutInterface::form() only took the site object and block object (if available). When the block argument was null there was no way to derive the page object for layouts that need it. In this case, when adding a PageTitle block to a page, it had no way to know the page title.