### PR TITLE
Allow arbitrary keys to be passed into batch update job

### DIFF
--- a/application/src/Controller/Admin/ItemController.php
+++ b/application/src/Controller/Admin/ItemController.php
@@ -334,9 +334,7 @@ class ItemController extends AbstractActionController
                 $job = $this->jobDispatcher()->dispatch('Omeka\Job\BatchUpdate', [
                     'resource' => 'items',
                     'query' => $query,
-                    'data' => isset($data['replace']) ? $data['replace'] : [],
-                    'data_remove' => isset($data['remove']) ? $data['remove'] : [],
-                    'data_append' => isset($data['append']) ? $data['append'] : [],
+                    'data' => $data
                 ]);
 
                 $this->messenger()->addSuccess('Editing items. This may take a while.'); // @translate

--- a/application/src/Job/BatchUpdate.php
+++ b/application/src/Job/BatchUpdate.php
@@ -10,8 +10,6 @@ class BatchUpdate extends AbstractJob
         $resource = $this->getArg('resource');
         $query = $this->getArg('query', []);
         $data = $this->getArg('data', []);
-        $dataRemove = $this->getArg('data_remove', []);
-        $dataAppend = $this->getArg('data_append', []);
 
         $response = $api->search($resource, $query, ['returnScalar' => 'id']);
 
@@ -20,21 +18,10 @@ class BatchUpdate extends AbstractJob
             if ($this->shouldStop()) {
                 return;
             }
-            if ($data) {
-                $api->batchUpdate($resource, $idsChunk, $data, [
+            foreach ($data as $collectionAction => $properties) {
+                $api->batchUpdate('items', $idsChunk, $properties, [
                     'continueOnError' => true,
-                ]);
-            }
-            if ($dataRemove) {
-                $api->batchUpdate($resource, $idsChunk, $dataRemove, [
-                    'continueOnError' => true,
-                    'collectionAction' => 'remove',
-                ]);
-            }
-            if ($dataAppend) {
-                $api->batchUpdate($resource, $idsChunk, $dataAppend, [
-                    'continueOnError' => true,
-                    'collectionAction' => 'append',
+                    'collectionAction' => $collectionAction,
                 ]);
             }
         }


### PR DESCRIPTION
This brings "batch update all" in line with "batch update selected," which allows arbitrary keys to be passed in the request data. Otherwise, only the `replace`, `remove`, and `append` keys (those that declare the "collection action" request option) can be passed to and processed by the batch update job. This is a safe change because the data is still passed through `preprocessBatchUpdate()` in the adapter.