### PR TITLE
Allow item set sorting

### DIFF
--- a/application/src/Api/Adapter/ItemSetAdapter.php
+++ b/application/src/Api/Adapter/ItemSetAdapter.php
@@ -86,7 +86,7 @@ class ItemSetAdapter extends AbstractResourceEntityAdapter
             }
         }
 
-		if (!empty($query['site_id'])) {
+        if (!empty($query['site_id'])) {
             $siteAdapter = $this->getAdapter('sites');
             try {
                 $site = $siteAdapter->findEntity($query['site_id']);

--- a/application/src/Api/Adapter/ItemSetAdapter.php
+++ b/application/src/Api/Adapter/ItemSetAdapter.php
@@ -71,8 +71,22 @@ class ItemSetAdapter extends AbstractResourceEntityAdapter
                 $qb->andWhere($expr);
             }
         }
+    }
 
-        if (!empty($query['site_id'])) {
+    /**
+     * {@inheritDoc}
+     */
+    public function sortQuery(QueryBuilder $qb, array $query)
+    {
+        if (is_string($query['sort_by'])) {
+            if ('item_count' == $query['sort_by']) {
+                $this->sortByCount($qb, $query, 'items');
+            } else {
+                parent::sortQuery($qb, $query);
+            }
+        }
+
+		if (!empty($query['site_id'])) {
             $siteAdapter = $this->getAdapter('sites');
             try {
                 $site = $siteAdapter->findEntity($query['site_id']);
@@ -89,20 +103,6 @@ class ItemSetAdapter extends AbstractResourceEntityAdapter
                 $this->createNamedParameter($qb, $query['site_id']))
             );
             $qb->addOrderBy("$siteItemSetsAlias.position", 'ASC');
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function sortQuery(QueryBuilder $qb, array $query)
-    {
-        if (is_string($query['sort_by'])) {
-            if ('item_count' == $query['sort_by']) {
-                $this->sortByCount($qb, $query, 'items');
-            } else {
-                parent::sortQuery($qb, $query);
-            }
         }
     }
 


### PR DESCRIPTION
In ItemSetAdapter, moves ORDER BY site_item_set.position from `buildQuery()` to end of `sortQuery()`, in order to prioritize user sorting choice.

Note that `$site` seems to be unused.