### PR TITLE
Upgrade PHPUnit to v5 in way compatible with v6

### DIFF
--- a/application/src/Stdlib/ErrorStore.php
+++ b/application/src/Stdlib/ErrorStore.php
@@ -29,7 +29,7 @@ class ErrorStore
      * @param ErrorStore $errorStore
      * @param string $key Optional key to merge in errors under
      */
-    public function mergeErrors(ErrorStore $errorStore, $key = null)
+    public function mergeErrors(self $errorStore, $key = null)
     {
         if ($key === null) {
             foreach ($errorStore->getErrors() as $origKey => $messages) {

--- a/application/src/Test/TestCase.php
+++ b/application/src/Test/TestCase.php
@@ -11,7 +11,7 @@ use Zend\ServiceManager\ServiceManager;
  * The idea is to first set the mock objects to variables and then set
  * their expectations according to the specific test case.
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * Get a mock Zend\ServiceManager\ServiceManager (ServiceLocator) object.

--- a/application/src/Test/TestCase.php
+++ b/application/src/Test/TestCase.php
@@ -25,7 +25,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      */
     public function getServiceManager(array $services = [])
     {
-        $serviceManager = $this->getMock('Zend\ServiceManager\ServiceManager');
+        $serviceManager = $this->createMock('Zend\ServiceManager\ServiceManager');
         $serviceManager->expects($this->any())
             ->method('get')
             ->with($this->callback(function ($subject) use ($services) {

--- a/application/test/OmekaTest/Api/Adapter/AbstractAdapterTest.php
+++ b/application/test/OmekaTest/Api/Adapter/AbstractAdapterTest.php
@@ -19,49 +19,49 @@ class AbstractAdapterTest extends TestCase
     public function testSearchRequiresImplementation()
     {
         $this->setServiceManager();
-        $this->setExpectedException('Omeka\Api\Exception\RuntimeException');
+        $this->expectException('Omeka\Api\Exception\RuntimeException');
         $this->adapter->search($this->getMockRequest());
     }
 
     public function testCreateRequiresImplementation()
     {
         $this->setServiceManager();
-        $this->setExpectedException('Omeka\Api\Exception\RuntimeException');
+        $this->expectException('Omeka\Api\Exception\RuntimeException');
         $this->adapter->create($this->getMockRequest());
     }
 
     public function testBatchCreateRequiresImplementation()
     {
         $this->setServiceManager();
-        $this->setExpectedException('Omeka\Api\Exception\RuntimeException');
+        $this->expectException('Omeka\Api\Exception\RuntimeException');
         $this->adapter->batchCreate($this->getMockRequest());
     }
 
     public function testReadRequiresImplementation()
     {
         $this->setServiceManager();
-        $this->setExpectedException('Omeka\Api\Exception\RuntimeException');
+        $this->expectException('Omeka\Api\Exception\RuntimeException');
         $this->adapter->read($this->getMockRequest());
     }
 
     public function testUpdateRequiresImplementation()
     {
         $this->setServiceManager();
-        $this->setExpectedException('Omeka\Api\Exception\RuntimeException');
+        $this->expectException('Omeka\Api\Exception\RuntimeException');
         $this->adapter->update($this->getMockRequest());
     }
 
     public function testDeleteRequiresImplementation()
     {
         $this->setServiceManager();
-        $this->setExpectedException('Omeka\Api\Exception\RuntimeException');
+        $this->expectException('Omeka\Api\Exception\RuntimeException');
         $this->adapter->delete($this->getMockRequest());
     }
 
     protected function setServiceManager()
     {
         // MvcTranslator
-        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator = $this->createMock('Zend\I18n\Translator\Translator');
         $mockTranslator->expects($this->any())
             ->method('translate')
             ->will($this->returnArgument(0));
@@ -77,7 +77,7 @@ class AbstractAdapterTest extends TestCase
         $serviceManager = $this->getServiceManager([
             'MvcTranslator' => $mockTranslator,
             'Omeka\ApiAdapterManager' => $mockAdapterManager,
-            'EventManager' => $this->getMock('Zend\EventManager\EventManager'),
+            'EventManager' => $this->createMock('Zend\EventManager\EventManager'),
         ]);
         $this->adapter->setServiceLocator($serviceManager);
     }

--- a/application/test/OmekaTest/Api/Adapter/Entity/AbstractEntityAdapterTest.php
+++ b/application/test/OmekaTest/Api/Adapter/Entity/AbstractEntityAdapterTest.php
@@ -39,10 +39,10 @@ class AbstractEntityAdapterTest extends TestCase
             ->with($this->isInstanceOf('Omeka\Entity\EntityInterface'));
 
         // Service: MvcTranslator
-        $translator = $this->getMock('Zend\I18n\Translator\Translator');
+        $translator = $this->createMock('Zend\I18n\Translator\Translator');
 
         // Service: Omeka\Acl
-        $acl = $this->getMock('Omeka\Permissions\Acl');
+        $acl = $this->createMock('Omeka\Permissions\Acl');
         $acl->expects($this->once())
             ->method('userIsAllowed')
             ->with(
@@ -51,7 +51,7 @@ class AbstractEntityAdapterTest extends TestCase
             )
             ->will($this->returnValue(true));
 
-        $eventManager = $this->getMock('Zend\EventManager\EventManager');
+        $eventManager = $this->createMock('Zend\EventManager\EventManager');
         $eventManager->expects($this->exactly(2))
             ->method('triggerEvent')
             ->with($this->isInstanceOf('Zend\EventManager\Event'));

--- a/application/test/OmekaTest/Api/Adapter/ManagerTest.php
+++ b/application/test/OmekaTest/Api/Adapter/ManagerTest.php
@@ -18,7 +18,7 @@ class ManagerTest extends TestCase
 
     public function testValidateRequiresAdapterInterface()
     {
-        $this->setExpectedException('Zend\ServiceManager\Exception\InvalidServiceException');
+        $this->expectException('Zend\ServiceManager\Exception\InvalidServiceException');
         $this->manager->validate(new \stdClass);
     }
 }

--- a/application/test/OmekaTest/Api/ManagerTest.php
+++ b/application/test/OmekaTest/Api/ManagerTest.php
@@ -69,11 +69,10 @@ class ManagerTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Omeka\Api\Exception\BadRequestException
-     */
     public function testExecuteRequiresValidResource()
     {
+        $this->expectException(\Omeka\Api\Exception\BadRequestException::class);
+
         $mockResponse = $this->getMockResponse(true);
         $manager = $this->getApiManager(Request::SEARCH, $mockResponse, true, false);
 
@@ -81,11 +80,10 @@ class ManagerTest extends TestCase
         $response = $manager->execute($mockRequest);
     }
 
-    /**
-     * @expectedException \Omeka\Api\Exception\PermissionDeniedException
-     */
     public function testExecuteRequiresAccess()
     {
+        $this->expectException(\Omeka\Api\Exception\PermissionDeniedException::class);
+
         $mockResponse = $this->getMockResponse(true);
         $manager = $this->getApiManager(Request::SEARCH, $mockResponse, false);
 
@@ -93,11 +91,10 @@ class ManagerTest extends TestCase
         $response = $manager->execute($mockRequest);
     }
 
-    /**
-     * @expectedException \Omeka\Api\Exception\BadResponseException
-     */
     public function testExecuteRequiresValidResponse()
     {
+        $this->expectException(\Omeka\Api\Exception\BadResponseException::class);
+
         $mockResponse = null;
         $manager = $this->getApiManager(Request::SEARCH, $mockResponse);
 

--- a/application/test/OmekaTest/Api/ManagerTest.php
+++ b/application/test/OmekaTest/Api/ManagerTest.php
@@ -109,29 +109,29 @@ class ManagerTest extends TestCase
         $isAllowed = true, $validResource = true, $isBatchCreate = false
     ) {
         // Omeka\Logger
-        $mockLogger = $this->getMock('Zend\Log\Logger');
+        $mockLogger = $this->createMock('Zend\Log\Logger');
 
         // MvcTranslator
-        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator = $this->createMock('Zend\I18n\Translator\Translator');
         $mockTranslator->expects($this->any())
             ->method('translate')
             ->will($this->returnArgument(0));
 
         // EventManager returned by adapter
-        $mockEventManager = $this->getMock('Zend\EventManager\EventManager');
+        $mockEventManager = $this->createMock('Zend\EventManager\EventManager');
         $mockEventManager->expects($this->any())
             ->method('trigger')
             ->with($this->isInstanceOf('Zend\EventManager\Event'));
 
         // TestAdapter returned by the adapter manager
-        $mockAdapter = $this->getMock('Omeka\Api\Adapter\AdapterInterface');
+        $mockAdapter = $this->createMock('Omeka\Api\Adapter\AdapterInterface');
         $mockAdapter->expects($this->any())
             ->method('getResourceId')
             ->will($this->returnValue('Omeka\Api\Adapter\AdapterInterface'));
         $mockAdapter->expects($this->any())
             ->method('getRepresentation')
             ->will($this->returnValue(
-                $this->getMock('Omeka\Api\Representation\RepresentationInterface')
+                $this->createMock('Omeka\Api\Representation\RepresentationInterface')
             ));
         $mockAdapter->expects($this->any())
             ->method('getEventManager')
@@ -165,7 +165,7 @@ class ManagerTest extends TestCase
         }
 
         // Omeka\Acl
-        $mockAcl = $this->getMock('Omeka\Permissions\Acl');
+        $mockAcl = $this->createMock('Omeka\Permissions\Acl');
         $mockAcl->expects($this->any())
             ->method('userIsAllowed')
             ->with(
@@ -179,10 +179,10 @@ class ManagerTest extends TestCase
 
     protected function getMockResponse($isValidStatus)
     {
-        $mockResource = $this->getMock(
+        $mockResource = $this->createMock(
             'Omeka\Api\ResourceInterface'
         );
-        $mockResponse = $this->getMock('Omeka\Api\Response');
+        $mockResponse = $this->createMock('Omeka\Api\Response');
         $mockResponse->expects($this->any())
             ->method('getContent')
             ->will($this->returnValue($mockResource));

--- a/application/test/OmekaTest/Api/Representation/AbstractRepresentationTest.php
+++ b/application/test/OmekaTest/Api/Representation/AbstractRepresentationTest.php
@@ -9,7 +9,7 @@ class AbstractRepresentationTest extends TestCase
     public function testSetServiceLocator()
     {
         $serviceLocator = $this->getServiceManager([
-            'EventManager' => $this->getMock('Zend\EventManager\EventManager'),
+            'EventManager' => $this->createMock('Zend\EventManager\EventManager'),
         ]);
         $abstractRep = $this->getMockForAbstractClass(
             'Omeka\Api\Representation\AbstractRepresentation'

--- a/application/test/OmekaTest/Api/Representation/AbstractResourceRepresentationTest.php
+++ b/application/test/OmekaTest/Api/Representation/AbstractResourceRepresentationTest.php
@@ -14,7 +14,7 @@ class AbstractResourceRepresentationTest extends TestCase
         $url = 'test_url';
         $context = 'test_context';
 
-        $urlHelper = $this->getMock('Zend\View\Helper\Url');
+        $urlHelper = $this->createMock('Zend\View\Helper\Url');
         $urlHelper->expects($this->once())
             ->method('__invoke')
             ->will($this->returnValue($context));
@@ -24,7 +24,7 @@ class AbstractResourceRepresentationTest extends TestCase
             ->method('getId')
             ->will($this->returnValue($id));
 
-        $adapter = $this->getMock('Omeka\Api\Adapter\AdapterInterface');
+        $adapter = $this->createMock('Omeka\Api\Adapter\AdapterInterface');
         $adapter->expects($this->once())
             ->method('getServiceLocator')
             ->will($this->returnValue($this->getServiceManager([

--- a/application/test/OmekaTest/Api/Representation/Entity/AbstractResourceEntityRepresentationTest.php
+++ b/application/test/OmekaTest/Api/Representation/Entity/AbstractResourceEntityRepresentationTest.php
@@ -7,14 +7,14 @@ class AbstractResourceEntityRepresentationTest extends TestCase
 {
     public function testGetResourceClass()
     {
-        $resourceClass = $this->getMock('Omeka\Entity\ResourceClass');
+        $resourceClass = $this->createMock('Omeka\Entity\ResourceClass');
 
-        $resource = $this->getMock('Omeka\Entity\Resource');
+        $resource = $this->createMock('Omeka\Entity\Resource');
         $resource->expects($this->once())
             ->method('getResourceClass')
             ->will($this->returnValue($resourceClass));
 
-        $resourceClassAdapter = $this->getMock('Omeka\Api\Adapter\AbstractEntityAdapter');
+        $resourceClassAdapter = $this->createMock('Omeka\Api\Adapter\AbstractEntityAdapter');
         $resourceClassAdapter->expects($this->once())
             ->method('getRepresentation')
             ->with(
@@ -30,10 +30,10 @@ class AbstractResourceEntityRepresentationTest extends TestCase
 
         $serviceLocator = $this->getServiceManager([
             'Omeka\ApiAdapterManager' => $apiAdapterManager,
-            'EventManager' => $this->getMock('Zend\EventManager\EventManager'),
+            'EventManager' => $this->createMock('Zend\EventManager\EventManager'),
         ]);
 
-        $adapter = $this->getMock('Omeka\Api\Adapter\AbstractEntityAdapter');
+        $adapter = $this->createMock('Omeka\Api\Adapter\AbstractEntityAdapter');
         $adapter->expects($this->once())
             ->method('getServiceLocator')
             ->will($this->returnValue($serviceLocator));
@@ -49,16 +49,16 @@ class AbstractResourceEntityRepresentationTest extends TestCase
     {
         $resourceCreated = 'test-resource_created';
 
-        $resource = $this->getMock('Omeka\Entity\Resource');
+        $resource = $this->createMock('Omeka\Entity\Resource');
         $resource->expects($this->once())
             ->method('getCreated')
             ->will($this->returnValue($resourceCreated));
 
         $serviceLocator = $this->getServiceManager([
-            'EventManager' => $this->getMock('Zend\EventManager\EventManager'),
+            'EventManager' => $this->createMock('Zend\EventManager\EventManager'),
         ]);
 
-        $adapter = $this->getMock('Omeka\Api\Adapter\AbstractEntityAdapter');
+        $adapter = $this->createMock('Omeka\Api\Adapter\AbstractEntityAdapter');
         $adapter->expects($this->once())
             ->method('getServiceLocator')
             ->will($this->returnValue($serviceLocator));
@@ -74,16 +74,16 @@ class AbstractResourceEntityRepresentationTest extends TestCase
     {
         $resourceModified = 'test-resource_modified';
 
-        $resource = $this->getMock('Omeka\Entity\Resource');
+        $resource = $this->createMock('Omeka\Entity\Resource');
         $resource->expects($this->once())
             ->method('getModified')
             ->will($this->returnValue($resourceModified));
 
         $serviceLocator = $this->getServiceManager([
-            'EventManager' => $this->getMock('Zend\EventManager\EventManager'),
+            'EventManager' => $this->createMock('Zend\EventManager\EventManager'),
         ]);
 
-        $adapter = $this->getMock('Omeka\Api\Adapter\AbstractEntityAdapter');
+        $adapter = $this->createMock('Omeka\Api\Adapter\AbstractEntityAdapter');
         $adapter->expects($this->once())
             ->method('getServiceLocator')
             ->will($this->returnValue($serviceLocator));

--- a/application/test/OmekaTest/Api/Representation/ResourceReferenceTest.php
+++ b/application/test/OmekaTest/Api/Representation/ResourceReferenceTest.php
@@ -19,12 +19,12 @@ class ResourceReferenceTest extends TestCase
             ->method('getId')
             ->will($this->returnValue($this->id));
 
-        $this->viewHelperManager = $this->getMock('Interop\Container\ContainerInterface');
-        $this->adapter = $this->getMock('Omeka\Api\Adapter\AbstractAdapter');
+        $this->viewHelperManager = $this->createMock('Interop\Container\ContainerInterface');
+        $this->adapter = $this->createMock('Omeka\Api\Adapter\AbstractAdapter');
         $this->adapter->expects($this->once())
             ->method('getServiceLocator')
             ->will($this->returnValue($this->getServiceManager([
-                'EventManager' => $this->getMock('Zend\EventManager\EventManager'),
+                'EventManager' => $this->createMock('Zend\EventManager\EventManager'),
                 'ViewHelperManager' => $this->viewHelperManager,
             ])));
     }

--- a/application/test/OmekaTest/Db/Event/Subscriber/EntityTest.php
+++ b/application/test/OmekaTest/Db/Event/Subscriber/EntityTest.php
@@ -14,7 +14,7 @@ class EntityTest extends TestCase
 
     public function testGetSubscribedEvents()
     {
-        $eventManager = $this->getMock('Zend\EventManager\EventManager');
+        $eventManager = $this->createMock('Zend\EventManager\EventManager');
         $entity = new Entity($eventManager);
         $this->assertEquals(
             $this->subscribedEvents,
@@ -24,7 +24,7 @@ class EntityTest extends TestCase
 
     public function testCallbacks()
     {
-        $eventManager = $this->getMock('Zend\EventManager\EventManager');
+        $eventManager = $this->createMock('Zend\EventManager\EventManager');
         $eventManager->expects($this->exactly(6))
             ->method('setIdentifiers')
             ->with($this->equalTo(['Omeka\Db\Event\Subscriber\Entity']));

--- a/application/test/OmekaTest/Db/Migration/ManagerTest.php
+++ b/application/test/OmekaTest/Db/Migration/ManagerTest.php
@@ -59,11 +59,10 @@ class ManagerTest extends TestCase
         $this->assertInstanceOf($class, $migration);
     }
 
-    /**
-     * @expectedException Omeka\Db\Migration\Exception\ClassNotFoundException
-     */
     public function testLoadMigrationWithBadClassName()
     {
+        $this->expectException(\Omeka\Db\Migration\Exception\ClassNotFoundException::class);
+
         $path = __DIR__ . '/_files/1_MockMigration.php';
         $class = 'OmekaTest\Db\Migration\BogusMigration';
 
@@ -81,11 +80,10 @@ class ManagerTest extends TestCase
         $manager->loadMigration($path, $class);
     }
 
-    /**
-     * @expectedException Omeka\Db\Migration\Exception\ClassNotFoundException
-     */
     public function testLoadMigrationWithInvalidMigration()
     {
+        $this->expectException(\Omeka\Db\Migration\Exception\ClassNotFoundException::class);
+
         $path = __DIR__ . '/_files/2_MockInvalidMigration.php';
         $class = 'OmekaTest\Db\Migration\MockInvalidMigration';
 

--- a/application/test/OmekaTest/Installation/InstallerTest.php
+++ b/application/test/OmekaTest/Installation/InstallerTest.php
@@ -73,7 +73,7 @@ class InstallerTest extends TestCase
     public function getConfiguredServiceManager()
     {
         $status = $this->getMockBuilder('Omeka\Mvc\Status')->disableOriginalConstructor()->getMock();
-        $translator = $this->getMock('Zend\I18n\Translator\Translator');
+        $translator = $this->createMock('Zend\I18n\Translator\Translator');
         return $this->getServiceManager([
             'MvcTranslator' => $translator,
             'Omeka\Status' => $status,

--- a/application/test/OmekaTest/Job/AbstractJobTest.php
+++ b/application/test/OmekaTest/Job/AbstractJobTest.php
@@ -9,7 +9,7 @@ class AbstractJobTest extends TestCase
     {
         $args = ['foo' => 'bar', 'baz' => 'bat'];
 
-        $job = $this->getMock('Omeka\Entity\Job');
+        $job = $this->createMock('Omeka\Entity\Job');
         $job->expects($this->any())
             ->method('getArgs')
             ->will($this->returnValue($args));

--- a/application/test/OmekaTest/Job/DispatcherTest.php
+++ b/application/test/OmekaTest/Job/DispatcherTest.php
@@ -22,7 +22,7 @@ class DispatcherTest extends TestCase
             ['send', 'setServiceLocator', 'getServiceLocator']
         );
 
-        $this->auth = $this->getMock('Zend\Authentication\AuthenticationService');
+        $this->auth = $this->createMock('Zend\Authentication\AuthenticationService');
         $this->entityManager = $this->getMockBuilder('Doctrine\ORM\EntityManager')
             ->disableOriginalConstructor()
             ->getMock();
@@ -45,7 +45,7 @@ class DispatcherTest extends TestCase
             ->method('send')
             ->with($this->isInstanceOf('Omeka\Entity\Job'));
 
-        $owner = $this->getMock('Omeka\Entity\User');
+        $owner = $this->createMock('Omeka\Entity\User');
         $this->auth->expects($this->once())
             ->method('getIdentity')
             ->will($this->returnValue($owner));

--- a/application/test/OmekaTest/Job/Strategy/SynchronousStrategyTest.php
+++ b/application/test/OmekaTest/Job/Strategy/SynchronousStrategyTest.php
@@ -26,7 +26,7 @@ class SynchronousStrategyTest extends TestCase
     {
         require OMEKA_PATH . '/application/test/OmekaTest/Job/_files/Job.php';
 
-        $job = $this->getMock('Omeka\Entity\Job');
+        $job = $this->createMock('Omeka\Entity\Job');
         $job->expects($this->once())
             ->method('getClass')
             ->will($this->returnValue('OmekaTest\Job\Job'));

--- a/application/test/OmekaTest/Model/Entity/JobTest.php
+++ b/application/test/OmekaTest/Model/Entity/JobTest.php
@@ -55,21 +55,21 @@ class JobTest extends TestCase
 
     public function testSetOwner()
     {
-        $owner = $this->getMock('Omeka\Entity\User');
+        $owner = $this->createMock('Omeka\Entity\User');
         $this->job->setOwner($owner);
         $this->assertEquals($owner, $this->job->getOwner());
     }
 
     public function testSetStarted()
     {
-        $dateTime = $this->getMock('DateTime');
+        $dateTime = $this->createMock('DateTime');
         $this->job->setStarted($dateTime);
         $this->assertSame($dateTime, $this->job->getStarted());
     }
 
     public function testSetEnded()
     {
-        $dateTime = $this->getMock('DateTime');
+        $dateTime = $this->createMock('DateTime');
         $this->job->setEnded($dateTime);
         $this->assertSame($dateTime, $this->job->getEnded());
     }

--- a/application/test/OmekaTest/Mvc/Controller/Plugin/ApiTest.php
+++ b/application/test/OmekaTest/Mvc/Controller/Plugin/ApiTest.php
@@ -15,7 +15,7 @@ class ApiTest extends TestCase
         $mockApiManager->expects($this->once())
             ->method('search')
             ->with($this->equalTo($resource), $this->equalTo($data))
-            ->will($this->returnValue($this->getMock('Omeka\Api\Response')));
+            ->will($this->returnValue($this->createMock('Omeka\Api\Response')));
 
         $mockController = $this->getMockForAbstractClass('Zend\Mvc\Controller\AbstractController');
 
@@ -33,7 +33,7 @@ class ApiTest extends TestCase
         $mockApiManager->expects($this->once())
             ->method('create')
             ->with($this->equalTo($resource), $this->equalTo($data))
-            ->will($this->returnValue($this->getMock('Omeka\Api\Response')));
+            ->will($this->returnValue($this->createMock('Omeka\Api\Response')));
 
         $mockController = $this->getMockForAbstractClass('Zend\Mvc\Controller\AbstractController');
 
@@ -51,7 +51,7 @@ class ApiTest extends TestCase
         $mockApiManager->expects($this->once())
             ->method('batchCreate')
             ->with($this->equalTo($resource), $this->equalTo($data))
-            ->will($this->returnValue($this->getMock('Omeka\Api\Response')));
+            ->will($this->returnValue($this->createMock('Omeka\Api\Response')));
 
         $mockController = $this->getMockForAbstractClass('Zend\Mvc\Controller\AbstractController');
 
@@ -70,7 +70,7 @@ class ApiTest extends TestCase
         $mockApiManager->expects($this->once())
             ->method('read')
             ->with($this->equalTo($resource), $this->equalTo($id), $this->equalTo($data))
-            ->will($this->returnValue($this->getMock('Omeka\Api\Response')));
+            ->will($this->returnValue($this->createMock('Omeka\Api\Response')));
 
         $mockController = $this->getMockForAbstractClass('Zend\Mvc\Controller\AbstractController');
 
@@ -89,7 +89,7 @@ class ApiTest extends TestCase
         $mockApiManager->expects($this->once())
             ->method('update')
             ->with($this->equalTo($resource), $this->equalTo($id), $this->equalTo($data))
-            ->will($this->returnValue($this->getMock('Omeka\Api\Response')));
+            ->will($this->returnValue($this->createMock('Omeka\Api\Response')));
 
         $mockController = $this->getMockForAbstractClass('Zend\Mvc\Controller\AbstractController');
 
@@ -108,7 +108,7 @@ class ApiTest extends TestCase
         $mockApiManager->expects($this->once())
             ->method('delete')
             ->with($this->equalTo($resource), $this->equalTo($id), $this->equalTo($data))
-            ->will($this->returnValue($this->getMock('Omeka\Api\Response')));
+            ->will($this->returnValue($this->createMock('Omeka\Api\Response')));
 
         $mockController = $this->getMockForAbstractClass('Zend\Mvc\Controller\AbstractController');
 

--- a/application/test/OmekaTest/Mvc/MvcListenersTest.php
+++ b/application/test/OmekaTest/Mvc/MvcListenersTest.php
@@ -33,7 +33,7 @@ class MvcListenersTest extends TestCase
         $options['is_installed'] = isset($options['is_installed']) ? true : false;
         $options['is_install_route'] = isset($options['is_install_route']) ? true : false;
 
-        $event = $this->getMock('Zend\Mvc\MvcEvent');
+        $event = $this->createMock('Zend\Mvc\MvcEvent');
 
         // Zend\Mvc\Application
         $application = $this->getMockBuilder('Zend\Mvc\Application')
@@ -65,7 +65,7 @@ class MvcListenersTest extends TestCase
             ->will($this->returnValue($routeMatch));
 
         // Zend\Mvc\Router\RouteStackInterface
-        $router = $this->getMock('Zend\Router\RouteStackInterface');
+        $router = $this->createMock('Zend\Router\RouteStackInterface');
         $router->expects($this->any())
             ->method('assemble')
             ->with($this->equalTo([]), $this->equalTo(['name' => 'install']));
@@ -74,11 +74,11 @@ class MvcListenersTest extends TestCase
             ->will($this->returnValue($router));
 
         // Zend\Http\PhpEnvironment\Response
-        $headers = $this->getMock('Zend\Http\Headers');
+        $headers = $this->createMock('Zend\Http\Headers');
         $headers->expects($this->any())
             ->method('addHeaderLine')
             ->with($this->equalTo('Location'));
-        $response = $this->getMock('Zend\Http\PhpEnvironment\Response');
+        $response = $this->createMock('Zend\Http\PhpEnvironment\Response');
         $response->expects($this->any())
             ->method('getHeaders')
             ->will($this->returnValue($headers));

--- a/application/test/OmekaTest/Service/LoggerFactoryTest.php
+++ b/application/test/OmekaTest/Service/LoggerFactoryTest.php
@@ -33,7 +33,7 @@ class LoggerFactoryTest extends TestCase
 
     protected function getMockServiceLocator(array $config)
     {
-        $serviceLocator = $this->getMock('Zend\ServiceManager\ServiceLocatorInterface');
+        $serviceLocator = $this->createMock('Zend\ServiceManager\ServiceLocatorInterface');
         $serviceLocator->expects($this->once())
             ->method('get')
             ->with($this->equalTo('Config'))

--- a/application/test/OmekaTest/Stdlib/ErrorStoreTest.php
+++ b/application/test/OmekaTest/Stdlib/ErrorStoreTest.php
@@ -41,7 +41,7 @@ class ErrorStoreTest extends TestCase
 
     public function testMergesErrors()
     {
-        $errorStore = $this->getMock('Omeka\Stdlib\ErrorStore');
+        $errorStore = $this->createMock('Omeka\Stdlib\ErrorStore');
         $errorStore->expects($this->once())
             ->method('getErrors')
             ->will($this->returnValue(['foo' => ['foo_message_two']]));

--- a/application/test/OmekaTest/View/Helper/AssetUrlTest.php
+++ b/application/test/OmekaTest/View/Helper/AssetUrlTest.php
@@ -10,7 +10,7 @@ class AssetUrlTest extends TestCase
 
     public function setUp()
     {
-        $view = $this->getMock('Zend\View\Renderer\PhpRenderer');
+        $view = $this->createMock('Zend\View\Renderer\PhpRenderer');
         $this->assetUrl = new AssetUrl(
             'foo-theme',
             ['MyModule' => []],

--- a/application/test/OmekaTest/View/Helper/HtmlElementTest.php
+++ b/application/test/OmekaTest/View/Helper/HtmlElementTest.php
@@ -10,7 +10,7 @@ class HtmlElementTest extends TestCase
 
     public function setUp()
     {
-        $view = $this->getMock('Zend\View\Renderer\PhpRenderer');
+        $view = $this->createMock('Zend\View\Renderer\PhpRenderer');
         $view->expects($this->any())
             ->method('plugin')
             ->will($this->returnValue('htmlspecialchars'));

--- a/application/test/OmekaTest/View/Helper/PaginationTest.php
+++ b/application/test/OmekaTest/View/Helper/PaginationTest.php
@@ -30,7 +30,7 @@ class PaginationTest extends TestCase
             ->will($this->returnValue($query));
 
         // Omeka\Pagination
-        $paginator = $this->getMock('Omeka\Stdlib\Paginator');
+        $paginator = $this->createMock('Omeka\Stdlib\Paginator');
         $paginator->expects($this->any())
             ->method('setTotalCount')
             ->with($this->equalTo($totalCount));

--- a/application/test/OmekaTest/View/Renderer/ApiJsonRendererTest.php
+++ b/application/test/OmekaTest/View/Renderer/ApiJsonRendererTest.php
@@ -12,12 +12,12 @@ class ApiJsonRendererTest extends TestCase
     public function testRendererUsesApiResponse()
     {
         $testValue = ['test' => 'foo'];
-        $response = $this->getMock('Omeka\Api\Response');
+        $response = $this->createMock('Omeka\Api\Response');
         $response->expects($this->once())
                  ->method('getContent')
                  ->will($this->returnValue($testValue));
 
-        $model = $this->getMock('Omeka\View\Model\ApiJsonModel');
+        $model = $this->createMock('Omeka\View\Model\ApiJsonModel');
         $model->expects($this->once())
               ->method('getApiResponse')
               ->will($this->returnValue($response));
@@ -28,12 +28,12 @@ class ApiJsonRendererTest extends TestCase
 
     public function testRendererPassesOnNullResponse()
     {
-        $response = $this->getMock('Omeka\Api\Response');
+        $response = $this->createMock('Omeka\Api\Response');
         $response->expects($this->once())
                  ->method('getContent')
                  ->will($this->returnValue(null));
 
-        $model = $this->getMock('Omeka\View\Model\ApiJsonModel');
+        $model = $this->createMock('Omeka\View\Model\ApiJsonModel');
         $model->expects($this->once())
               ->method('getApiResponse')
               ->will($this->returnValue($response));
@@ -49,7 +49,7 @@ class ApiJsonRendererTest extends TestCase
         $exception = new ValidationException('exception message');
         $exception->setErrorStore($errorStore);
 
-        $model = $this->getMock('Omeka\View\Model\ApiJsonModel');
+        $model = $this->createMock('Omeka\View\Model\ApiJsonModel');
         $model->expects($this->once())
               ->method('getApiResponse')
               ->will($this->returnValue(null));

--- a/application/test/OmekaTest/View/Strategy/ApiJsonStrategyTest.php
+++ b/application/test/OmekaTest/View/Strategy/ApiJsonStrategyTest.php
@@ -16,7 +16,7 @@ class ApiJsonStrategyTest extends TestCase
 
     public function setUp()
     {
-        $this->renderer = $this->getMock('Omeka\View\Renderer\ApiJsonRenderer');
+        $this->renderer = $this->createMock('Omeka\View\Renderer\ApiJsonRenderer');
 
         $this->strategy = new ApiJsonStrategy($this->renderer);
 
@@ -28,7 +28,7 @@ class ApiJsonStrategyTest extends TestCase
 
     public function testStrategyPicksRendererForApiJsonModel()
     {
-        $model = $this->getMock('Omeka\View\Model\ApiJsonModel');
+        $model = $this->createMock('Omeka\View\Model\ApiJsonModel');
 
         $this->event->setModel($model);
 
@@ -37,7 +37,7 @@ class ApiJsonStrategyTest extends TestCase
 
     public function testStrategyDoesNothingForOtherModels()
     {
-        $model = $this->getMock('Zend\View\Model\JsonModel');
+        $model = $this->createMock('Zend\View\Model\JsonModel');
         $model->expects($this->never())
               ->method('getOption');
 
@@ -66,7 +66,7 @@ class ApiJsonStrategyTest extends TestCase
     public function testStrategySetsStatus($apiContent, $apiException, $httpStatus)
     {
         if (!$apiException) {
-            $apiResponse = $this->getMock('Omeka\Api\Response');
+            $apiResponse = $this->createMock('Omeka\Api\Response');
             $apiResponse->expects($this->any())
                         ->method('getContent')
                         ->will($this->returnValue($apiContent));
@@ -74,7 +74,7 @@ class ApiJsonStrategyTest extends TestCase
             $apiResponse = null;
         }
 
-        $model = $this->getMock('Omeka\View\Model\ApiJsonModel');
+        $model = $this->createMock('Omeka\View\Model\ApiJsonModel');
         $model->expects($this->once())
               ->method('getApiResponse')
               ->will($this->returnValue($apiResponse));
@@ -90,9 +90,9 @@ class ApiJsonStrategyTest extends TestCase
 
     public function testStrategySetsContentType()
     {
-        $apiResponse = $this->getMock('Omeka\Api\Response');
+        $apiResponse = $this->createMock('Omeka\Api\Response');
 
-        $model = $this->getMock('Omeka\View\Model\ApiJsonModel');
+        $model = $this->createMock('Omeka\View\Model\ApiJsonModel');
         $model->expects($this->once())
               ->method('getApiResponse')
               ->will($this->returnValue($apiResponse));

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "beberlei/DoctrineExtensions": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.2",
+        "phpunit/phpunit": "^5.7.23 || ^6.4.4",
         "friendsofphp/php-cs-fixer": "^2.0",
         "zendframework/zend-test": "^3.0.1",
         "zerocrates/extract-tagged-strings": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "82ede064d86030a762ea94eb955f7c2d",
+    "content-hash": "d0cf0f2a989edae2e90fe931c0742114",
     "packages": [
         {
             "name": "beberlei/DoctrineExtensions",
@@ -4636,6 +4636,51 @@
             "time": "2017-08-23T07:39:54+00:00"
         },
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
             "name": "php-cs-fixer/diff",
             "version": "v1.1.0",
             "source": {
@@ -4893,39 +4938,40 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "^1.0 || ^2.0"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "ext-xdebug": "^2.1.4",
+                "phpunit/phpunit": "^5.7"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -4951,7 +4997,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06T15:47:00+00:00"
+            "time": "2017-04-02T07:44:40+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -5141,40 +5187,50 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.36",
+            "version": "5.7.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517"
+                "reference": "4b1c822a68ae6577df38a59eb49b046712ec0f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/46023de9a91eec7dfb06cc56cb4e260017298517",
-                "reference": "46023de9a91eec7dfb06cc56cb4e260017298517",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b1c822a68ae6577df38a59eb49b046712ec0f6a",
+                "reference": "4b1c822a68ae6577df38a59eb49b046712ec0f6a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.6.2",
+                "phpunit/php-code-coverage": "^4.0.4",
                 "phpunit/php-file-iterator": "~1.4",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.2.2",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "^1.2.4",
+                "sebastian/diff": "^1.4.3",
+                "sebastian/environment": "^1.3.4 || ^2.0",
+                "sebastian/exporter": "~2.0",
+                "sebastian/global-state": "^1.1",
+                "sebastian/object-enumerator": "~2.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0.3|~2.0",
+                "symfony/yaml": "~2.1|~3.0|~4.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
+                "ext-xdebug": "*",
                 "phpunit/php-invoker": "~1.1"
             },
             "bin": [
@@ -5183,7 +5239,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "5.7.x-dev"
                 }
             },
             "autoload": {
@@ -5209,30 +5265,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-06-21T08:07:12+00:00"
+            "time": "2017-11-14T14:50:51+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
+                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2 || ^2.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.4"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -5240,7 +5299,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -5265,7 +5324,52 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02T06:51:40+00:00"
+            "time": "2017-06-30T09:13:00+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -5385,28 +5489,28 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.8",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
-                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8 || ^5.0"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -5431,25 +5535,25 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18T05:49:44+00:00"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.2",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
-                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "sebastian/recursion-context": "~2.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
@@ -5458,7 +5562,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -5498,7 +5602,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17T09:04:28+00:00"
+            "time": "2016-11-19T08:54:04+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -5552,17 +5656,63 @@
             "time": "2015-10-12T03:26:01+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.5",
+            "name": "sebastian/object-enumerator",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
-                "reference": "b19cc3298482a335a95f3016d2f8a6950f0fbcd7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-02-18T15:18:39+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
                 "shasum": ""
             },
             "require": {
@@ -5574,7 +5724,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -5602,23 +5752,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03T07:41:43+00:00"
+            "time": "2016-11-19T07:33:16+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -5637,7 +5837,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21T13:59:46+00:00"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -6068,16 +6268,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.3.10",
+            "version": "v3.3.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46"
+                "reference": "0938408c4faa518d95230deabb5f595bf0de31b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46",
-                "reference": "8c7bf1e7d5d6b05a690b715729cb4cd0c0a99c46",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0938408c4faa518d95230deabb5f595bf0de31b9",
+                "reference": "0938408c4faa518d95230deabb5f595bf0de31b9",
                 "shasum": ""
             },
             "require": {
@@ -6119,7 +6319,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-10-05T14:43:42+00:00"
+            "time": "2017-11-10T18:26:04+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
Brought to you by [PHP CS Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)

Upgrade PHPUnit to v5 in way compatible with v6.
That means, you could start using PHPUnit 6 as well without any changes in tests, as soon as you fulfill PHPUnit 6 requirements (bumping php itself to v7)