### PR TITLE
Hidden missing item in block.

### DIFF
--- a/application/view/common/block-layout/item-with-metadata.phtml
+++ b/application/view/common/block-layout/item-with-metadata.phtml
@@ -1,7 +1,8 @@
 <div class="item-with-metadata">
 <?php foreach($attachments as $attachment): ?>
-    <div class="resource show">
     <?php $item = $attachment->item(); ?>
+    <?php if (empty($item)) continue; ?>
+    <div class="resource show">
     <?php echo $item->displayValues(); ?>
     <?php if($item->itemSets()): ?>
         <div class="property">


### PR DESCRIPTION
A quick fix to avoid an error in block when an item is not available.