### PR TITLE
Set correct default value of media_type_whitelist and extension_white…

### DIFF
--- a/application/data/migrations/20160930163058_AddFileValidation.php
+++ b/application/data/migrations/20160930163058_AddFileValidation.php
@@ -21,9 +21,9 @@ class AddFileValidation implements ConstructedMigrationInterface
 
     public function up(Connection $conn)
     {
-        $mediaTypes = explode(',', FileManager::MEDIA_TYPE_WHITELIST);
+        $mediaTypes = FileManager::MEDIA_TYPE_WHITELIST;
         $this->settings->set('media_type_whitelist', $mediaTypes);
-        $extensions = explode(',', FileManager::EXTENSION_WHITELIST);
+        $extensions = FileManager::EXTENSION_WHITELIST;
         $this->settings->set('extension_whitelist', $extensions);
     }
 

--- a/application/src/File/Manager.php
+++ b/application/src/File/Manager.php
@@ -14,9 +14,43 @@ class Manager
 
     const THUMBNAIL_EXTENSION = 'jpg';
 
-    const MEDIA_TYPE_WHITELIST = 'application/msword,application/ogg,application/pdf,application/rtf,application/vnd.ms-access,application/vnd.ms-excel,application/vnd.ms-powerpoint,application/vnd.ms-project,application/vnd.ms-write,application/vnd.oasis.opendocument.chart,application/vnd.oasis.opendocument.database,application/vnd.oasis.opendocument.formula,application/vnd.oasis.opendocument.graphics,application/vnd.oasis.opendocument.presentation,application/vnd.oasis.opendocument.spreadsheet,application/vnd.oasis.opendocument.text,application/x-ms-wmp,application/x-ogg,application/x-gzip,application/x-msdownload,application/x-shockwave-flash,application/x-tar,application/zip,audio/aac,audio/aiff,audio/mid,audio/midi,audio/mp3,audio/mp4,audio/mpeg,audio/mpeg3,audio/ogg,audio/wav,audio/wma,audio/x-aac,audio/x-aiff,audio/x-midi,audio/x-mp3,audio/x-mp4,audio/x-mpeg,audio/x-mpeg3,audio/x-mpegaudio,audio/x-ms-wax,audio/x-realaudio,audio/x-wav,audio/x-wma,image/bmp,image/gif,image/icon,image/jpeg,image/pjpeg,image/png,image/tiff,image/x-icon,image/x-ms-bmp,text/css,text/plain,text/richtext,text/rtf,video/asf,video/avi,video/divx,video/mp4,video/mpeg,video/msvideo,video/ogg,video/quicktime,video/x-ms-wmv,video/x-msvideo';
+    const MEDIA_TYPE_WHITELIST = [
+        'application/msword', 'application/ogg', 'application/pdf',
+        'application/rtf', 'application/vnd.ms-access',
+        'application/vnd.ms-excel', 'application/vnd.ms-powerpoint',
+        'application/vnd.ms-project', 'application/vnd.ms-write',
+        'application/vnd.oasis.opendocument.chart',
+        'application/vnd.oasis.opendocument.database',
+        'application/vnd.oasis.opendocument.formula',
+        'application/vnd.oasis.opendocument.graphics',
+        'application/vnd.oasis.opendocument.presentation',
+        'application/vnd.oasis.opendocument.spreadsheet',
+        'application/vnd.oasis.opendocument.text',
+        'application/x-ms-wmp', 'application/x-ogg', 'application/x-gzip',
+        'application/x-msdownload', 'application/x-shockwave-flash',
+        'application/x-tar', 'application/zip', 'audio/aac', 'audio/aiff',
+        'audio/mid', 'audio/midi', 'audio/mp3', 'audio/mp4', 'audio/mpeg',
+        'audio/mpeg3', 'audio/ogg', 'audio/wav', 'audio/wma', 'audio/x-aac',
+        'audio/x-aiff', 'audio/x-midi', 'audio/x-mp3', 'audio/x-mp4',
+        'audio/x-mpeg', 'audio/x-mpeg3', 'audio/x-mpegaudio', 'audio/x-ms-wax',
+        'audio/x-realaudio', 'audio/x-wav', 'audio/x-wma', 'image/bmp',
+        'image/gif', 'image/icon', 'image/jpeg', 'image/pjpeg', 'image/png',
+        'image/tiff', 'image/x-icon', 'image/x-ms-bmp', 'text/css',
+        'text/plain', 'text/richtext', 'text/rtf', 'video/asf', 'video/avi',
+        'video/divx', 'video/mp4', 'video/mpeg', 'video/msvideo',
+        'video/ogg', 'video/quicktime', 'video/x-ms-wmv', 'video/x-msvideo',
+    ];
 
-    const EXTENSION_WHITELIST = 'aac,aif,aiff,asf,asx,avi,bmp,c,cc,class,css,divx,doc,docx,exe,gif,gz,gzip,h,ico,j2k,jp2,jpe,jpeg,jpg,m4a,mdb,mid,midi,mov,mp2,mp3,mp4,mpa,mpe,mpeg,mpg,mpp,odb,odc,odf,odg,odp,ods,odt,ogg, pdf,png,pot,pps,ppt,pptx,qt,ra,ram,rtf,rtx,swf,tar,tif,tiff,txt, wav,wax,wma,wmv,wmx,wri,xla,xls,xlsx,xlt,xlw,zip';
+    const EXTENSION_WHITELIST = [
+        'aac', 'aif', 'aiff', 'asf', 'asx', 'avi', 'bmp', 'c', 'cc', 'class',
+        'css', 'divx', 'doc', 'docx', 'exe', 'gif', 'gz', 'gzip', 'h', 'ico',
+        'j2k', 'jp2', 'jpe', 'jpeg', 'jpg', 'm4a', 'mdb', 'mid', 'midi', 'mov',
+        'mp2', 'mp3', 'mp4', 'mpa', 'mpe', 'mpeg', 'mpg', 'mpp', 'odb', 'odc',
+        'odf', 'odg', 'odp', 'ods', 'odt', 'ogg', 'pdf', 'png', 'pot', 'pps',
+        'ppt', 'pptx', 'qt', 'ra', 'ram', 'rtf', 'rtx', 'swf', 'tar', 'tif',
+        'tiff', 'txt', 'wav', 'wax', 'wma', 'wmv', 'wmx', 'wri', 'xla', 'xls',
+        'xlsx', 'xlt', 'xlw', 'zip',
+    ];
 
     /**
      * @var array

--- a/application/src/Form/SettingForm.php
+++ b/application/src/Form/SettingForm.php
@@ -164,7 +164,7 @@ class SettingForm extends Form
             ->setAttribute('rows', '4')
             ->setRestoreButtonText('Restore default media types')
             ->setValue(implode(',', $this->settings->get('media_type_whitelist', [])))
-            ->setRestoreValue(FileManager::MEDIA_TYPE_WHITELIST);
+            ->setRestoreValue(implode(',', FileManager::MEDIA_TYPE_WHITELIST));
         $this->add($mediaTypeWhitelist);
 
         $extensionWhitelist = new RestoreTextarea('extension_whitelist');
@@ -174,7 +174,7 @@ class SettingForm extends Form
             ->setAttribute('rows', '4')
             ->setRestoreButtonText('Restore default extensions')
             ->setValue(implode(',', $this->settings->get('extension_whitelist', [])))
-            ->setRestoreValue(FileManager::EXTENSION_WHITELIST);
+            ->setRestoreValue(implode(',', FileManager::EXTENSION_WHITELIST));
         $this->add($extensionWhitelist);
 
         $event = new Event(Event::GLOBAL_SETTINGS_ADD_ELEMENTS, $this, ['form' => $this]);

--- a/application/src/Installation/Task/AddDefaultSettingsTask.php
+++ b/application/src/Installation/Task/AddDefaultSettingsTask.php
@@ -11,8 +11,8 @@ class AddDefaultSettingsTask implements TaskInterface
     protected $defaultSettings = [
         'version' => Module::VERSION,
         'pagination_per_page' => Paginator::PER_PAGE,
-        'media_type_whitelist' => FileManager::EXTENSION_WHITELIST,
-        'extension_whitelist' => FileManager::MEDIA_TYPE_WHITELIST,
+        'media_type_whitelist' => FileManager::MEDIA_TYPE_WHITELIST,
+        'extension_whitelist' => FileManager::EXTENSION_WHITELIST,
     ];
 
     public function perform(Installer $installer)


### PR DESCRIPTION
…list

Those two settings should be arrays, so this patch changes
FileManager::MEDIA_TYPE_WHITELIST and FileManager::EXTENSION_WHITELIST
accordingly.
It also fixes the installation task where values were inverted