### PR TITLE
Add language to vocabulary import

### DIFF
--- a/application/src/Controller/Admin/VocabularyController.php
+++ b/application/src/Controller/Admin/VocabularyController.php
@@ -77,7 +77,10 @@ class VocabularyController extends AbstractActionController
                 $data = $form->getData();
                 try {
                     $strategy = null;
-                    $options = ['format' => $data['format']];
+                    $options = [
+                        'format' => $data['format'],
+                        'lang' => $data['lang'],
+                    ];
                     if (\UPLOAD_ERR_OK === $data['file']['error']) {
                         $strategy = 'file';
                         $options['file'] = $data['file']['tmp_name'];

--- a/application/src/Form/VocabularyImportForm.php
+++ b/application/src/Form/VocabularyImportForm.php
@@ -50,6 +50,17 @@ class VocabularyImportForm extends Form
             ],
         ]);
         $this->add([
+            'name' => 'lang',
+            'type' => 'text',
+            'options' => [
+                'label' => 'Language', // @translate
+                'info' => 'Enter the preferred language of the labels and comments using an IETF language tag. Defaults to the first available.', // @translate
+            ],
+            'attributes' => [
+                'id' => 'lang',
+            ],
+        ]);
+        $this->add([
             'name' => 'o:prefix',
             'type' => 'text',
             'options' => [


### PR DESCRIPTION
Currently, RdfImporter gets the first available label/comment during vocabulary import, regardless of language. Some vocabularies have multilingual labels/comments (e.g. [CIDOC-CRM](http://www.cidoc-crm.org/sites/default/files/cidoc_crm_core-2014Feb%20%283%29.rdf)), so an imported vocabulary could have labels/comments of multiple languages. This PR fixes this by adding a "Language" input on the import vocabulary form.