### PR TITLE
Upgrade/easyrdf

### DIFF
--- a/application/src/Stdlib/RdfImporter.php
+++ b/application/src/Stdlib/RdfImporter.php
@@ -84,7 +84,7 @@ class RdfImporter
         }
 
         // Get the full RDF graph from EasyRdf.
-        $graph = new \EasyRdf\Graph;
+        $graph = new EasyRdf\Graph;
         switch ($strategy) {
             case 'file':
                 // Import from a file
@@ -97,7 +97,7 @@ class RdfImporter
                 }
                 try {
                     $graph->parseFile($file, $options['format'], $namespaceUri);
-                } catch (\EasyRdf\Exception $e) {
+                } catch (EasyRdf\Exception $e) {
                     throw new ValidationException($e->getMessage(), $e->getCode(), $e);
                 }
                 break;
@@ -108,7 +108,7 @@ class RdfImporter
                 }
                 try {
                     $graph->load($options['url'], $options['format']);
-                } catch (\EasyRdf\Exception $e) {
+                } catch (EasyRdf\Exception $e) {
                     throw new ValidationException($e->getMessage(), $e->getCode(), $e);
                 }
                 break;
@@ -121,7 +121,7 @@ class RdfImporter
         // Iterate through all resources of the graph instead of selectively by
         // rdf:type because a resource may have more than one type, causing
         // illegal attempts to duplicate classes and properties.
-        /** @var \EasyRdf\Resource $resource */
+        /** @var EasyRdf\Resource $resource */
         foreach ($graph->resources() as $resource) {
             // The resource must not be a blank node.
             if ($resource->isBnode()) {
@@ -332,7 +332,7 @@ class RdfImporter
      * @param EasyRdf\Resource $resource
      * @param string $namespaceUri
      */
-    protected function isMember(\EasyRdf\Resource $resource, $namespaceUri)
+    protected function isMember(EasyRdf\Resource $resource, $namespaceUri)
     {
         $output = strncmp($resource->getUri(), $namespaceUri, strlen($namespaceUri));
         return $output === 0;
@@ -349,7 +349,7 @@ class RdfImporter
      * @param string $lang
      * @return string
      */
-    protected function getLabel(\EasyRdf\Resource $resource, $default, $lang = null)
+    protected function getLabel(EasyRdf\Resource $resource, $default, $lang = null)
     {
         $label = $resource->label($lang) ?: $resource->label();
         if ($label instanceof EasyRdf\Literal) {
@@ -372,10 +372,10 @@ class RdfImporter
      * @param string $lang
      * @return string
      */
-    protected function getComment(\EasyRdf\Resource $resource, $commentProperty, $lang = null)
+    protected function getComment(EasyRdf\Resource $resource, $commentProperty, $lang = null)
     {
         $comment = $resource->get($commentProperty, null, $lang) ?: $resource->get($commentProperty);
-        if ($comment instanceof \EasyRdf\Literal) {
+        if ($comment instanceof EasyRdf\Literal) {
             return $comment->getValue();
         }
     }

--- a/application/src/Stdlib/RdfImporter.php
+++ b/application/src/Stdlib/RdfImporter.php
@@ -2,9 +2,7 @@
 namespace Omeka\Stdlib;
 
 use Doctrine\ORM\EntityManager;
-use EasyRdf_Graph;
-use EasyRdf_Literal;
-use EasyRdf_Resource;
+use EasyRdf;
 use Omeka\Api\Exception\ValidationException;
 use Omeka\Api\Manager as ApiManager;
 use Omeka\Entity\Property;
@@ -86,7 +84,7 @@ class RdfImporter
         }
 
         // Get the full RDF graph from EasyRdf.
-        $graph = new EasyRdf_Graph;
+        $graph = new \EasyRdf\Graph;
         switch ($strategy) {
             case 'file':
                 // Import from a file
@@ -99,7 +97,7 @@ class RdfImporter
                 }
                 try {
                     $graph->parseFile($file, $options['format'], $namespaceUri);
-                } catch (\EasyRdf_Exception $e) {
+                } catch (\EasyRdf\Exception $e) {
                     throw new ValidationException($e->getMessage(), $e->getCode(), $e);
                 }
                 break;
@@ -110,7 +108,7 @@ class RdfImporter
                 }
                 try {
                     $graph->load($options['url'], $options['format']);
-                } catch (\EasyRdf_Exception $e) {
+                } catch (\EasyRdf\Exception $e) {
                     throw new ValidationException($e->getMessage(), $e->getCode(), $e);
                 }
                 break;
@@ -329,10 +327,10 @@ class RdfImporter
     /**
      * Determine whether a resource is a local member of the vocabulary.
      *
-     * @param EasyRdf_Resource $resource
+     * @param EasyRdf\Resource $resource
      * @param string $namespaceUri
      */
-    protected function isMember(EasyRdf_Resource $resource, $namespaceUri)
+    protected function isMember(\EasyRdf\Resource $resource, $namespaceUri)
     {
         $output = strncmp($resource->getUri(), $namespaceUri, strlen($namespaceUri));
         return $output === 0;
@@ -344,15 +342,15 @@ class RdfImporter
      * Attempts to get the label of the passed language. If one does not exist
      * it defaults to the first available label, if any.
      *
-     * @param EasyRdf_Resource $resource
+     * @param EasyRdf\Resource $resource
      * @param string $default
      * @param string $lang
      * @return string
      */
-    protected function getLabel(EasyRdf_Resource $resource, $default, $lang = null)
+    protected function getLabel(\EasyRdf\Resource $resource, $default, $lang = null)
     {
         $label = $resource->label($lang) ?: $resource->label();
-        if ($label instanceof EasyRdf_Literal) {
+        if ($label instanceof EasyRdf\Literal) {
             $value = $label->getValue();
             if ('' !== $value) {
                 return $value;
@@ -367,15 +365,15 @@ class RdfImporter
      * Attempts to get the comment of the passed language. If one does not exist
      * it defaults to the first available comment, if any.
      *
-     * @param EasyRdf_Resource $resource
+     * @param EasyRdf\Resource $resource
      * @param string $commentProperty
      * @param string $lang
      * @return string
      */
-    protected function getComment(EasyRdf_Resource $resource, $commentProperty, $lang = null)
+    protected function getComment(\EasyRdf\Resource $resource, $commentProperty, $lang = null)
     {
         $comment = $resource->get($commentProperty, null, $lang) ?: $resource->get($commentProperty);
-        if ($comment instanceof EasyRdf_Literal) {
+        if ($comment instanceof \EasyRdf\Literal) {
             return $comment->getValue();
         }
     }

--- a/application/src/Stdlib/RdfImporter.php
+++ b/application/src/Stdlib/RdfImporter.php
@@ -121,6 +121,7 @@ class RdfImporter
         // Iterate through all resources of the graph instead of selectively by
         // rdf:type because a resource may have more than one type, causing
         // illegal attempts to duplicate classes and properties.
+        /** @var \EasyRdf\Resource $resource */
         foreach ($graph->resources() as $resource) {
             // The resource must not be a blank node.
             if ($resource->isBnode()) {
@@ -131,14 +132,15 @@ class RdfImporter
                 continue;
             }
             // Get the vocabulary's classes.
-            if (in_array($resource->type(), $this->classTypes)) {
+            $types = $resource->types();
+            if (array_intersect($types, $this->classTypes)) {
                 $members['classes'][$resource->localName()] = [
                     'label' => $this->getLabel($resource, $resource->localName(), $options['lang']),
                     'comment' => $this->getComment($resource, $options['comment_property'], $options['lang']),
                 ];
             }
             // Get the vocabulary's properties.
-            if (in_array($resource->type(), $this->propertyTypes)) {
+            if (array_intersect($types, $this->propertyTypes)) {
                 $members['properties'][$resource->localName()] = [
                     'label' => $this->getLabel($resource, $resource->localName(), $options['lang']),
                     'comment' => $this->getComment($resource, $options['comment_property'], $options['lang']),

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "php": ">=5.6",
         "doctrine/orm": "2.5.15",
-        "easyrdf/easyrdf": "~0.9",
+        "easyrdf/easyrdf": "dev-master",
         "ml/json-ld": "^1.1",
         "ezyang/htmlpurifier": "^4.8",
         "composer/semver": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ff2e01486610540ed42f43c94bf2413",
+    "content-hash": "7ffc320aee973a7e9d1a3f1c5cd56116",
     "packages": [
         {
             "name": "beberlei/DoctrineExtensions",
@@ -777,35 +777,39 @@
         },
         {
             "name": "easyrdf/easyrdf",
-            "version": "0.9.1",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/njh/easyrdf.git",
-                "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566"
+                "reference": "245addbd3d4f01c0781d0a42c082fd9d257b7b79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/njh/easyrdf/zipball/acd09dfe0555fbcfa254291e433c45fdd4652566",
-                "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566",
+                "url": "https://api.github.com/repos/njh/easyrdf/zipball/245addbd3d4f01c0781d0a42c082fd9d257b7b79",
+                "reference": "245addbd3d4f01c0781d0a42c082fd9d257b7b79",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "ext-pcre": "*",
-                "php": ">=5.2.8"
+                "php": ">=5.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~3.5",
-                "sami/sami": "~1.4",
-                "squizlabs/php_codesniffer": "~1.4.3"
+                "ml/json-ld": "~1.0",
+                "phpunit/phpunit": "~4.1",
+                "sami/sami": "~2.0",
+                "semsol/arc2": "~2.2",
+                "squizlabs/php_codesniffer": "~1.4.3",
+                "zendframework/zend-http": "~2.3"
             },
             "suggest": {
-                "ml/json-ld": "~1.0"
+                "ml/json-ld": "~1.0",
+                "semsol/arc2": "~2.2"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "EasyRdf_": "lib/"
+                "psr-4": {
+                    "EasyRdf\\": "lib"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -822,6 +826,7 @@
                 {
                     "name": "Alexey Zakhlestin",
                     "email": "indeyets@gmail.com",
+                    "homepage": "http://indeyets.ru/",
                     "role": "Developer"
                 }
             ],
@@ -835,7 +840,7 @@
                 "rdfa",
                 "sparql"
             ],
-            "time": "2015-02-27T09:45:49+00:00"
+            "time": "2018-09-22T08:44:25+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -1269,16 +1274,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "71ce77f37af0c5ffb9590e43cc4f70e426945c5e"
+                "reference": "98ae3cdc4bec48fe7ee24afc81dbb4a242186c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/71ce77f37af0c5ffb9590e43cc4f70e426945c5e",
-                "reference": "71ce77f37af0c5ffb9590e43cc4f70e426945c5e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/98ae3cdc4bec48fe7ee24afc81dbb4a242186c9e",
+                "reference": "98ae3cdc4bec48fe7ee24afc81dbb4a242186c9e",
                 "shasum": ""
             },
             "require": {
@@ -1337,20 +1342,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:06:07+00:00"
+            "time": "2019-03-31T11:33:18+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "8d8a9e877b3fcdc50ddecf8dcea146059753f782"
+                "reference": "adbdd5d66342fb0a0bce7422ba68181842b6610d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/8d8a9e877b3fcdc50ddecf8dcea146059753f782",
-                "reference": "8d8a9e877b3fcdc50ddecf8dcea146059753f782",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/adbdd5d66342fb0a0bce7422ba68181842b6610d",
+                "reference": "adbdd5d66342fb0a0bce7422ba68181842b6610d",
                 "shasum": ""
             },
             "require": {
@@ -1393,7 +1398,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-24T15:45:11+00:00"
+            "time": "2019-03-10T17:07:42+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -6087,16 +6092,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "ec625e2fff7f584eeb91754821807317b2e79236"
+                "reference": "a088aafcefb4eef2520a290ed82e4374092a6dff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ec625e2fff7f584eeb91754821807317b2e79236",
-                "reference": "ec625e2fff7f584eeb91754821807317b2e79236",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/a088aafcefb4eef2520a290ed82e4374092a6dff",
+                "reference": "a088aafcefb4eef2520a290ed82e4374092a6dff",
                 "shasum": ""
             },
             "require": {
@@ -6146,11 +6151,11 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:06:07+00:00"
+            "time": "2019-04-02T08:51:52+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -6200,7 +6205,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -6249,7 +6254,7 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
@@ -6475,7 +6480,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -6524,7 +6529,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -6573,16 +6578,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.23",
+            "version": "v3.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c"
+                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/57f1ce82c997f5a8701b89ef970e36bb657fd09c",
-                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/212a27b731e5bfb735679d1ffaac82bd6a1dc996",
+                "reference": "212a27b731e5bfb735679d1ffaac82bd6a1dc996",
                 "shasum": ""
             },
             "require": {
@@ -6628,7 +6633,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:06:07+00:00"
+            "time": "2019-03-25T07:48:46+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -6788,6 +6793,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "easyrdf/easyrdf": 20,
         "omeka-s-themes/default": 20,
         "zerocrates/extract-tagged-strings": 20
     },


### PR DESCRIPTION
[EasyRdf](https://github.com/njh/easyrdf) is still in version 9.0 since four years, but in fact, the version 0.10 alpha works a lot better. In particular, you can now import ontologies of any size (many MB) in some seconds only. So this simple upgrade fixes many issues for heavy or complex ontologies. 

The second commit is a pure fix: i want to import properties that are annotation property too, but this is not possible in this case (for example in the skos ontology, `skos:note` is a `owl:AnnotationProperty , rdf:Property`, so it should be imported, but it can't because only the first type was checked). 

On this subject, I like to add a checkbox to let the user to import all properties, included annotation properties (that I need for one project).