### PR TITLE
Fix/install php

### DIFF
--- a/application/src/Installation/Task/CheckEnvironmentTask.php
+++ b/application/src/Installation/Task/CheckEnvironmentTask.php
@@ -43,10 +43,14 @@ class CheckEnvironmentTask implements TaskInterface
      */
     protected function testRandomGeneration()
     {
-        try {
-            random_bytes(32);
-        } catch (\Exception $e) {
-            $installer->addError('Omeka is unable to securely generate random numbers.');
+        if (function_exists('random_bytes')) {
+            try {
+                random_bytes(32);
+            } catch (\Exception $e) {
+                $installer->addError('Omeka is unable to securely generate random numbers.');
+            }
+        } else {
+            $installer->addError('Omeka is unable to securely generate random numbers. Install random compat (https://packagist.org/packages/paragonie/random_compat).');
         }
     }
 }

--- a/application/view/error/index.phtml
+++ b/application/view/error/index.phtml
@@ -1,12 +1,13 @@
 <h1><?php echo $this->translate('Omeka S encountered an error'); ?></h1>
 
 <?php if (ini_get('display_errors')): ?>
+<?php $exception = $this->exception ?: new \Exception(); ?>
 <p>
-<strong><?php echo $this->escapeHtml(get_class($this->exception)); ?></strong><br>
-<?php echo $this->escapeHtml($this->exception->getMessage()); ?>
+<strong><?php echo $this->escapeHtml(get_class($exception)); ?></strong><br>
+<?php echo $this->escapeHtml($exception->getMessage()); ?>
 </p>
 <p><?php echo $this->translate('Details:'); ?></p>
 <pre>
-<?php echo $this->escapeHtml($this->exception); ?>
+<?php echo $this->escapeHtml($exception); ?>
 </pre>
 <?php endif; ?>


### PR DESCRIPTION
There is an error when installing on a php 5.6 server : random_bytes is not present, so there is a fatal error. 

Note that the [workaround](https://secure.php.net/manual/en/intro.csprng.php) for this php version is to use the library [paragonie/random_compat](https://github.com/paragonie/random_compat), but it is marked 

> Although this library has been examined by some security experts in the PHP community, there will always be a chance that we overlooked something. Please ask your favorite trusted hackers to hammer it for implementation errors and bugs before even thinking about deploying it in production.

So Omeka S should not be marked available with php 5.6, unless you warn the user of it.