### PR TITLE
Feature/locale page

### DIFF
--- a/application/Module.php
+++ b/application/Module.php
@@ -13,7 +13,7 @@ class Module extends AbstractModule
     /**
      * This Omeka version.
      */
-    const VERSION = '1.2.1-alpha4';
+    const VERSION = '1.2.1-alpha.5';
 
     /**
      * The vocabulary IRI used to define Omeka application data.

--- a/application/Module.php
+++ b/application/Module.php
@@ -13,7 +13,7 @@ class Module extends AbstractModule
     /**
      * This Omeka version.
      */
-    const VERSION = '1.2.1-alpha.5';
+    const VERSION = '1.3.0';
 
     /**
      * The vocabulary IRI used to define Omeka application data.

--- a/application/asset/js/admin.js
+++ b/application/asset/js/admin.js
@@ -190,7 +190,7 @@ var Omeka = {
     },
 
     // @see http://stackoverflow.com/questions/7035825/regular-expression-for-a-language-tag-as-defined-by-bcp47
-    // Removes `|[A-Za-z]{4}|[A-Za-z]{5,8}` from the "language" portion becuase,
+    // Removes `|[A-Za-z]{4}|[A-Za-z]{5,8}` from the "language" portion because,
     // while in the spec, it does not represent current usage.
     langIsValid: function(lang) {
         return lang.match(/^(((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?))(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+))$/);
@@ -273,6 +273,17 @@ var Omeka = {
                 isPublicIcon.attr('aria-label', Omeka.jsTranslate('Make public'));
                 isPublicIcon.attr('title', Omeka.jsTranslate('Make public'));
                 isPublicHiddenValue.attr('value', 0);
+            }
+        });
+
+        $('#content').on('keyup', 'input[name="o:lang"]', function(e) {
+console.log('idi');
+            if ('' === this.value || Omeka.langIsValid(this.value)) {
+console.log('xcv');
+                this.setCustomValidity('');
+            } else {
+console.log('try');
+                this.setCustomValidity(Omeka.jsTranslate('Please enter a valid language tag'))
             }
         });
 

--- a/application/data/doctrine-proxies/__CG__OmekaEntitySitePage.php
+++ b/application/data/doctrine-proxies/__CG__OmekaEntitySitePage.php
@@ -64,10 +64,10 @@ class SitePage extends \Omeka\Entity\SitePage implements \Doctrine\ORM\Proxy\Pro
     public function __sleep()
     {
         if ($this->__isInitialized__) {
-            return ['__isInitialized__', 'id', 'slug', 'title', 'site', 'created', 'modified', 'blocks'];
+            return ['__isInitialized__', 'id', 'slug', 'title', 'lang', 'site', 'created', 'modified', 'blocks'];
         }
 
-        return ['__isInitialized__', 'id', 'slug', 'title', 'site', 'created', 'modified', 'blocks'];
+        return ['__isInitialized__', 'id', 'slug', 'title', 'lang', 'site', 'created', 'modified', 'blocks'];
     }
 
     /**
@@ -230,6 +230,28 @@ class SitePage extends \Omeka\Entity\SitePage implements \Doctrine\ORM\Proxy\Pro
         $this->__initializer__ && $this->__initializer__->__invoke($this, 'getTitle', []);
 
         return parent::getTitle();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setLang($lang)
+    {
+
+        $this->__initializer__ && $this->__initializer__->__invoke($this, 'setLang', [$lang]);
+
+        return parent::setLang($lang);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getLang()
+    {
+
+        $this->__initializer__ && $this->__initializer__->__invoke($this, 'getLang', []);
+
+        return parent::getLang();
     }
 
     /**

--- a/application/data/install/schema.sql
+++ b/application/data/install/schema.sql
@@ -238,6 +238,7 @@ CREATE TABLE `site_page` (
   `site_id` int(11) NOT NULL,
   `slug` varchar(190) COLLATE utf8mb4_unicode_ci NOT NULL,
   `title` varchar(190) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `lang` varchar(190) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created` datetime NOT NULL,
   `modified` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),

--- a/application/data/migrations/20181119000000_AddLangToSitePage.php
+++ b/application/data/migrations/20181119000000_AddLangToSitePage.php
@@ -1,0 +1,13 @@
+<?php
+namespace Omeka\Db\Migrations;
+
+use Doctrine\DBAL\Connection;
+use Omeka\Db\Migration\MigrationInterface;
+
+class AddLangToSitePage implements MigrationInterface
+{
+    public function up(Connection $conn)
+    {
+        $conn->exec('ALTER TABLE site_page ADD lang VARCHAR(190) COLLATE utf8mb4_unicode_ci DEFAULT NULL AFTER title;');
+    }
+}

--- a/application/src/Api/Representation/SitePageRepresentation.php
+++ b/application/src/Api/Representation/SitePageRepresentation.php
@@ -24,6 +24,7 @@ class SitePageRepresentation extends AbstractEntityRepresentation
         return [
             'o:slug' => $this->slug(),
             'o:title' => $this->title(),
+            'o:lang' => $this->lang(),
             'o:block' => $this->blocks(),
             'o:site' => $this->site()->getReference(),
             'o:created' => $created,
@@ -59,6 +60,14 @@ class SitePageRepresentation extends AbstractEntityRepresentation
     public function title()
     {
         return $this->resource->getTitle();
+    }
+
+    /**
+     * @return string
+     */
+    public function lang()
+    {
+        return $this->resource->getLang();
     }
 
     /**

--- a/application/src/Entity/SitePage.php
+++ b/application/src/Entity/SitePage.php
@@ -34,6 +34,11 @@ class SitePage extends AbstractEntity
     protected $title;
 
     /**
+     * @Column(nullable=true, length=190)
+     */
+    protected $lang;
+
+    /**
      * @ManyToOne(targetEntity="Site", inversedBy="pages")
      * @JoinColumn(nullable=false)
      */
@@ -88,6 +93,16 @@ class SitePage extends AbstractEntity
     public function getTitle()
     {
         return $this->title;
+    }
+
+    public function setLang($lang)
+    {
+        $this->lang = $lang;
+    }
+
+    public function getLang()
+    {
+        return $this->lang;
     }
 
     public function setSite(Site $site)

--- a/application/src/Form/SitePageForm.php
+++ b/application/src/Form/SitePageForm.php
@@ -1,6 +1,7 @@
 <?php
 namespace Omeka\Form;
 
+use Zend\Form\Element;
 use Zend\Form\Form;
 
 class SitePageForm extends Form
@@ -11,7 +12,7 @@ class SitePageForm extends Form
 
         $this->add([
             'name' => 'o:title',
-            'type' => 'Text',
+            'type' => Element\Text::class,
             'options' => [
                 'label' => 'Title', // @translate
             ],
@@ -20,9 +21,10 @@ class SitePageForm extends Form
                 'required' => true,
             ],
         ]);
+
         $this->add([
             'name' => 'o:slug',
-            'type' => 'Text',
+            'type' => Element\Text::class,
             'options' => [
                 'label' => 'URL slug', // @translate
             ],
@@ -31,6 +33,19 @@ class SitePageForm extends Form
                 'required' => false,
             ],
         ]);
+
+        $this->add([
+            'name' => 'o:lang',
+            'type' => Element\Text::class,
+            'options' => [
+                'label' => 'Language code', // @translate
+            ],
+            'attributes' => [
+                'id' => 'o-lang',
+                'required' => false,
+            ],
+        ]);
+
         if ($this->getOption('addPage')) {
             $this->add([
                 'name' => 'add_to_navigation',

--- a/application/view/omeka/site-admin/page/index.phtml
+++ b/application/view/omeka/site-admin/page/index.phtml
@@ -20,15 +20,21 @@ $escape = $this->plugin('escapeHtml');
     </thead>
     <tbody>
     <?php foreach ($pages as $page): ?>
+    <?php $lang = $page->lang(); ?>
     <tr class="page">
         <td>
             <?php if (array_key_exists($page->id(), $indents)): ?>
             <?php echo str_repeat('<span class="indent"></span>', intval($indents[$page->id()])); ?>
             <?php endif; ?>
+            <span<?php if ($lang) echo ' lang="' . $this->lang($lang) . '"'; ?>>
             <?php if ($page->userIsAllowed('update')): ?>
             <?php echo $page->link($page->title(), 'edit'); ?>
             <?php else: ?>
             <?php echo $page->title(); ?>
+            <?php endif; ?>
+            </span>
+            <?php if ($lang): ?>
+            <span class="lang <?php echo $this->lang($lang); ?>"><?php echo $lang; ?></span>
             <?php endif; ?>
             <input type="hidden" name="o:page[][o:id]" value="<?php echo $escape($page->id()); ?>">
             <ul class="actions">

--- a/application/view/omeka/site-admin/page/show-details.phtml
+++ b/application/view/omeka/site-admin/page/show-details.phtml
@@ -1,4 +1,11 @@
+<?php
+$translate = $this->plugin('translate');
+?>
 <div class='resource-details'>
     <h3 class="title"><?php echo $resource->title(); ?></h3>
+    <?php $lang = $resource->lang(); ?>
+    <?php if ($lang): ?>
+    <p class="lang <?php echo $this->lang($lang); ?>"><?php echo sprintf($translate('Language: %s'), $lang); ?></p>
+    <?php endif; ?>
 </div>
 <?php $this->trigger('view.details', array('entity' => $resource)); ?>

--- a/application/view/omeka/site/page/show.phtml
+++ b/application/view/omeka/site/page/show.phtml
@@ -1,5 +1,9 @@
 <?php
 $this->htmlElement('body')->appendAttribute('class', 'page');
+$lang = $page->lang();
+if ($lang != $this->lang()):
+    $this->htmlElement('body')->appendAttribute('lang', $this->lang($lang));
+endif;
 $this->pageTitle($page->title(), 2);
 $showPagePagination = $this->siteSetting('show_page_pagination', true);
 ?>


### PR DESCRIPTION
This feature is the required first step to make Omeka full multilingual, as many users want. 

There are two main ways to manage localization: one site by language, or multilanguage by site. The first way has many limitation, in particular it implies to have two urls for the same pages and documents. The second way is the normal way we found on many cms. 

Because there is a new value in the database for the site pages, it can be used by future modules easily, unlike in Omeka Classic.

Fix #898, #1293, https://forum.omeka.org/t/bilingual-content-internationalisation/2116, https://forum.omeka.org/t/internationalized-omeka-s/3154/22, etc.