### PR TITLE
omeka/omeka-s#1193: quick patch to prevent crashing on too-large image

### DIFF
--- a/application/src/Media/Ingester/IIIF.php
+++ b/application/src/Media/Ingester/IIIF.php
@@ -93,8 +93,8 @@ class IIIF implements IngesterInterface
                     $media->setStorageId($tempFile->getStorageId());
                     $media->setHasThumbnails(true);
                 }
+                $tempFile->delete();
             }
-            $tempFile->delete();
         }
     }
 


### PR DESCRIPTION
This produces slightly weird behavior, as the full-size image fails to import, but it doesn’t crash and the IIIF viewer seems to work correctly.