### PR TITLE
Add ResourceTemplateProperty::getIsRequired()

### DIFF
--- a/application/src/Entity/ResourceTemplateProperty.php
+++ b/application/src/Entity/ResourceTemplateProperty.php
@@ -127,8 +127,13 @@ class ResourceTemplateProperty extends AbstractEntity
         $this->isRequired = (bool) $isRequired;
     }
 
-    public function isRequired()
+    public function getIsRequired()
     {
         return (bool) $this->isRequired;
+    }
+
+    public function isRequired()
+    {
+        return $this->getIsRequired();
     }
 }


### PR DESCRIPTION
isRequired() is not usable by Doctrine which sometimes may fail with the
following error:

PHP Fatal error:  Cannot access protected property
Omeka\Entity\ResourceTemplateProperty::$isRequired

Keep isRequired() for convenience and backward compatibility for
modules that might use it

(fix #955)