### PR TITLE
Handle and log errors thrown during render

### DIFF
--- a/application/src/Mvc/ExceptionListener.php
+++ b/application/src/Mvc/ExceptionListener.php
@@ -24,6 +24,7 @@ class ExceptionListener extends AbstractListenerAggregate
     public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(MvcEvent::EVENT_DISPATCH_ERROR, [$this, 'handleException'], -5000);
+        $this->listeners[] = $events->attach(MvcEvent::EVENT_RENDER_ERROR, [$this, 'handleException'], -5000);
     }
 
     /**


### PR DESCRIPTION
Omeka was previously only listening on exception events that came from the
`EVENT_DISPATCH_ERROR` event.  However, errors can also be signalled as
`EVENT_RENDER_ERROR` events, which will never be logged with the current
implementation.