### PR TITLE
Feature/allow full access to config forms

### DIFF
--- a/application/src/Controller/Admin/ModuleController.php
+++ b/application/src/Controller/Admin/ModuleController.php
@@ -277,7 +277,7 @@ class ModuleController extends AbstractActionController
         }
 
         $view = new ViewModel;
-        $view->setVariable('configForm', $moduleObject->getConfigForm($this->viewRenderer));
+        $view->setVariable('configForm', $moduleObject->getConfigForm());
         $view->setVariable('module', $module);
         return $view;
     }

--- a/application/src/Module/AbstractModule.php
+++ b/application/src/Module/AbstractModule.php
@@ -68,10 +68,9 @@ abstract class AbstractModule implements ConfigProviderInterface
     /**
      * Get this module's configuration form.
      *
-     * @param PhpRenderer $renderer
-     * @return string
+     * @return form
      */
-    public function getConfigForm(PhpRenderer $renderer)
+    public function getConfigForm()
     {
     }
 

--- a/application/view/omeka/admin/module/configure.phtml
+++ b/application/view/omeka/admin/module/configure.phtml
@@ -1,12 +1,13 @@
 <?php
 $this->htmlElement('body')->appendAttribute('class', 'modules configure');
+$configForm->prepare();
 ?>
 
 <?php echo $this->pageTitle(sprintf($this->translate('Configure “%s”'), $module->getName())); ?>
 
-<form method="post">
+<?php echo $this->form()->openTag($configForm); ?>
 <div id="page-actions">
     <button><?php echo $this->translate('Submit'); ?></button>
 </div>
-<?php echo $configForm; ?>
-</form>
+<?php echo $this->form()->render($configForm); ?>
+<?php echo $this->form()->closeTag(); ?>


### PR DESCRIPTION
Changing the way the module config form is rendered. This approach allows attributes on the form tag itself to be altered in the module config, specifically the 'enctype' attribute to allow module config forms to upload files. 