### PR TITLE
Set the site option "show_user_bar" ternary option.

### DIFF
--- a/application/src/Form/SiteSettingsForm.php
+++ b/application/src/Form/SiteSettingsForm.php
@@ -95,13 +95,17 @@ class SiteSettingsForm extends Form
         ]);
         $this->add([
             'name' => 'show_user_bar',
-            'type' => 'checkbox',
+            'type' => 'radio',
             'options' => [
-                'label' => 'Always show user bar on public views', // @translate
+                'label' => 'Show user bar on public views', // @translate
+                'value_options' => [
+                    '-1' => 'Never', // @translate
+                    '0' => 'When identified', // @translate
+                    '1' => 'Always', // @translate
+                ],
             ],
             'attributes' => [
-                'id' => 'show_user_bar',
-                'value' => $settings->get('show_user_bar', false),
+                'value' => $settings->get('show_user_bar', '0'),
             ],
         ]);
         $this->add([

--- a/application/view/common/user-bar.phtml
+++ b/application/view/common/user-bar.phtml
@@ -1,9 +1,8 @@
-<?php 
-$alwaysShowUserBar = $this->siteSetting('show_user_bar', false);
+<?php
+$showUserBar = $this->siteSetting('show_user_bar', 0);
 $currentUser = $this->identity();
 ?>
-
-<?php if ( $currentUser || $alwaysShowUserBar): ?>
+<?php if ($showUserBar == 1 || ($showUserBar != -1 && $currentUser)): ?>
     <?php 
     $escape = $this->plugin('escapeHtml'); 
     $this->headLink()->prependStylesheet($this->assetUrl('css/user-bar.css', 'Omeka'));
@@ -11,10 +10,12 @@ $currentUser = $this->identity();
     ?>
     <div id="user-bar">
         <?php if ($currentUser): ?>
+            <?php if ($this->userIsAllowed('Omeka\Controller\Admin\Index', 'index')): ?>
         <div class="logo"><a href="<?php echo $this->url('admin'); ?>"><?php echo $this->setting('installation_title', 'Omeka S'); ?></a></div>
         <span class="current-site">
             <a href="<?php echo $site->adminUrl('show'); ?>"><?php echo $site->title(); ?></a>
         </span>
+            <?php endif; ?>
         <span class="user-id">
         <?php 
         echo sprintf($this->translate('Signed in as %s'),  '<a href="' . $this->url('admin/id', [


### PR DESCRIPTION
I added a new value to the site setting `show_user_bar`, so it is possible now to display the user bar "never", "when identified" or "always", and not only "when identified" or "always".