### PR TITLE
Feature/batch edit factorize and trigger events for modules 

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -442,6 +442,7 @@ return [
         ],
         'factories' => [
             'Omeka\Form\ResourceForm' => Service\Form\ResourceFormFactory::class,
+            'Omeka\Form\ResourceBatchUpdateForm' => Service\Form\ResourceBatchUpdateFormFactory::class,
             'Omeka\Form\UserForm' => Service\Form\UserFormFactory::class,
             'Omeka\Form\SettingForm' => Service\Form\SettingFormFactory::class,
             'Omeka\Form\ModuleStateChangeForm' => Service\Form\ModuleStateChangeFormFactory::class,

--- a/application/src/Controller/Admin/ItemController.php
+++ b/application/src/Controller/Admin/ItemController.php
@@ -277,6 +277,7 @@ class ItemController extends AbstractActionController
         }
 
         $form = $this->getForm(ResourceBatchUpdateForm::class, ['resource_type' => 'item']);
+        $form->setAttribute('id', 'batch-edit-item');
         if ($this->params()->fromPost('batch_update')) {
             $data = $this->params()->fromPost();
             $form->setData($data);
@@ -324,6 +325,7 @@ class ItemController extends AbstractActionController
         $count = $this->api()->search('items', ['limit' => 0] + $query)->getTotalResults();
 
         $form = $this->getForm(ResourceBatchUpdateForm::class, ['resource_type' => 'item']);
+        $form->setAttribute('id', 'batch-edit-item');
         if ($this->params()->fromPost('batch_update')) {
             $data = $this->params()->fromPost();
             $form->setData($data);
@@ -370,7 +372,7 @@ class ItemController extends AbstractActionController
         $dataAppend = [];
 
         // Set the data to change and data to remove.
-        if (in_array($data['is_public'], ['0', '1'])) {
+        if (array_key_exists('is_public', $data) && in_array($data['is_public'], ['0', '1'])) {
             $dataRemove['o:is_public'] = $data['is_public'];
         }
         if (-1 == $data['resource_template']) {

--- a/application/src/Controller/Admin/ItemController.php
+++ b/application/src/Controller/Admin/ItemController.php
@@ -283,16 +283,14 @@ class ItemController extends AbstractActionController
             $form->setData($data);
 
             if ($form->isValid()) {
-                list($dataRemove, $dataAppend) = $form->preprocessData();
+                $data = $form->preprocessData();
 
-                $this->api($form)->batchUpdate('items', $resourceIds, $dataRemove, [
-                    'continueOnError' => true,
-                    'collectionAction' => 'remove',
-                ]);
-                $this->api($form)->batchUpdate('items', $resourceIds, $dataAppend, [
-                    'continueOnError' => true,
-                    'collectionAction' => 'append',
-                ]);
+                foreach ($data as $collectionAction => $properties) {
+                    $this->api($form)->batchUpdate('items', $resourceIds, $properties, [
+                        'continueOnError' => true,
+                        'collectionAction' => $collectionAction,
+                    ]);
+                }
 
                 $this->messenger()->addSuccess('Items successfully edited'); // @translate
                 return $this->redirect()->toRoute(null, ['action' => 'browse'], true);
@@ -331,13 +329,14 @@ class ItemController extends AbstractActionController
             $form->setData($data);
 
             if ($form->isValid()) {
-                list($dataRemove, $dataAppend) = $form->preprocessData();
+                $data = $form->preprocessData();
 
                 $job = $this->jobDispatcher()->dispatch('Omeka\Job\BatchUpdate', [
                     'resource' => 'items',
                     'query' => $query,
-                    'data_remove' => $dataRemove,
-                    'data_append' => $dataAppend,
+                    'data' => isset($data['replace']) ? $data['replace'] : [],
+                    'data_remove' => isset($data['remove']) ? $data['remove'] : [],
+                    'data_append' => isset($data['append']) ? $data['append'] : [],
                 ]);
 
                 $this->messenger()->addSuccess('Editing items. This may take a while.'); // @translate

--- a/application/src/Controller/Admin/ItemSetController.php
+++ b/application/src/Controller/Admin/ItemSetController.php
@@ -248,7 +248,8 @@ class ItemSetController extends AbstractActionController
             $resources[] = $this->api()->read('item_sets', $resourceId)->getContent();
         }
 
-        $form = $this->getForm(ResourceBatchUpdateForm::class);
+        $form = $this->getForm(ResourceBatchUpdateForm::class, ['resource_type' => 'itemSet']);
+        $form->setAttribute('id', 'batch-edit-item-set');
         if ($this->params()->fromPost('batch_update')) {
             $data = $this->params()->fromPost();
             $form->setData($data);
@@ -295,7 +296,8 @@ class ItemSetController extends AbstractActionController
             $query['offset'], $query['sort_by'], $query['sort_order']);
         $count = $this->api()->search('item_sets', ['limit' => 0] + $query)->getTotalResults();
 
-        $form = $this->getForm(ResourceBatchUpdateForm::class);
+        $form = $this->getForm(ResourceBatchUpdateForm::class, ['resource_type' => 'itemSet']);
+        $form->setAttribute('id', 'batch-edit-item-set');
         if ($this->params()->fromPost('batch_update')) {
             $data = $this->params()->fromPost();
             $form->setData($data);
@@ -342,10 +344,10 @@ class ItemSetController extends AbstractActionController
         $dataAppend = [];
 
         // Set the data to change and data to remove.
-        if (in_array($data['is_public'], ['0', '1'])) {
+        if (array_key_exists('is_public', $data) && in_array($data['is_public'], ['0', '1'])) {
             $dataRemove['o:is_public'] = $data['is_public'];
         }
-        if (in_array($data['is_open'], ['0', '1'])) {
+        if (array_key_exists('is_open', $data) && in_array($data['is_open'], ['0', '1'])) {
             $dataRemove['o:is_open'] = $data['is_open'];
         }
         if (-1 == $data['resource_template']) {

--- a/application/src/Controller/Admin/ItemSetController.php
+++ b/application/src/Controller/Admin/ItemSetController.php
@@ -255,7 +255,7 @@ class ItemSetController extends AbstractActionController
             $form->setData($data);
 
             if ($form->isValid()) {
-                list($dataRemove, $dataAppend) = $this->preprocessBatchUpdateData($data);
+                list($dataRemove, $dataAppend) = $form->preprocessData();
 
                 $this->api($form)->batchUpdate('item_sets', $resourceIds, $dataRemove, [
                     'continueOnError' => true,
@@ -303,7 +303,7 @@ class ItemSetController extends AbstractActionController
             $form->setData($data);
 
             if ($form->isValid()) {
-                list($dataRemove, $dataAppend) = $this->preprocessBatchUpdateData($data);
+                list($dataRemove, $dataAppend) = $form->preprocessData();
 
                 $job = $this->jobDispatcher()->dispatch('Omeka\Job\BatchUpdate', [
                     'resource' => 'item_sets',
@@ -326,67 +326,5 @@ class ItemSetController extends AbstractActionController
         $view->setVariable('query', $query);
         $view->setVariable('count', $count);
         return $view;
-    }
-
-    /**
-     * Preprocess batch update data.
-     *
-     * Batch update data contains instructions on what to update. It needs to be
-     * preprocessed before it's sent to the API.
-     *
-     * @param array $data
-     * @return array An array containing the collectionAction=remove data as the
-     * first element and the collectionAction=append data as the second.
-     */
-    protected function preprocessBatchUpdateData(array $data)
-    {
-        $dataRemove = [];
-        $dataAppend = [];
-
-        // Set the data to change and data to remove.
-        if (array_key_exists('is_public', $data) && in_array($data['is_public'], ['0', '1'])) {
-            $dataRemove['o:is_public'] = $data['is_public'];
-        }
-        if (array_key_exists('is_open', $data) && in_array($data['is_open'], ['0', '1'])) {
-            $dataRemove['o:is_open'] = $data['is_open'];
-        }
-        if (-1 == $data['resource_template']) {
-            $dataRemove['o:resource_template'] = ['o:id' => null];
-        } elseif (is_numeric($data['resource_template'])) {
-            $dataRemove['o:resource_template'] = ['o:id' => $data['resource_template']];
-        }
-        if (-1 == $data['resource_class']) {
-            $dataRemove['o:resource_class'] = ['o:id' => null];
-        } elseif (is_numeric($data['resource_class'])) {
-            $dataRemove['o:resource_class'] = ['o:id' => $data['resource_class']];
-        }
-        if (isset($data['clear_property_values'])) {
-            $dataRemove['clear_property_values'] = $data['clear_property_values'];
-        }
-
-        // Set the data to append.
-        if (isset($data['value'])) {
-            foreach ($data['value'] as $value) {
-                $valueObj = [
-                    'property_id' => $value['property_id'],
-                    'type' => $value['type'],
-                ];
-                switch ($value['type']) {
-                    case 'uri':
-                        $valueObj['@id'] = $value['id'];
-                        $valueObj['o:label'] = $value['label'];
-                        break;
-                    case 'resource':
-                        $valueObj['value_resource_id'] = $value['value_resource_id'];
-                        break;
-                    case 'literal':
-                    default:
-                        $valueObj['@value'] = $value['value'];
-                }
-                $dataAppend[$value['property_id']][] = $valueObj;
-            }
-        }
-
-        return [$dataRemove, $dataAppend];
     }
 }

--- a/application/src/Controller/Admin/ItemSetController.php
+++ b/application/src/Controller/Admin/ItemSetController.php
@@ -255,16 +255,14 @@ class ItemSetController extends AbstractActionController
             $form->setData($data);
 
             if ($form->isValid()) {
-                list($dataRemove, $dataAppend) = $form->preprocessData();
+                $data = $form->preprocessData();
 
-                $this->api($form)->batchUpdate('item_sets', $resourceIds, $dataRemove, [
-                    'continueOnError' => true,
-                    'collectionAction' => 'remove',
-                ]);
-                $this->api($form)->batchUpdate('item_sets', $resourceIds, $dataAppend, [
-                    'continueOnError' => true,
-                    'collectionAction' => 'append',
-                ]);
+                foreach ($data as $collectionAction => $properties) {
+                    $this->api($form)->batchUpdate('item_sets', $resourceIds, $properties, [
+                        'continueOnError' => true,
+                        'collectionAction' => $collectionAction,
+                    ]);
+                }
 
                 $this->messenger()->addSuccess('Item sets successfully edited'); // @translate
                 return $this->redirect()->toRoute(null, ['action' => 'browse'], true);
@@ -303,13 +301,14 @@ class ItemSetController extends AbstractActionController
             $form->setData($data);
 
             if ($form->isValid()) {
-                list($dataRemove, $dataAppend) = $form->preprocessData();
+                $data = $form->preprocessData();
 
                 $job = $this->jobDispatcher()->dispatch('Omeka\Job\BatchUpdate', [
                     'resource' => 'item_sets',
                     'query' => $query,
-                    'data_remove' => $dataRemove,
-                    'data_append' => $dataAppend,
+                    'data' => isset($data['replace']) ? $data['replace'] : [],
+                    'data_remove' => isset($data['remove']) ? $data['remove'] : [],
+                    'data_append' => isset($data['append']) ? $data['append'] : [],
                 ]);
 
                 $this->messenger()->addSuccess('Editing item sets. This may take a while.'); // @translate

--- a/application/src/Form/ResourceBatchUpdateForm.php
+++ b/application/src/Form/ResourceBatchUpdateForm.php
@@ -1,11 +1,192 @@
 <?php
 namespace Omeka\Form;
 
+use Omeka\Form\Element\ItemSetSelect;
+use Omeka\Form\Element\PropertySelect;
+use Omeka\Form\Element\ResourceClassSelect;
+use Omeka\Form\Element\ResourceSelect;
+use Zend\EventManager\Event;
+use Zend\EventManager\EventManagerAwareTrait;
 use Zend\Form\Form;
+use Zend\View\Helper\Url;
 
 class ResourceBatchUpdateForm extends Form
 {
+    use EventManagerAwareTrait;
+
+    /**
+     * @var Url
+     */
+    protected $urlHelper;
+
     public function init()
     {
+        $urlHelper = $this->getUrlHelper();
+
+        $resourceType = $this->getOption('resource_type');
+
+        $this->add([
+            'name' => 'is_public',
+            'type' => 'radio',
+            'options' => [
+                'label' => 'Set visibility', // @translate
+                'value_options' => [
+                    '' => '[No change]', // @translate
+                    '1' => 'Public', // @translate
+                    '0' => 'Not public', // @translate
+                ],
+            ],
+        ]);
+
+        if ($resourceType === 'itemSet') {
+            $this->add([
+                'name' => 'is_open',
+                'type' => 'radio',
+                'options' => [
+                    'label' => 'Set openness', // @translate
+                    'value_options' => [
+                        '' => '[No change]', // @translate
+                        '1' => 'Open', // @translate
+                        '0' => 'Not open', // @translate
+                    ],
+                ],
+            ]);
+        }
+
+        $this->add([
+            'name' => 'resource_template',
+            'type' => ResourceSelect::class,
+            'attributes' => [
+                'id' => 'resource-template-select',
+                'class' => 'chosen-select',
+                'data-placeholder' => 'Select a template', // @translate
+                'data-api-base-url' => $urlHelper('api/default', ['resource' => 'resource_templates']),
+            ],
+            'options' => [
+                'label' => 'Set template', // @translate
+                'empty_option' => '[No change]', // @translate
+                'prepend_value_options' => ['-1' => '[Unset template]'], // @translate
+                'resource_value_options' => [
+                    'resource' => 'resource_templates',
+                    'query' => [],
+                    'option_text_callback' => function ($resourceTemplate) {
+                        return $resourceTemplate->label();
+                    },
+                ],
+            ],
+        ]);
+
+        $this->add([
+            'name' => 'resource_class',
+            'type' => ResourceClassSelect::class,
+            'attributes' => [
+                'id' => 'resource-class-select',
+                'class' => 'chosen-select',
+                'data-placeholder' => 'Select a class', // @translate
+            ],
+            'options' => [
+                'label' => 'Set class', // @translate
+                'prepend_value_options' => ['-1' => '[Unset class]'], // @translate
+                'empty_option' => '[No change]', // @translate
+            ],
+        ]);
+
+        if ($resourceType === 'item') {
+            $this->add([
+                'name' => 'add_to_item_set',
+                'type' => ItemSetSelect::class,
+                'attributes' => [
+                    'id' => 'add-to-item-sets',
+                    'class' => 'chosen-select',
+                    'multiple' => true,
+                    'data-placeholder' => 'Select item sets', // @translate
+                ],
+                'options' => [
+                    'label' => 'Add to item sets', // @translate
+                ],
+            ]);
+
+            $this->add([
+                'name' => 'remove_from_item_set',
+                'type' => ItemSetSelect::class,
+                'attributes' => [
+                    'id' => 'remove-from-item-sets',
+                    'class' => 'chosen-select',
+                    'multiple' => true,
+                    'data-placeholder' => 'Select item sets', // @translate
+                ],
+                'options' => [
+                    'label' => 'Remove from item sets', // @translate
+                ],
+            ]);
+        }
+
+        $this->add([
+            'name' => 'clear_property_values',
+            'type' => PropertySelect::class,
+            'attributes' => [
+                'id' => 'remove-property-values',
+                'class' => 'chosen-select',
+                'multiple' => true,
+                'data-placeholder' => 'Select properties', // @translate
+            ],
+            'options' => [
+                'label' => 'Clear property values', // @translate
+            ],
+        ]);
+
+        // TODO Add dynamic properties here instead of the partial.
+
+        $addEvent = new Event('form.add_elements', $this);
+        $this->getEventManager()->triggerEvent($addEvent);
+
+        $inputFilter = $this->getInputFilter();
+        $inputFilter->add([
+            'name' => 'is_public',
+            'required' => false,
+        ]);
+        $inputFilter->add([
+            'name' => 'is_open',
+            'required' => false,
+        ]);
+        $inputFilter->add([
+            'name' => 'resource_template',
+            'required' => false,
+        ]);
+        $inputFilter->add([
+            'name' => 'resource_class',
+            'required' => false,
+        ]);
+        $inputFilter->add([
+            'name' => 'add_to_item_set',
+            'required' => false,
+        ]);
+        $inputFilter->add([
+            'name' => 'remove_from_item_set',
+            'required' => false,
+        ]);
+        $inputFilter->add([
+            'name' => 'clear_property_values',
+            'required' => false,
+        ]);
+
+        $filterEvent = new Event('form.add_input_filters', $this, ['inputFilter' => $inputFilter]);
+        $this->getEventManager()->triggerEvent($filterEvent);
+    }
+
+    /**
+     * @param Url $urlHelper
+     */
+    public function setUrlHelper(Url $urlHelper)
+    {
+        $this->urlHelper = $urlHelper;
+    }
+
+    /**
+     * @return Url
+     */
+    public function getUrlHelper()
+    {
+        return $this->urlHelper;
     }
 }

--- a/application/src/Form/ResourceBatchUpdateForm.php
+++ b/application/src/Form/ResourceBatchUpdateForm.php
@@ -135,7 +135,14 @@ class ResourceBatchUpdateForm extends Form
             ],
         ]);
 
-        // TODO Add dynamic properties here instead of the partial.
+        // This hidden element manages the elements "value" added in the view.
+        $this->add([
+            'name' => 'value',
+            'type' => 'Hidden',
+            'attributes' => [
+                'value' => '',
+            ],
+        ]);
 
         $addEvent = new Event('form.add_elements', $this);
         $this->getEventManager()->triggerEvent($addEvent);
@@ -169,6 +176,10 @@ class ResourceBatchUpdateForm extends Form
             'name' => 'clear_property_values',
             'required' => false,
         ]);
+        $inputFilter->add([
+            'name' => 'value',
+            'required' => false,
+        ]);
 
         $filterEvent = new Event('form.add_input_filters', $this, ['inputFilter' => $inputFilter]);
         $this->getEventManager()->triggerEvent($filterEvent);
@@ -188,5 +199,106 @@ class ResourceBatchUpdateForm extends Form
     public function getUrlHelper()
     {
         return $this->urlHelper;
+    }
+
+    /**
+     * Preprocess data in order to get data to apply, to remove and to append.
+     *
+     * Batch update data contains instructions on what to update. It needs to be
+     * preprocessed before it's sent to the API.
+     *
+     * @todo Use standard validationGroup and filters.
+     * Note: The elements added by modules are added according to the attribute
+     * "data-preprocess-group", that can be "remove" (default) or "append". The
+     * attribute "data-preprocess-key" saves the key when needed. It avoids to
+     * attach an event. Anyway, the triggers "api.batch_update.{pre|post}" and
+     * some other ones can be used.
+     *
+     * @return array An array containing the collectionAction=remove data as the
+     * first element and the collectionAction=append data as the second.
+     */
+    public function preprocessData()
+    {
+        $data = $this->getData();
+
+        $dataRemove = [];
+        $dataAppend = [];
+
+        // Set the data to change and data to remove.
+        if (array_key_exists('is_public', $data) && in_array($data['is_public'], ['0', '1'])) {
+            $dataRemove['o:is_public'] = $data['is_public'];
+        }
+        if (array_key_exists('is_open', $data) && in_array($data['is_open'], ['0', '1'])) {
+            $dataRemove['o:is_open'] = $data['is_open'];
+        }
+        if (-1 == $data['resource_template']) {
+            $dataRemove['o:resource_template'] = ['o:id' => null];
+        } elseif (is_numeric($data['resource_template'])) {
+            $dataRemove['o:resource_template'] = ['o:id' => $data['resource_template']];
+        }
+        if (-1 == $data['resource_class']) {
+            $dataRemove['o:resource_class'] = ['o:id' => null];
+        } elseif (is_numeric($data['resource_class'])) {
+            $dataRemove['o:resource_class'] = ['o:id' => $data['resource_class']];
+        }
+        if (isset($data['remove_from_item_set'])) {
+            $dataRemove['o:item_set'] = $data['remove_from_item_set'];
+        }
+        if (isset($data['clear_property_values'])) {
+            $dataRemove['clear_property_values'] = $data['clear_property_values'];
+        }
+
+        // Set the data to append.
+        if (!empty($data['value'])) {
+            foreach ($data['value'] as $value) {
+                $valueObj = [
+                    'property_id' => $value['property_id'],
+                    'type' => $value['type'],
+                ];
+                switch ($value['type']) {
+                    case 'uri':
+                        $valueObj['@id'] = $value['id'];
+                        $valueObj['o:label'] = $value['label'];
+                        break;
+                    case 'resource':
+                        $valueObj['value_resource_id'] = $value['value_resource_id'];
+                        break;
+                    case 'literal':
+                    default:
+                        $valueObj['@value'] = $value['value'];
+                }
+                $dataAppend[$value['property_id']][] = $valueObj;
+            }
+        }
+        if (isset($data['add_to_item_set'])) {
+            $dataAppend['o:item_set'] = array_unique($data['add_to_item_set']);
+        }
+
+        // Set remaining elements according to attribute data-preprocess-group.
+        $processeds = [
+            'csrf', 'is_public', 'is_open', 'resource_template', 'resource_class',
+            'remove_from_item_set', 'add_to_item_set', 'clear_property_values',
+            'value', 'id', 'o:id',
+        ];
+        foreach ($data as $key => $value) {
+            if (is_numeric($key) || in_array($key, $processeds)
+                || is_null($value) || $value === ''
+            ) {
+                continue;
+            }
+            if ($this->has($key)) {
+                $element = $this->get($key);
+                $elementKey = $element->getAttribute('data-preprocess-key') ?: $key;
+                if ($element->getAttribute('data-preprocess-group') == 'append') {
+                    $dataAppend[$elementKey] = $value;
+                } else {
+                    $dataRemove[$elementKey] = $value;
+                }
+            } else {
+                $dataRemove[$key] = $value;
+            }
+        }
+
+        return [$dataRemove, $dataAppend];
     }
 }

--- a/application/src/Form/ResourceBatchUpdateForm.php
+++ b/application/src/Form/ResourceBatchUpdateForm.php
@@ -7,6 +7,7 @@ use Omeka\Form\Element\ResourceClassSelect;
 use Omeka\Form\Element\ResourceSelect;
 use Zend\EventManager\Event;
 use Zend\EventManager\EventManagerAwareTrait;
+use Zend\Form\Element;
 use Zend\Form\Form;
 use Zend\View\Helper\Url;
 
@@ -27,28 +28,34 @@ class ResourceBatchUpdateForm extends Form
 
         $this->add([
             'name' => 'is_public',
-            'type' => 'radio',
+            'type' => Element\Radio::class,
             'options' => [
                 'label' => 'Set visibility', // @translate
                 'value_options' => [
-                    '' => '[No change]', // @translate
                     '1' => 'Public', // @translate
                     '0' => 'Not public', // @translate
+                    '' => '[No change]', // @translate
                 ],
+            ],
+            'attributes' => [
+                'value' => '',
             ],
         ]);
 
         if ($resourceType === 'itemSet') {
             $this->add([
                 'name' => 'is_open',
-                'type' => 'radio',
+                'type' => Element\Radio::class,
                 'options' => [
                     'label' => 'Set openness', // @translate
                     'value_options' => [
-                        '' => '[No change]', // @translate
                         '1' => 'Open', // @translate
                         '0' => 'Not open', // @translate
+                        '' => '[No change]', // @translate
                     ],
+                ],
+                'attributes' => [
+                    'value' => '',
                 ],
             ]);
         }
@@ -91,34 +98,57 @@ class ResourceBatchUpdateForm extends Form
             ],
         ]);
 
-        if ($resourceType === 'item') {
-            $this->add([
-                'name' => 'add_to_item_set',
-                'type' => ItemSetSelect::class,
-                'attributes' => [
-                    'id' => 'add-to-item-sets',
-                    'class' => 'chosen-select',
-                    'multiple' => true,
-                    'data-placeholder' => 'Select item sets', // @translate
-                ],
-                'options' => [
-                    'label' => 'Add to item sets', // @translate
-                ],
-            ]);
+        switch ($resourceType) {
+            case 'item':
+                $this->add([
+                    'name' => 'add_to_item_set',
+                    'type' => ItemSetSelect::class,
+                    'attributes' => [
+                        'id' => 'add-to-item-sets',
+                        'class' => 'chosen-select',
+                        'multiple' => true,
+                        'data-placeholder' => 'Select item sets', // @translate
+                    ],
+                    'options' => [
+                        'label' => 'Add to item sets', // @translate
+                    ],
+                ]);
 
-            $this->add([
-                'name' => 'remove_from_item_set',
-                'type' => ItemSetSelect::class,
-                'attributes' => [
-                    'id' => 'remove-from-item-sets',
-                    'class' => 'chosen-select',
-                    'multiple' => true,
-                    'data-placeholder' => 'Select item sets', // @translate
-                ],
-                'options' => [
-                    'label' => 'Remove from item sets', // @translate
-                ],
-            ]);
+                $this->add([
+                    'name' => 'remove_from_item_set',
+                    'type' => ItemSetSelect::class,
+                    'attributes' => [
+                        'id' => 'remove-from-item-sets',
+                        'class' => 'chosen-select',
+                        'multiple' => true,
+                        'data-placeholder' => 'Select item sets', // @translate
+                    ],
+                    'options' => [
+                        'label' => 'Remove from item sets', // @translate
+                    ],
+                ]);
+                break;
+
+            case 'media':
+                $this->add([
+                    'name' => 'clear_language',
+                    'type' => Element\Checkbox::class,
+                    'options' => [
+                        'label' => 'Clear language', // @transalte
+                    ],
+                ]);
+
+                $this->add([
+                    'name' => 'language',
+                    'type' => Element\Text::class,
+                    'attributes' => [
+                        'class' => 'value-language active',
+                    ],
+                    'options' => [
+                        'label' => 'Set language', // @transalte
+                    ],
+                ]);
+                break;
         }
 
         $this->add([
@@ -138,7 +168,7 @@ class ResourceBatchUpdateForm extends Form
         // This hidden element manages the elements "value" added in the view.
         $this->add([
             'name' => 'value',
-            'type' => 'Hidden',
+            'type' => Element\Hidden::class,
             'attributes' => [
                 'value' => '',
             ],
@@ -210,7 +240,6 @@ class ResourceBatchUpdateForm extends Form
      * "replace" (default), "remove" or "append".
      *
      * @todo Use standard validationGroup and filters.
-     * Note:
      *
      * @return array Associative array of data to replace, to remove and to
      * append.
@@ -247,6 +276,12 @@ class ResourceBatchUpdateForm extends Form
         if (isset($data['clear_property_values'])) {
             $preData['remove']['clear_property_values'] = $data['clear_property_values'];
         }
+        if (!empty($data['clear_language'])) {
+            $preData['remove']['o:lang'] = null;
+        }
+        if (!empty($data['language'])) {
+            $preData['remove']['o:lang'] = $data['language'];
+        }
 
         // Set the data to append.
         if (!empty($data['value'])) {
@@ -279,6 +314,7 @@ class ResourceBatchUpdateForm extends Form
             'is_public', 'is_open', 'resource_template', 'resource_class',
             'remove_from_item_set', 'add_to_item_set',
             'clear_property_values', 'value',
+            'clear_language', 'language',
             'csrf', 'id', 'o:id',
         ];
 

--- a/application/src/Service/Form/ResourceBatchUpdateFormFactory.php
+++ b/application/src/Service/Form/ResourceBatchUpdateFormFactory.php
@@ -1,0 +1,17 @@
+<?php
+namespace Omeka\Service\Form;
+
+use Omeka\Form\ResourceBatchUpdateForm;
+use Zend\ServiceManager\Factory\FactoryInterface;
+use Interop\Container\ContainerInterface;
+
+class ResourceBatchUpdateFormFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        $form = new ResourceBatchUpdateForm(null, $options);
+        $form->setUrlHelper($services->get('ViewHelperManager')->get('Url'));
+        $form->setEventManager($services->get('EventManager'));
+        return $form;
+    }
+}

--- a/application/view/common/property-form-batch-edit.phtml
+++ b/application/view/common/property-form-batch-edit.phtml
@@ -1,0 +1,82 @@
+<?php
+$escape = $this->plugin('escapeHtml');
+
+$selectProperty = $this->propertySelect([
+    'name' => 'value[__INDEX__][property_id]',
+    'options' => ['empty_option' => $this->translate('Select property')],
+]);
+$templateLiteral = '
+<div class="field">
+    <div class="field-meta">
+        <label>' . $this->translate('Add text value') . '</label>
+    </div>
+    <div class="inputs">
+        ' . $selectProperty . '
+        <textarea name="value[__INDEX__][value]"></textarea>
+        <input type="hidden" name="value[__INDEX__][type]" value="literal">
+        <button type="button" class="remove-value">' . $this->translate('Remove') . '</button>
+    </div>
+</div>';
+$templateResource = '
+<div class="field">
+    <div class="field-meta">
+        <label>' . $this->translate('Add resource value') . '</label>
+    </div>
+    <div class="inputs">
+        ' . $selectProperty . '
+        <input type="text" name="value[__INDEX__][value_resource_id]" placeholder="' . $this->escapeHtml($this->translate('Resource ID')) . '">
+        <input type="hidden" name="value[__INDEX__][type]" value="resource">
+        <button type="button" class="remove-value">' . $this->translate('Remove') . '</button>
+    </div>
+</div>';
+$templateUri = '
+<div class="field">
+    <div class="field-meta">
+        <label>' . $this->translate('Add URI value') . '</label>
+    </div>
+    <div class="inputs">
+        ' . $selectProperty . '
+        <input type="text" name="value[__INDEX__][id]" placeholder="' . $this->escapeHtml($this->translate('URI')) . '">
+        <input type="text" name="value[__INDEX__][label]" placeholder="' . $this->escapeHtml($this->translate('Label')) . '">
+        <input type="hidden" name="value[__INDEX__][type]" value="uri">
+        <button type="button" class="remove-value">' . $this->translate('Remove') . '</button>
+    </div>
+</div>';
+?>
+<div id="values"
+    data-template-literal="<?php echo $this->escapeHtml($templateLiteral); ?>"
+    data-template-resource="<?php echo $this->escapeHtml($templateResource); ?>"
+    data-template-uri="<?php echo $this->escapeHtml($templateUri); ?>"
+>
+    <div class="field-container"></div>
+    <button type="button" class="value-add-button" data-type="literal"><?php echo $this->translate('Add text value'); ?></button>
+    <button type="button" class="value-add-button" data-type="resource"><?php echo $this->translate('Add resource value'); ?></button>
+    <button type="button" class="value-add-button" data-type="uri"><?php echo $this->translate('Add URI value'); ?></button>
+</div>
+<script>
+$(document).ready(function() {
+    // Add a value field.
+    var index = 0;
+    var addValueField = function(type) {
+        var container = $('#values');
+        switch (type) {
+            case 'resource':
+                template = container.data('template-resource');
+                break;
+            case 'uri':
+                template = container.data('template-uri');
+                break;
+            case 'literal':
+            default:
+                template = container.data('template-literal');
+        }
+        container.children('.field-container').append($.parseHTML(template.replace(/__INDEX__/g, index++)));
+    };
+    $('.value-add-button').on('click', function(e) {
+        addValueField($(this).data('type'));
+    });
+    $(document).on('click', '.field-container .remove-value', function(e) {
+        $(this).closest('.field').remove();
+    });
+});
+</script>

--- a/application/view/omeka/admin/item-set/batch-edit.phtml
+++ b/application/view/omeka/admin/item-set/batch-edit.phtml
@@ -1,53 +1,11 @@
 <?php
-echo $this->pageTitle($this->translate('Batch edit item sets'));
-
-$selectPropertyToClear = $this->propertySelect([
-    'name' => 'clear_property_values[]',
-    'options' => ['empty_option' => 'Select property'],
-]);
-
-$selectProperty = $this->propertySelect([
-    'name' => 'value[__INDEX__][property_id]',
-    'options' => ['empty_option' => $this->translate('Select property')],
-]);
-$templateLiteral = '
-<div class="field">
-    <div class="field-meta">
-        <label>' . $this->translate('Add text value') . '</label>
-    </div>
-    <div class="inputs">
-        ' . $selectProperty . '
-        <textarea name="value[__INDEX__][value]"></textarea>
-        <input type="hidden" name="value[__INDEX__][type]" value="literal">
-        <button type="button" class="remove-value">' . $this->translate('Remove') . '</button>
-    </div>
-</div>';
-$templateResource = '
-<div class="field">
-    <div class="field-meta">
-        <label>' . $this->translate('Add resource value') . '</label>
-    </div>
-    <div class="inputs">
-        ' . $selectProperty . '
-        <input type="text" name="value[__INDEX__][value_resource_id]" placeholder="' . $this->escapeHtml($this->translate('Resource ID')) . '">
-        <input type="hidden" name="value[__INDEX__][type]" value="resource">
-        <button type="button" class="remove-value">' . $this->translate('Remove') . '</button>
-    </div>
-</div>';
-$templateUri = '
-<div class="field">
-    <div class="field-meta">
-        <label>' . $this->translate('Add URI value') . '</label>
-    </div>
-    <div class="inputs">
-        ' . $selectProperty . '
-        <input type="text" name="value[__INDEX__][id]" placeholder="' . $this->escapeHtml($this->translate('URI')) . '">
-        <input type="text" name="value[__INDEX__][label]" placeholder="' . $this->escapeHtml($this->translate('Label')) . '">
-        <input type="hidden" name="value[__INDEX__][type]" value="uri">
-        <button type="button" class="remove-value">' . $this->translate('Remove') . '</button>
-    </div>
-</div>';
+$form->prepare();
+$this->htmlElement('body')->appendAttribute('class', 'batch-edit item-sets');
+$escape = $this->plugin('escapeHtml');
 ?>
+<?php echo $this->pageTitle($this->translate('Batch edit item sets')); ?>
+
+<?php $this->trigger('view.batch_edit.before'); ?>
 
 <?php echo $this->form()->openTag($form); ?>
 
@@ -60,94 +18,9 @@ $templateUri = '
     <input type="submit" name="batch_update" value="<?php echo $this->escapeHtml($this->translate('Save')); ?>">
 </div>
 
-<div class="field">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Set visibility'); ?></label>
-    </div>
-    <div class="inputs">
-        <select name="is_public">
-            <option value="" selected="selected"><?php echo $this->translate('[No change]'); ?></option>
-            <option value="1"><?php echo $this->translate('Public'); ?></option>
-            <option value="0"><?php echo $this->translate('Not public'); ?></option>
-        </select>
-    </div>
-</div>
-
-<div class="field">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Set openness'); ?></label>
-    </div>
-    <div class="inputs">
-        <select name="is_open">
-            <option value="" selected="selected"><?php echo $this->translate('[No change]'); ?></option>
-            <option value="1"><?php echo $this->translate('Open'); ?></option>
-            <option value="0"><?php echo $this->translate('Not open'); ?></option>
-        </select>
-    </div>
-</div>
-
-<div class="field">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Set template'); ?></label>
-    </div>
-    <div class="inputs">
-        <?php echo $this->resourceSelect([
-            'name' => 'resource_template',
-            'options' => [
-                'empty_option' => $this->translate('[No change]'),
-                'prepend_value_options' => ['-1' => $this->translate('[Unset template]')],
-                'resource_value_options' => [
-                    'resource' => 'resource_templates',
-                    'option_text_callback' => function ($resourceTemplate) {
-                        return $resourceTemplate->label();
-                    },
-                ],
-            ],
-        ]); ?>
-    </div>
-</div>
-
-<div class="field">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Set class'); ?></label>
-    </div>
-    <div class="inputs">
-        <?php echo $this->resourceClassSelect([
-            'name' => 'resource_class',
-            'options' => [
-                'empty_option' => $this->translate('[No change]'),
-                'prepend_value_options' => ['-1' => $this->translate('[Unset class]')],
-            ],
-        ]); ?>
-    </div>
-</div>
-
-<div class="field multi-value">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Clear property values'); ?></label>
-    </div>
-    <div class="inputs">
-        <div class="value">
-            <?php echo $selectPropertyToClear; ?>
-            <button type="button" class="o-icon-delete remove-value"><?php echo $this->translate('Remove'); ?></button>
-        </div>
-        <button type="button" class="add-value button"><?php echo $this->translate('Clear another property'); ?></button>
-    </div>
-</div>
-
-<div id="values"
-    data-template-literal="<?php echo $this->escapeHtml($templateLiteral); ?>"
-    data-template-resource="<?php echo $this->escapeHtml($templateResource); ?>"
-    data-template-uri="<?php echo $this->escapeHtml($templateUri); ?>"
->
-    <div class="field-container"></div>
-    <button type="button" class="value-add-button" data-type="literal"><?php echo $this->translate('Add text value'); ?></button>
-    <button type="button" class="value-add-button" data-type="resource"><?php echo $this->translate('Add resource value'); ?></button>
-    <button type="button" class="value-add-button" data-type="uri"><?php echo $this->translate('Add URI value'); ?></button>
-</div>
-
-<?php echo $this->formRow($form->get('resourcebatchupdateform_csrf')); ?>
-<?php echo $this->form()->closeTag();; ?>
+<?php echo $this->formCollection($form, false); ?>
+<?php echo $this->partial('common/property-form-batch-edit.phtml', ['resourceType' => 'item_sets']); ?>
+<?php echo $this->form()->closeTag(); ?>
 
 <div class="sidebar always-open">
     <h3><?php echo $this->translate('Affected item sets'); ?></h3>
@@ -163,30 +36,4 @@ $templateUri = '
     <?php endif; ?>
 </div>
 
-<script>
-$(document).ready(function() {
-    // Add a value field.
-    var index = 0;
-    var addValueField = function(type) {
-        var container = $('#values');
-        switch (type) {
-            case 'resource':
-                template = container.data('template-resource');
-                break;
-            case 'uri':
-                template = container.data('template-uri');
-                break;
-            case 'literal':
-            default:
-                template = container.data('template-literal');
-        }
-        container.children('.field-container').append($.parseHTML(template.replace(/__INDEX__/g, index++)));
-    };
-    $('.value-add-button').on('click', function(e) {
-        addValueField($(this).data('type'));
-    });
-    $(document).on('click', '.field-container .remove-value', function(e) {
-        $(this).closest('.field').remove();
-    });
-});
-</script>
+<?php $this->trigger('view.batch_edit.after'); ?>

--- a/application/view/omeka/admin/item/batch-edit.phtml
+++ b/application/view/omeka/admin/item/batch-edit.phtml
@@ -1,63 +1,11 @@
 <?php
-echo $this->pageTitle($this->translate('Batch edit items'));
-
-$selectItemSetToAdd = $this->itemSetSelect([
-    'name' => 'add_to_item_set[]',
-    'options' => ['empty_option' => 'Select item set'],
-]);
-
-$selectItemSetToRemove = $this->itemSetSelect([
-    'name' => 'remove_from_item_set[]',
-    'options' => ['empty_option' => 'Select item set'],
-]);
-
-$selectPropertyToClear = $this->propertySelect([
-    'name' => 'clear_property_values[]',
-    'options' => ['empty_option' => 'Select property'],
-]);
-
-$selectProperty = $this->propertySelect([
-    'name' => 'value[__INDEX__][property_id]',
-    'options' => ['empty_option' => $this->translate('Select property')],
-]);
-$templateLiteral = '
-<div class="field">
-    <div class="field-meta">
-        <label>' . $this->translate('Add text value') . '</label>
-    </div>
-    <div class="inputs">
-        ' . $selectProperty . '
-        <textarea name="value[__INDEX__][value]"></textarea>
-        <input type="hidden" name="value[__INDEX__][type]" value="literal">
-        <button type="button" class="remove-value">' . $this->translate('Remove') . '</button>
-    </div>
-</div>';
-$templateResource = '
-<div class="field">
-    <div class="field-meta">
-        <label>' . $this->translate('Add resource value') . '</label>
-    </div>
-    <div class="inputs">
-        ' . $selectProperty . '
-        <input type="text" name="value[__INDEX__][value_resource_id]" placeholder="' . $this->escapeHtml($this->translate('Resource ID')) . '">
-        <input type="hidden" name="value[__INDEX__][type]" value="resource">
-        <button type="button" class="remove-value">' . $this->translate('Remove') . '</button>
-    </div>
-</div>';
-$templateUri = '
-<div class="field">
-    <div class="field-meta">
-        <label>' . $this->translate('Add URI value') . '</label>
-    </div>
-    <div class="inputs">
-        ' . $selectProperty . '
-        <input type="text" name="value[__INDEX__][id]" placeholder="' . $this->escapeHtml($this->translate('URI')) . '">
-        <input type="text" name="value[__INDEX__][label]" placeholder="' . $this->escapeHtml($this->translate('Label')) . '">
-        <input type="hidden" name="value[__INDEX__][type]" value="uri">
-        <button type="button" class="remove-value">' . $this->translate('Remove') . '</button>
-    </div>
-</div>';
+$form->prepare();
+$this->htmlElement('body')->appendAttribute('class', 'batch-edit items');
+$escape = $this->plugin('escapeHtml');
 ?>
+<?php echo $this->pageTitle($this->translate('Batch edit items')); ?>
+
+<?php $this->trigger('view.batch_edit.before'); ?>
 
 <?php echo $this->form()->openTag($form); ?>
 
@@ -70,107 +18,9 @@ $templateUri = '
     <input type="submit" name="batch_update" value="<?php echo $this->escapeHtml($this->translate('Save')); ?>">
 </div>
 
-<div class="field">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Set visibility'); ?></label>
-    </div>
-    <div class="inputs">
-        <select name="is_public">
-            <option value="" selected="selected"><?php echo $this->translate('[No change]'); ?></option>
-            <option value="1"><?php echo $this->translate('Public'); ?></option>
-            <option value="0"><?php echo $this->translate('Not public'); ?></option>
-        </select>
-    </div>
-</div>
-
-<div class="field">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Set template'); ?></label>
-    </div>
-    <div class="inputs">
-        <?php echo $this->resourceSelect([
-            'name' => 'resource_template',
-            'options' => [
-                'empty_option' => $this->translate('[No change]'),
-                'prepend_value_options' => ['-1' => $this->translate('[Unset template]')],
-                'resource_value_options' => [
-                    'resource' => 'resource_templates',
-                    'option_text_callback' => function ($resourceTemplate) {
-                        return $resourceTemplate->label();
-                    },
-                ],
-            ],
-        ]); ?>
-    </div>
-</div>
-
-<div class="field">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Set class'); ?></label>
-    </div>
-    <div class="inputs">
-        <?php echo $this->resourceClassSelect([
-            'name' => 'resource_class',
-            'options' => [
-                'empty_option' => $this->translate('[No change]'),
-                'prepend_value_options' => ['-1' => $this->translate('[Unset class]')],
-            ],
-        ]); ?>
-    </div>
-</div>
-
-<div class="field multi-value">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Add to item set'); ?></label>
-    </div>
-    <div class="inputs">
-        <div class="value">
-          <?php echo $selectItemSetToAdd; ?>
-          <button type="button" class="o-icon-delete remove-value"><?php echo $this->translate('Remove'); ?></button>
-        </div>
-        <button type="button" class="add-value button"><?php echo $this->translate('Add another item set'); ?></button>
-    </div>
-</div>
-
-<div class="field multi-value">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Remove from item set'); ?></label>
-    </div>
-    <div class="inputs">
-        <div class="value">
-        <?php echo $selectItemSetToRemove; ?>
-        <button type="button" class="o-icon-delete remove-value"><?php echo $this->translate('Remove'); ?></button>
-        </div>
-        <button type="button" class="add-value button"><?php echo $this->translate('Remove another item set'); ?></button>
-    </div>
-</div>
-
-<div class="field multi-value">
-    <div class="field-meta">
-        <label><?php echo $this->translate('Clear property values'); ?></label>
-    </div>
-    <div class="inputs">
-        <div class="value">
-            <?php echo $selectPropertyToClear; ?>
-            <button type="button" class="o-icon-delete remove-value"><?php echo $this->translate('Remove'); ?></button>
-        </div>
-        <button type="button" class="add-value button"><?php echo $this->translate('Clear another property'); ?></button>
-    </div>
-</div>
-
-<div id="values"
-    data-template-literal="<?php echo $this->escapeHtml($templateLiteral); ?>"
-    data-template-resource="<?php echo $this->escapeHtml($templateResource); ?>"
-    data-template-uri="<?php echo $this->escapeHtml($templateUri); ?>"
->
-    <div class="field-container"></div>
-    <button type="button" class="value-add-button" data-type="literal"><?php echo $this->translate('Add text value'); ?></button>
-    <button type="button" class="value-add-button" data-type="resource"><?php echo $this->translate('Add resource value'); ?></button>
-    <button type="button" class="value-add-button" data-type="uri"><?php echo $this->translate('Add URI value'); ?></button>
-</div>
-
-<?php echo $this->formRow($form->get('resourcebatchupdateform_csrf')); ?>
-<?php echo $this->form()->closeTag();; ?>
+<?php echo $this->formCollection($form, false); ?>
+<?php echo $this->partial('common/property-form-batch-edit.phtml', ['resourceType' => 'item_sets']); ?>
+<?php echo $this->form()->closeTag(); ?>
 
 <div class="sidebar always-open">
     <h3><?php echo $this->translate('Affected items'); ?></h3>
@@ -186,30 +36,4 @@ $templateUri = '
     <?php endif; ?>
 </div>
 
-<script>
-$(document).ready(function() {
-    // Add a value field.
-    var index = 0;
-    var addValueField = function(type) {
-        var container = $('#values');
-        switch (type) {
-            case 'resource':
-                template = container.data('template-resource');
-                break;
-            case 'uri':
-                template = container.data('template-uri');
-                break;
-            case 'literal':
-            default:
-                template = container.data('template-literal');
-        }
-        container.children('.field-container').append($.parseHTML(template.replace(/__INDEX__/g, index++)));
-    };
-    $('.value-add-button').on('click', function(e) {
-        addValueField($(this).data('type'));
-    });
-    $(document).on('click', '.field-container .remove-value', function(e) {
-        $(this).closest('.field').remove();
-    });
-});
-</script>
+<?php $this->trigger('view.batch_edit.after'); ?>


### PR DESCRIPTION
It factorizes batch edit item and batch edit item set, and added triggers `view.batch_edit.before / after` (may be renamed) in the view and `form.add_elements / add_input_filters` in the form. 

The main purpose is to simplify the maintenance of the batch-edit (but the resource controllers are not factorized), and to allow modules to set values to add/remove too.

Note that there is an issue for modules : currently, they can't use the event `api.update.pre/post`, that is used by the `AbstractEntityAdapter::batchUpdate()`, because the request is strictly filtered in [application/src/Api/Adapter/AbstractEntityAdapter.php#L375](https://github.com/omeka/omeka-s/blob/develop/application/src/Api/Adapter/AbstractEntityAdapter.php#L375) (default to empty array), so everything in the request is removed except core values of the resources. 

This filter is not used for other resources, so I was wondering if there is a particular reason for that. If not, the filter should be improved to allow a preprocess, but without removing unidentified keys from the raw data (they belong to modules that use the batch-edit).

