### PR TITLE
Skip bad queries in AbstractResourceEntityAdapter (instead of throwing an exception)

### DIFF
--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -246,7 +246,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter
                 case 'ex':
                     $predicateExpr = $qb->expr()->isNotNull("$valuesAlias.id");
                 default:
-                    continue;
+                    continue 2;
             }
 
             $joinConditions = [];


### PR DESCRIPTION
Fix `continue` use which has to continue the `foreach` loop, not only the `switch`, when a nonexistent query type is used.