### PR TITLE
Order modules alphabetically.

### DIFF
--- a/application/src/Controller/Admin/ModuleController.php
+++ b/application/src/Controller/Admin/ModuleController.php
@@ -59,7 +59,7 @@ class ModuleController extends AbstractActionController
 
         // Order modules by name.
         uasort($modules, function ($a, $b) {
-            return strcmp($a->getName(), $b->getName());
+            return strcmp(strtolower($a->getName()), strtolower($b->getName()));
         });
 
         $view = new ViewModel;


### PR DESCRIPTION
It is the same thing than #1123, but here, it is inside the module list : unApi should not be after UniversalViewer or ZoteroImport.