### PR TITLE
Displayed modules alphabetically in the left admin board.

### DIFF
--- a/application/src/Module/Manager.php
+++ b/application/src/Module/Manager.php
@@ -120,6 +120,14 @@ class Manager implements ResourceInterface
     }
 
     /**
+     * Sort modules alphabetically.
+     */
+    public function sortModules()
+    {
+        ksort($this->modules);
+    }
+
+    /**
      * Get all registered modules
      *
      * @return array

--- a/application/src/Service/ModuleManagerFactory.php
+++ b/application/src/Service/ModuleManagerFactory.php
@@ -141,6 +141,9 @@ class ModuleManagerFactory implements FactoryInterface
             }
         }
 
+        // Reorder modules.
+        $manager->sortModules();
+
         return $manager;
     }
 }


### PR DESCRIPTION
The list of modules in the left admin bar is displayed in various order, depending on file system, and on the order the modules are enabled, so it is not ergonomic. It is simpler to set a main order for all modules, so the same order is used anywhere.