### PR TITLE
Check for resource values with default type set. (Fix #1369)

### DIFF
--- a/application/view/common/resource-values.phtml
+++ b/application/view/common/resource-values.phtml
@@ -19,11 +19,12 @@ $labelInfo = $this->setting('property_label_information');
         <div class="values">
         <?php foreach ($propertyData['values'] as $value): ?>
             <?php
+            $valueType = $value->type();
             $class = ['value'];
-            if ('resource' == $value->type()) {
+            if ('resource' == $valueType || strpos($valueType, 'resource') !== false) {
                 $class[] = 'resource';
                 $class[] = $escape($value->valueResource()->resourceName());
-            } elseif ('uri' == $value->type()) {
+            } elseif ('uri' == $valueType) {
                 $class[] = 'uri';
             }
             if (!$value->isPublic()) {


### PR DESCRIPTION
When displaying a resource value, this checks to see if the value type contains the string 'resource' to catch values that have a default type set to resources. (These values output "resource:[resource name]".)