### PR TITLE
Add `.svg` support for themes in Admin

### DIFF
--- a/application/src/Api/Adapter/AssetAdapter.php
+++ b/application/src/Api/Adapter/AssetAdapter.php
@@ -9,7 +9,7 @@ use Omeka\Stdlib\ErrorStore;
 
 class AssetAdapter extends AbstractEntityAdapter
 {
-    const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif'];
+    const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/svg', 'image/svgz'];
 
     protected $sortFields = [
         'id' => 'id',

--- a/application/view/omeka/admin/asset/sidebar-select.phtml
+++ b/application/view/omeka/admin/asset/sidebar-select.phtml
@@ -8,7 +8,7 @@ $escape = $this->plugin('escapeHtml');
 <?php if ($this->userIsAllowed('Omeka\Api\Adapter\AssetAdapter', 'create')): ?>
 <h3 id="asset-upload-label"><?php echo $this->translate('Upload new asset'); ?></h3>
 <form class="asset-upload" method="post" enctype="multipart/form-data" action="<?php echo $escape($this->url('admin/default', ['controller' => 'asset', 'action' => 'add'])); ?>">
-    <input type="file" name="file" accept="image/jpeg,image/png,image/gif" required aria-labelledby="asset-upload-label">
+    <input type="file" name="file" accept="image/jpeg,image/png,image/gif,image/svg+xml,image/svgz+xml" required aria-labelledby="asset-upload-label">
     <button type="submit"><?php echo $this->translate('Upload'); ?></button>
     <ul class="errors"></ul>
 </form>


### PR DESCRIPTION
I'd like to add support for uploading `.svg` and `.svgz` files on the admin side for themes (for logos and such). This pull request allows those files to be uploaded and updates the validator to allow them to work.