### PR TITLE
Add site setting to let choose whether open URI properties in new windows

### DIFF
--- a/application/src/DataType/Uri.php
+++ b/application/src/DataType/Uri.php
@@ -53,8 +53,10 @@ class Uri extends AbstractDataType
         if (!$uriLabel) {
             $uriLabel = $uri;
         }
-        $attributes = ['class' => 'uri-value-link', 
-            'target' => $view->siteSetting('uri_value_target_attribute', '_self')];
+        $attributes = [
+            'class' => 'uri-value-link',
+            'target' => $view->siteSetting('uri_value_target_attribute', '_self'),
+        ];
         return $view->hyperlink($uriLabel, $uri, $attributes);
     }
 

--- a/application/src/Form/SiteSettingsForm.php
+++ b/application/src/Form/SiteSettingsForm.php
@@ -89,6 +89,20 @@ class SiteSettingsForm extends Form
             ],
         ]);
         $this->add([
+            'name' => 'uri_value_target_attribute',
+            'type' => 'Select',
+            'options' => [
+                'label' => 'Open URI of a property value...', // @translate
+                'value_options' => [
+                    '_self' => 'In the same window (exiting the page)', // @translate
+                    '_blank' => 'In a new window', // @translate
+                ],
+            ],
+            'attributes' => [
+                'value' => $settings->get('uri_value_target_attribute'),
+            ],
+        ]);
+        $this->add([
             'name' => 'show_user_bar',
             'type' => 'checkbox',
             'options' => [


### PR DESCRIPTION
In order to address [Jane’s request on the forum](https://forum.omeka.org/t/how-to-set-a-sub-attribute-uri-and-label-of-a-dublin-core-property-eg-rights-in-csv/5127/10).

Currently, the partial `common/resource-values` calls `ValueRepresentation::asHtml()` which calls DataType renderer. So it is not easy to perform this in the theme.

Another way to do would be to let `asHtml()` and DataType renderers take attribute array.