### PR TITLE
Allowed to use a select element in theme form.

### DIFF
--- a/application/src/Controller/SiteAdmin/IndexController.php
+++ b/application/src/Controller/SiteAdmin/IndexController.php
@@ -355,20 +355,24 @@ class IndexController extends AbstractActionController
             $form->setData($oldSettings);
         }
 
-        if ($this->getRequest()->isPost()) {
-            $form->setData($this->params()->fromPost());
-            if ($form->isValid()) {
-                $data = $form->getData();
-                unset($data['form_csrf']);
-                $this->siteSettings()->set($theme->getSettingsKey(), $data);
-                $this->messenger()->addSuccess('Theme settings successfully updated'); // @translate
-                return $this->redirect()->refresh();
-            } else {
-                $this->messenger()->addFormErrors($form);
-            }
-        }
         $view->setVariable('form', $form);
         $view->setVariable('theme', $theme);
+        if (!$this->getRequest()->isPost()) {
+            return $view;
+        }
+
+        $postData = $this->params()->fromPost();
+        $form->setData($postData);
+        if ($form->isValid()) {
+            $data = $form->getData();
+            unset($data['form_csrf']);
+            $this->siteSettings()->set($theme->getSettingsKey(), $data);
+            $this->messenger()->addSuccess('Theme settings successfully updated'); // @translate
+            return $this->redirect()->refresh();
+        }
+
+        $this->messenger()->addFormErrors($form);
+
         return $view;
     }
 

--- a/application/src/Controller/SiteAdmin/IndexController.php
+++ b/application/src/Controller/SiteAdmin/IndexController.php
@@ -340,9 +340,14 @@ class IndexController extends AbstractActionController
         }
 
         $form = $this->getForm(Form::class)->setAttribute('id', 'site-form');
+        $inputFilter = $form->getInputFilter();
 
         foreach ($config['elements'] as $elementSpec) {
             $form->add($elementSpec);
+            $inputFilter->add([
+                'name' => $elementSpec['name'],
+                'required' => false,
+            ]);
         }
 
         $oldSettings = $this->siteSettings()->get($theme->getSettingsKey());

--- a/application/src/Controller/SiteAdmin/IndexController.php
+++ b/application/src/Controller/SiteAdmin/IndexController.php
@@ -339,15 +339,25 @@ class IndexController extends AbstractActionController
             return $view;
         }
 
+        /** @var Form $form */
         $form = $this->getForm(Form::class)->setAttribute('id', 'site-form');
-        $inputFilter = $form->getInputFilter();
 
         foreach ($config['elements'] as $elementSpec) {
             $form->add($elementSpec);
-            $inputFilter->add([
-                'name' => $elementSpec['name'],
-                'required' => false,
-            ]);
+        }
+
+        // Fix to manage empty values for selects and multicheckboxes.
+        $inputFilter = $form->getInputFilter();
+        foreach ($form->getElements() as $element) {
+            if ($element instanceof \Zend\Form\Element\MultiCheckbox
+                || ($element instanceof \Zend\Form\Element\Select
+                    && $element->getOption('empty_option') !== null)
+            ) {
+                $inputFilter->add([
+                    'name' => $element->getName(),
+                    'allow_empty' => true,
+                ]);
+            }
         }
 
         $oldSettings = $this->siteSettings()->get($theme->getSettingsKey());


### PR DESCRIPTION
When a `theme.ini` contains a select form, an empty value is not allowed. This fixes it. 
In fact, the Select doesn't accept a default value nowhere, but this is a Zend element, so it may be changed globally via getInputSpecification or something else, but for now this is enough.