### PR TITLE
Triggered event "user.logout" when logout.

### DIFF
--- a/application/src/Controller/LoginController.php
+++ b/application/src/Controller/LoginController.php
@@ -75,8 +75,14 @@ class LoginController extends AbstractActionController
     public function logoutAction()
     {
         $this->auth->clearIdentity();
+
         $sessionManager = Container::getDefaultManager();
+
+        $eventManager = $this->getEventManager();
+        $eventManager->trigger('user.logout');
+
         $sessionManager->destroy();
+
         $this->messenger()->addSuccess('Successfully logged out'); // @translate
         return $this->redirect()->toRoute('login');
     }


### PR DESCRIPTION
When an external app is used to identify users, it should be warned that the user logs out.