### PR TITLE
Add option to show form row as required even if element is not required

### DIFF
--- a/application/view/common/form-row.phtml
+++ b/application/view/common/form-row.phtml
@@ -1,5 +1,6 @@
 <?php
-$class = $element->getAttribute('required') ? 'field required' : 'field';
+$showRequired = $element->getAttribute('required') || $element->getOption('show_required');
+$class = $showRequired ? 'field required' : 'field';
 ?>
 <?php if (null === $label || 'hidden' === $element->getAttribute('type')): ?>
 <?php echo $this->formElement($element); ?>


### PR DESCRIPTION
Needed when a form element is required but hidden from view.