### PR TITLE
Fixed output to string.

### DIFF
--- a/application/src/DataType/Resource/AbstractResource.php
+++ b/application/src/DataType/Resource/AbstractResource.php
@@ -77,7 +77,7 @@ abstract class AbstractResource extends AbstractDataType
 
     public function toString(ValueRepresentation $value)
     {
-        return $value->valueResource()->url(null, true);
+        return (string) $value->valueResource()->url(null, true);
     }
 
     public function getJsonLd(ValueRepresentation $value)


### PR DESCRIPTION
There may be an error when using __toString, because it should return a string, but $resource->url() may return a null...