### PR TITLE
Display linked resource Title instead of URI in Browse and Browse Preview

### DIFF
--- a/application/view/common/block-layout/browse-preview.phtml
+++ b/application/view/common/block-layout/browse-preview.phtml
@@ -17,7 +17,9 @@ foreach ($this->resources as $resource):
         'resource:item',
         'resource:itemset',
         'resource:media'
-    ])) ? $headingTermValue->valueResource()->displayTitle() . " (" . $resource->value('dcterms:title') . ")" : $headingTermValue;
+    ])) ? $headingTermValue->valueResource()->displayTitle() . " (" . $resource->value('dcterms:title', [
+        'default' => $this->translate('[Untitled]')
+    ]) . ")" : $headingTermValue;
 
 
     $bodyTermValue = $resource->value($bodyTerm);

--- a/application/view/common/block-layout/browse-preview.phtml
+++ b/application/view/common/block-layout/browse-preview.phtml
@@ -12,12 +12,13 @@ foreach ($this->resources as $resource):
     $headingTermValue = $resource->value($headingTerm, [
         'default' => $this->translate('[Untitled]')
     ]);
-    $heading = ($headingTermValue && !is_string($headingTermValue) && in_array($headingTermValue->type(), [
+    $heading = ($headingTermValue && ! is_string($headingTermValue) && in_array($headingTermValue->type(), [
         'resource',
         'resource:item',
         'resource:itemset',
         'resource:media'
-    ])) ? $headingTermValue->valueResource()->displayTitle() : $headingTermValue;
+    ])) ? $headingTermValue->valueResource()->displayTitle() . " (" . $resource->value('dcterms:title') . ")" : $headingTermValue;
+
 
     $bodyTermValue = $resource->value($bodyTerm);
     $body = ($bodyTermValue && in_array($bodyTermValue->type(), [

--- a/application/view/common/block-layout/browse-preview.phtml
+++ b/application/view/common/block-layout/browse-preview.phtml
@@ -9,12 +9,23 @@
 $headingTerm = $this->siteSetting('browse_heading_property_term', 'dcterms:title');
 $bodyTerm = $this->siteSetting('browse_body_property_term', 'dcterms:description');
 foreach ($this->resources as $resource):
-    $heading = $resource->value($headingTerm, ['default' => $this->translate('[Untitled]')]);
+    $headingTermValue = $resource->value($headingTerm, [
+        'default' => $this->translate('[Untitled]')
+    ]);
+    $heading = ($headingTermValue && !is_string($headingTermValue) && in_array($headingTermValue->type(), [
+        'resource',
+        'resource:item',
+        'resource:itemset',
+        'resource:media'
+    ])) ? $headingTermValue->valueResource()->displayTitle() : $headingTermValue;
+
     $bodyTermValue = $resource->value($bodyTerm);
-    if ($bodyTermValue && in_array($bodyTermValue->type(), ['resource', 'resource:item', 'resource:itemset', 'resource:media']))
-        $body = $bodyTermValue->valueResource()->displayTitle();
-    else
-        $body = $bodyTermValue
+    $body = ($bodyTermValue && in_array($bodyTermValue->type(), [
+        'resource',
+        'resource:item',
+        'resource:itemset',
+        'resource:media'
+    ])) ? $bodyTermValue->valueResource()->displayTitle() : $bodyTermValue;
 ?>
     <li class="<?php echo $this->resourceType; ?> resource">
         <?php echo $resource->linkRaw($this->thumbnail($resource, 'medium', ['title' => $heading])); ?>

--- a/application/view/common/block-layout/browse-preview.phtml
+++ b/application/view/common/block-layout/browse-preview.phtml
@@ -10,7 +10,11 @@ $headingTerm = $this->siteSetting('browse_heading_property_term', 'dcterms:title
 $bodyTerm = $this->siteSetting('browse_body_property_term', 'dcterms:description');
 foreach ($this->resources as $resource):
     $heading = $resource->value($headingTerm, ['default' => $this->translate('[Untitled]')]);
-    $body = $resource->value($bodyTerm);
+    $bodyTermValue = $resource->value($bodyTerm);
+    if ($bodyTermValue && in_array($bodyTermValue->type(), ['resource', 'resource:item', 'resource:itemset', 'resource:media']))
+        $body = $bodyTermValue->valueResource()->displayTitle();
+    else
+        $body = $bodyTermValue
 ?>
     <li class="<?php echo $this->resourceType; ?> resource">
         <?php echo $resource->linkRaw($this->thumbnail($resource, 'medium', ['title' => $heading])); ?>

--- a/application/view/omeka/site/item/browse.phtml
+++ b/application/view/omeka/site/item/browse.phtml
@@ -55,12 +55,23 @@ $sortHeadings = [
 <ul class="resource-list">
 <?php
 foreach ($items as $item):
-    $heading = $item->value($headingTerm, ['default' => $translate('[Untitled]')]);
+    $headingTermValue = $item->value($headingTerm, [
+        'default' => $translate('[Untitled]')
+    ]);
+    $heading = ($headingTermValue && ! is_string($headingTermValue) && in_array($headingTermValue->type(), [
+        'resource',
+        'resource:item',
+        'resource:itemset',
+        'resource:media'
+    ])) ? $headingTermValue->valueResource()->displayTitle() : $headingTermValue;
+
     $bodyTermValue = $item->value($bodyTerm);
-    if ($bodyTermValue && in_array($bodyTermValue->type(), ['resource', 'resource:item', 'resource:itemset', 'resource:media']))
-        $body = $bodyTermValue->valueResource()->displayTitle();
-    else
-        $body = $bodyTermValue
+    $body = ($bodyTermValue && in_array($bodyTermValue->type(), [
+        'resource',
+        'resource:item',
+        'resource:itemset',
+        'resource:media'
+    ])) ? $bodyTermValue->valueResource()->displayTitle() : $bodyTermValue;
 ?>
     <li class="item resource">
         <?php echo $item->linkRaw($this->thumbnail($item, 'medium')); ?>

--- a/application/view/omeka/site/item/browse.phtml
+++ b/application/view/omeka/site/item/browse.phtml
@@ -56,7 +56,11 @@ $sortHeadings = [
 <?php
 foreach ($items as $item):
     $heading = $item->value($headingTerm, ['default' => $translate('[Untitled]')]);
-    $body = $item->value($bodyTerm);
+    $bodyTermValue = $item->value($bodyTerm);
+    if ($bodyTermValue && in_array($bodyTermValue->type(), ['resource', 'resource:item', 'resource:itemset', 'resource:media']))
+        $body = $bodyTermValue->valueResource()->displayTitle();
+    else
+        $body = $bodyTermValue
 ?>
     <li class="item resource">
         <?php echo $item->linkRaw($this->thumbnail($item, 'medium')); ?>

--- a/application/view/omeka/site/item/browse.phtml
+++ b/application/view/omeka/site/item/browse.phtml
@@ -63,7 +63,8 @@ foreach ($items as $item):
         'resource:item',
         'resource:itemset',
         'resource:media'
-    ])) ? $headingTermValue->valueResource()->displayTitle() : $headingTermValue;
+    ])) ? $headingTermValue->valueResource()->displayTitle() . " (" . $item->value('dcterms:title') . ")" : $headingTermValue;
+
 
     $bodyTermValue = $item->value($bodyTerm);
     $body = ($bodyTermValue && in_array($bodyTermValue->type(), [

--- a/application/view/omeka/site/item/browse.phtml
+++ b/application/view/omeka/site/item/browse.phtml
@@ -63,7 +63,9 @@ foreach ($items as $item):
         'resource:item',
         'resource:itemset',
         'resource:media'
-    ])) ? $headingTermValue->valueResource()->displayTitle() . " (" . $item->value('dcterms:title') . ")" : $headingTermValue;
+    ])) ? $headingTermValue->valueResource()->displayTitle() . " (" . $item->value('dcterms:title', [
+        'default' => $translate('[Untitled]')
+    ]) . ")" : $headingTermValue;
 
 
     $bodyTermValue = $item->value($bodyTerm);


### PR DESCRIPTION
Hello,

I'm suggesting a slight modification of how Browse and BrowsePreview templates display linked resources' heading and body.

Currently if the selected _body_ property is of type 'resource', Omeka-S displays its (non clickable) URI which is not very intelligible.
Also, when displaying a _heading_ property of type 'resource', Omeka-S displays the URI property actually linking to a different URL, which is not very web-standard friendly.

These modifications test for the property type, and if it is a linked resource, item, item set or media, it tries to retrieve the 'dcterm:title', else defaults to [Untitled].

If accepted, I guess these modifications should also be rolled out to themes that modify these templates.
Thanks in advance and happy holidays.

Laurent Thomas