### PR TITLE
Add default visibility and apply it to new content

### DIFF
--- a/application/src/Form/SettingForm.php
+++ b/application/src/Form/SettingForm.php
@@ -243,7 +243,7 @@ class SettingForm extends Form
             'type' => 'Checkbox',
             'options' => [
               'label' => 'Default content visibility to Private', // @translate
-              'info' => 'If checked, all items and item sets created will have their visibility set to private by default.' // @translate
+              'info' => 'If checked, all items, item sets and sites newly created will have their visibility set to private by default.', // @translate
             ],
             'attributes' => [
                 'value' => $this->settings->get('default_to_private'),

--- a/application/src/Form/SettingForm.php
+++ b/application/src/Form/SettingForm.php
@@ -238,6 +238,19 @@ class SettingForm extends Form
             ],
         ]);
 
+        $generalFieldset->add([
+            'name' => 'default_to_private',
+            'type' => 'Checkbox',
+            'options' => [
+              'label' => 'Default content visibility to Private', // @translate
+              'info' => 'If checked, all items and item sets created will have their visibility set to private by default.' // @translate
+            ],
+            'attributes' => [
+                'value' => $this->settings->get('default_to_private'),
+                'id' => 'default_to_private',
+            ],
+        ]);
+
         // Security fieldset
 
         $this->add([

--- a/application/view/omeka/admin/item-set/form.phtml
+++ b/application/view/omeka/admin/item-set/form.phtml
@@ -34,7 +34,7 @@ $formElement = $this->plugin('formElement');
     <input type="hidden" name="o:is_open" value="0">
     <?php endif; ?>
 
-    <?php if ($itemSet && $itemSet->isPublic() || !isset($itemSet) ): ?>
+    <?php if ($itemSet && $itemSet->isPublic() || (!isset($itemSet) && !$this->setting('default_to_private')) ): ?>
     <?php echo $this->hyperlink('', '#', [
         'class' => 'o-icon-public button',
         'title' => $this->translate('Make private'),

--- a/application/view/omeka/admin/item/form.phtml
+++ b/application/view/omeka/admin/item/form.phtml
@@ -36,7 +36,7 @@ $formElement = $this->plugin('formElement');
 </fieldset>
 
 <div id="page-actions">
-    <?php if ($item && $item->isPublic() || !isset($item)): ?>
+    <?php if ($item && $item->isPublic() || (!isset($item)) && !$this->setting('default_to_private')) : ?>
     <?php echo $this->hyperlink('', '#', [
         'class' => 'o-icon-public button',
         'title' => $this->translate('Make private'),

--- a/application/view/omeka/site-admin/index/add.phtml
+++ b/application/view/omeka/site-admin/index/add.phtml
@@ -14,11 +14,19 @@ $fallbackThumbnailUrl = $this->assetUrl('img/theme.jpg', 'Omeka');
 <?php echo $this->form()->openTag($form); ?>
 
 <div id="page-actions">
+    <?php if ($this->setting('default_to_private')) : ?>
     <?php echo $this->hyperlink('', '#', [
         'class' => 'o-icon-private button',
         'title' => $this->translate('Make public'),
     ]); ?>
     <input type="hidden" name="o:is_public" value="0">
+    <?php else: ?>
+    <?php echo $this->hyperlink('', '#', [
+        'class' => 'o-icon-public button',
+        'title' => $this->translate('Make private'),
+    ]); ?>
+    <input type="hidden" name="o:is_public" value="1">
+    <?php endif; ?>
     <?php echo $this->cancelButton(); ?>
     <button><?php echo $this->translate('Add'); ?></button>
 </div>


### PR DESCRIPTION
Hello,

First, there are currently two different behaviors throughout Omeka S when it comes to default visibility:
* the visibility setting is by default set to 'Public' on new items and new item sets forms
* the site creation form has the visibility setting set to 'Private' by default

Secondly, in use cases where users wish to keep all content private (e.g. to prevent anonymous API access), they need to toggle the visibility setting each time instead of having a global option to do this. The nature of the form input (an icon a bit displaced above the form) also helps forgetting to apply the setting once in a while (more often than not, actually).

This PR addresses the two behaviors by adding a global setting to have a default visibility option that consistently applies to content and sites. Please note that the visibility can still be changed in each form, this is only about what default value is selected.

Please do not hesitate to ask if this requires any adjustments.

Have a nice day

Laurent


