### PR TITLE
catch_connection_exceptions

### DIFF
--- a/application/src/Service/ModuleManagerFactory.php
+++ b/application/src/Service/ModuleManagerFactory.php
@@ -100,6 +100,11 @@ class ModuleManagerFactory implements FactoryInterface
             // If the module table is not found we can assume that the
             // application is not installed.
             $status->setIsInstalled(false);
+            
+        } catch (ConnectionException $e) {
+            // If the module table is not found we can assume that the
+            // application is not installed.
+            $status->setIsInstalled(false);
         }
 
         foreach ($dbModules as $moduleRow) {


### PR DESCRIPTION
In the event MySQL goes away for any period of time, the full stack trace is outputted to all users including the MySQL credentials .. password etc.See screenshot below the password "Password123" is exposed.
[https://postimg.org/image/3zk2ymooh/](https://postimg.org/image/3zk2ymooh/)


