### PR TITLE
allow the addition of role labels to the ACL

### DIFF
--- a/application/src/Permissions/Acl.php
+++ b/application/src/Permissions/Acl.php
@@ -109,7 +109,6 @@ class Acl extends ZendAcl
      * @param $roleId
      * @param $roleLabel
      */
-
     public function addRoleLabel($roleId, $roleLabel)
     {
         $this->roleLabels[$roleId] = $roleLabel;
@@ -120,7 +119,6 @@ class Acl extends ZendAcl
      *
      * @param $roleId
      */
-
     public function removeRoleLabel($roleId)
     {
         unset($this->roleLabels[$roleId]);

--- a/application/src/Permissions/Acl.php
+++ b/application/src/Permissions/Acl.php
@@ -107,27 +107,24 @@ class Acl extends ZendAcl
      *
      * Add a role label to the ACL
      *
-     * @param $role
+     * @param $roleId
+     * @param $roleLabel
      */
 
-    public function addRoleLabel($role)
+    public function addRoleLabel($roleId, $roleLabel)
     {
-        $role_id = $role->getRoleId();
-        $role_id = str_replace(" ", "_", trim($role_id));
-
-        $this->roleLabels[strtolower($role_id)] = $role_id;
+        $this->roleLabels[$roleId] = $roleLabel;
     }
 
     /**
      *
      * Remove a role label from the ACL
      *
-     * @param $role_label
+     * @param $roleId
      */
 
-    public function removeRoleLabel($role_label)
+    public function removeRoleLabel($roleId)
     {
-        $role_label = str_replace(" ", "_", trim($role_label));
-        unset($this->roleLabels[strtolower($role_label)]);
+        unset($this->roleLabels[$roleId]);
     }
 }

--- a/application/src/Permissions/Acl.php
+++ b/application/src/Permissions/Acl.php
@@ -104,7 +104,6 @@ class Acl extends ZendAcl
     }
 
     /**
-     *
      * Add a role label to the ACL
      *
      * @param $roleId
@@ -117,7 +116,6 @@ class Acl extends ZendAcl
     }
 
     /**
-     *
      * Remove a role label from the ACL
      *
      * @param $roleId

--- a/application/src/Permissions/Acl.php
+++ b/application/src/Permissions/Acl.php
@@ -102,4 +102,32 @@ class Acl extends ZendAcl
     {
         return in_array($role, $this->adminRoles);
     }
+
+    /**
+     *
+     * Add a role label to the ACL
+     *
+     * @param $role
+     */
+
+    public function addRoleLabel($role)
+    {
+        $role_id = $role->getRoleId();
+        $role_id = str_replace(" ", "_", trim($role_id));
+
+        $this->roleLabels[strtolower($role_id)] = $role_id;
+    }
+
+    /**
+     *
+     * Remove a role label from the ACL
+     *
+     * @param $role_label
+     */
+
+    public function removeRoleLabel($role_label)
+    {
+        $role_label = str_replace(" ", "_", trim($role_label));
+        unset($this->roleLabels[strtolower($role_label)]);
+    }
 }


### PR DESCRIPTION
the addition of these functions allow roles to be added to the Omeka ACL, making them available to admin users in the admin UI 