### PR TITLE
Fix bug with "Filter by property" on item page.

### DIFF
--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -342,7 +342,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter
         }
 
         if ($property) {
-            $qb->where('v.property', $this->createNamedParameter($qb, $property));
+            $qb->andWhere($qb->expr()->eq('v.property', $this->createNamedParameter($qb, $property)));
         }
 
         $qb->setMaxResults($perPage);


### PR DESCRIPTION
In Omeka v1.2.0, the dropdown box "Filter by property" on item pages presents an error if you select a specific property. I think that it is because the query statement was not being built correctly with the property, and this change works for me as a fix.