### PR TITLE
Allowed to search item set by id.

### DIFF
--- a/application/src/Api/Adapter/ItemSetAdapter.php
+++ b/application/src/Api/Adapter/ItemSetAdapter.php
@@ -49,6 +49,10 @@ class ItemSetAdapter extends AbstractResourceEntityAdapter
     {
         parent::buildQuery($qb, $query);
 
+        if (isset($query['id'])) {
+            $qb->andWhere($qb->expr()->eq('Omeka\Entity\ItemSet.id', $query['id']));
+        }
+
         // Select item sets to which the current user can assign an item.
         if (isset($query['is_open'])) {
             $acl = $this->getServiceLocator()->get('Omeka\Acl');


### PR DESCRIPTION
To search by id is allowed for some entities (item, media...), but not all. Ideally, any entity should be available by id. So here for item set only, for consistency.