### PR TITLE
Convert the user bar into a helper

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -391,6 +391,7 @@ return [
             'themeSettingAssetUrl' => View\Helper\ThemeSettingAssetUrl::class,
             'formColorPicker' => Form\View\Helper\FormColorPicker::class,
             'thumbnail' => View\Helper\Thumbnail::class,
+            'userBar' => View\Helper\UserBar::class,
         ],
         'factories' => [
             'api' => Service\ViewHelper\ApiFactory::class,

--- a/application/src/Form/SiteSettingsForm.php
+++ b/application/src/Form/SiteSettingsForm.php
@@ -95,13 +95,17 @@ class SiteSettingsForm extends Form
         ]);
         $this->add([
             'name' => 'show_user_bar',
-            'type' => 'checkbox',
+            'type' => 'radio',
             'options' => [
-                'label' => 'Always show user bar on public views', // @translate
+                'label' => 'Show user bar on public views', // @translate
+                'value_options' => [
+                    '-1' => 'Never', // @translate
+                    '0' => 'When identified', // @translate
+                    '1' => 'Always', // @translate
+                ],
             ],
             'attributes' => [
-                'id' => 'show_user_bar',
-                'value' => $settings->get('show_user_bar', false),
+                'value' => $settings->get('show_user_bar', '0'),
             ],
         ]);
         $this->add([

--- a/application/src/View/Helper/UserBar.php
+++ b/application/src/View/Helper/UserBar.php
@@ -1,0 +1,50 @@
+<?php
+namespace Omeka\View\Helper;
+
+use Zend\View\Helper\AbstractHelper;
+
+/**
+ * View helper for rendering the user bar.
+ */
+class UserBar extends AbstractHelper
+{
+    /**
+     * The default partial view script.
+     */
+    const PARTIAL_NAME = 'common/user-bar';
+
+    /**
+     * Render the user bar.
+     *
+     * @param string|null $partialName Name of view script, or a view model
+     * @return string
+     */
+    public function __invoke($partialName = null)
+    {
+        $view = $this->getView();
+        $showUserBar = $view->siteSetting('show_user_bar', 0);
+        if ($showUserBar == -1) {
+            return '';
+        }
+
+        $user = $view->identity();
+        if ($showUserBar != 1 && !$user) {
+            return '';
+        }
+
+        $site = $view->vars()->site;
+        if (empty($site)) {
+            return '';
+        }
+
+        $partialName = $partialName ?: self::PARTIAL_NAME;
+
+        return $view->partial(
+            $partialName,
+            [
+                'site' => $site,
+                'user' => $user,
+            ]
+        );
+    }
+}

--- a/application/view/common/user-bar.phtml
+++ b/application/view/common/user-bar.phtml
@@ -1,9 +1,8 @@
-<?php 
-$alwaysShowUserBar = $this->siteSetting('show_user_bar', false);
+<?php
+$showUserBar = $this->siteSetting('show_user_bar', 0);
 $currentUser = $this->identity();
 ?>
-
-<?php if ( $currentUser || $alwaysShowUserBar): ?>
+<?php if ($showUserBar == 1 || ($showUserBar != -1 && $currentUser)): ?>
     <?php 
     $escape = $this->plugin('escapeHtml'); 
     $this->headLink()->prependStylesheet($this->assetUrl('css/user-bar.css', 'Omeka'));
@@ -11,10 +10,12 @@ $currentUser = $this->identity();
     ?>
     <div id="user-bar">
         <?php if ($currentUser): ?>
+            <?php if ($this->userIsAllowed('Omeka\Controller\Admin\Index', 'index')): ?>
         <div class="logo"><a href="<?php echo $this->url('admin'); ?>"><?php echo $this->setting('installation_title', 'Omeka S'); ?></a></div>
         <span class="current-site">
             <a href="<?php echo $site->adminUrl('show'); ?>"><?php echo $site->title(); ?></a>
         </span>
+            <?php endif; ?>
         <span class="user-id">
         <?php 
         echo sprintf($this->translate('Signed in as %s'),  '<a href="' . $this->url('admin/id', [

--- a/application/view/common/user-bar.phtml
+++ b/application/view/common/user-bar.phtml
@@ -2,6 +2,7 @@
 $escape = $this->plugin('escapeHtml');
 $this->headLink()->prependStylesheet($this->assetUrl('css/user-bar.css', 'Omeka'));
 $this->headLink()->prependStylesheet('//fonts.googleapis.com/css?family=Source+Code+Pro|Lato:400,400italic,700,700italic');
+if (!isset($user)) $user = $this->identity();
 ?>
 <div id="user-bar">
 <?php if ($user): ?>

--- a/application/view/common/user-bar.phtml
+++ b/application/view/common/user-bar.phtml
@@ -1,32 +1,26 @@
 <?php
-$showUserBar = $this->siteSetting('show_user_bar', 0);
-$currentUser = $this->identity();
+$escape = $this->plugin('escapeHtml');
+$this->headLink()->prependStylesheet($this->assetUrl('css/user-bar.css', 'Omeka'));
+$this->headLink()->prependStylesheet('//fonts.googleapis.com/css?family=Source+Code+Pro|Lato:400,400italic,700,700italic');
 ?>
-<?php if ($showUserBar == 1 || ($showUserBar != -1 && $currentUser)): ?>
-    <?php 
-    $escape = $this->plugin('escapeHtml'); 
-    $this->headLink()->prependStylesheet($this->assetUrl('css/user-bar.css', 'Omeka'));
-    $this->headLink()->prependStylesheet('//fonts.googleapis.com/css?family=Source+Code+Pro|Lato:400,400italic,700,700italic');
+<div id="user-bar">
+<?php if ($user): ?>
+    <?php if ($this->userIsAllowed('Omeka\Controller\Admin\Index', 'index')): ?>
+    <div class="logo"><a href="<?php echo $this->url('admin'); ?>"><?php echo $this->setting('installation_title', 'Omeka S'); ?></a></div>
+    <span class="current-site">
+        <a href="<?php echo $site->adminUrl('show'); ?>"><?php echo $site->title(); ?></a>
+    </span>
+    <?php endif; ?>
+    <span class="user-id">
+    <?php
+    echo sprintf($this->translate('Signed in as %s'), '<a href="' . $this->url('admin/id', [
+        'controller' => 'user',
+        'id' => $user->getId(),
+    ]) . '">' . $escape($user->getName()) . '</a>');
     ?>
-    <div id="user-bar">
-        <?php if ($currentUser): ?>
-            <?php if ($this->userIsAllowed('Omeka\Controller\Admin\Index', 'index')): ?>
-        <div class="logo"><a href="<?php echo $this->url('admin'); ?>"><?php echo $this->setting('installation_title', 'Omeka S'); ?></a></div>
-        <span class="current-site">
-            <a href="<?php echo $site->adminUrl('show'); ?>"><?php echo $site->title(); ?></a>
-        </span>
-            <?php endif; ?>
-        <span class="user-id">
-        <?php 
-        echo sprintf($this->translate('Signed in as %s'),  '<a href="' . $this->url('admin/id', [
-            'controller' => 'user',
-            'id' => $this->identity()->getId(),
-        ]) . '">' . $escape($this->identity()->getName()) . '</a>'); 
-        ?>
-        </span>
-        <span class="logout"><a href="<?php echo $this->url('logout'); ?>"><?php echo $this->translate('Logout'); ?></a></span>
-        <?php else: ?>
-        <span class="login"><a href="<?php echo $this->url('login'); ?>"><?php echo $this->translate('Log in'); ?></a></span>
-        <?php endif; ?>
-    </div>
-<?php endif; ?>
+    </span>
+    <span class="logout"><a href="<?php echo $this->url('logout'); ?>"><?php echo $this->translate('Logout'); ?></a></span>
+    <?php else: ?>
+    <span class="login"><a href="<?php echo $this->url('login'); ?>"><?php echo $this->translate('Log in'); ?></a></span>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
Based on the previous pull request, I converted the user bar into a helper, so it is possible to add new tools in it. In fact, there are two ways to add new tools: a helper, so it's possible to upgrade the https://github.com/omeka/plugin-EditLink, or a trigger, or even a block, but it's simpler via a helper and modules for now.

Note that this change requires an update to the official themes, since the user bar is now just `echo $this->userBar();` (the partial is still available, but it requires a value for "user" and checks are not done). I can push this update if needed.