### PR TITLE
Don’t display SitePagePagination view helper for unique pages

### DIFF
--- a/application/src/View/Helper/SitePagePagination.php
+++ b/application/src/View/Helper/SitePagePagination.php
@@ -46,6 +46,9 @@ class SitePagePagination extends AbstractHelper
         if (!$this->pageInNav) {
             return null;
         }
+        if (!$this->prevPage && !$this->nextPage) {
+            return null;
+        }
         return $this->getView()->partial(
             'common/site-page-pagination',
             [


### PR DESCRIPTION
SitePagePagination view helper returns null if the page which calls it does not have any previous nor next page.

Fix #1266 