### PR TITLE
Make controller plugin Trigger work with Forward

### DIFF
--- a/application/src/Service/ViewHelper/TriggerFactory.php
+++ b/application/src/Service/ViewHelper/TriggerFactory.php
@@ -18,6 +18,6 @@ class TriggerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
     {
-        return new Trigger($services->get('EventManager'), $services->get('Application'));
+        return new Trigger($services->get('EventManager'), $services->get('ControllerPluginManager'));
     }
 }

--- a/application/src/View/Helper/Trigger.php
+++ b/application/src/View/Helper/Trigger.php
@@ -3,7 +3,7 @@ namespace Omeka\View\Helper;
 
 use Omeka\Event\Event;
 use Zend\EventManager\EventManagerInterface;
-use Zend\Mvc\Application;
+use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;
 use Zend\View\Helper\AbstractHelper;
 
 class Trigger extends AbstractHelper
@@ -14,20 +14,20 @@ class Trigger extends AbstractHelper
     protected $events;
 
     /**
-     * @var Application
+     * @var ControllerPluginManager
      */
-    protected $application;
+    protected $controllerPluginManager;
 
     /**
      * Construct the helper.
      *
      * @param EventManagerInterface $eventManager
-     * @param Application $application
+     * @param ControllerPluginManager $controllerPluginManager
      */
-    public function __construct(EventManagerInterface $eventManager, Application $application)
+    public function __construct(EventManagerInterface $eventManager, ControllerPluginManager $controllerPluginManager)
     {
         $this->events = $eventManager;
-        $this->application = $application;
+        $this->controllerPluginManager = $controllerPluginManager;
     }
 
     /**
@@ -39,7 +39,8 @@ class Trigger extends AbstractHelper
      */
     public function __invoke($name, array $params = [], $filter = false)
     {
-        $routeMatch = $this->application->getMvcEvent()->getRouteMatch();
+        $routeMatch = $this->controllerPluginManager->getController()
+            ->getEvent()->getRouteMatch();
         if (!$routeMatch) {
             // Without a route match this request is 404. No need to trigger.
             return;


### PR DESCRIPTION
Trigger retrieve a RouteMatch object from the Application, but Forward
doesn't modify this RouteMatch. Instead it injects a new RouteMatch
object into the controller. Trigger needs to retrieve this RouteMatch in
order to set the correct identifiers for the SharedEventManager.