### PR TITLE
Adding a NoThumbnail thumbnailer

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -251,6 +251,7 @@ return [
             'Omeka\File\Thumbnailer\ImageMagick' => Service\File\Thumbnailer\ImageMagickFactory::class,
             'Omeka\File\Thumbnailer\Gd' => Service\File\Thumbnailer\GdFactory::class,
             'Omeka\File\Thumbnailer\Imagick' => Service\File\Thumbnailer\ImagickFactory::class,
+            'Omeka\File\Thumbnailer\NoThumbnail' => Service\File\Thumbnailer\NoThumbnailFactory::class,
             'Omeka\File\Store\Local' => Service\File\Store\LocalFactory::class,
             'Omeka\File\MediaTypeMap' => Service\MediaTypeMapFactory::class,
             'Omeka\File\ThumbnailManager' => Service\File\ThumbnailManagerFactory::class,

--- a/application/src/File/Thumbnailer/NoThumbnail.php
+++ b/application/src/File/Thumbnailer/NoThumbnail.php
@@ -1,0 +1,12 @@
+<?php
+namespace Omeka\File\Thumbnailer;
+
+use Omeka\File\Exception;
+
+class NoThumbnail extends AbstractThumbnailer
+{
+    public function create($strategy, $constraint, array $options = [])
+    {
+        throw new Exception\CannotCreateThumbnailException;
+    }
+}

--- a/application/src/Service/File/Thumbnailer/NoThumbnailFactory.php
+++ b/application/src/Service/File/Thumbnailer/NoThumbnailFactory.php
@@ -1,0 +1,19 @@
+<?php
+namespace Omeka\Service\File\Thumbnailer;
+
+use Interop\Container\ContainerInterface;
+use Omeka\File\Thumbnailer\NoThumbnail;
+use Zend\ServiceManager\Factory\FactoryInterface;
+
+class NothumbnailFactory implements FactoryInterface
+{
+    /**
+     * Create the NoThumbnail thumbnailer service.
+     *
+     * @return NoThumbnail
+     */
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        return new NoThumbnail();
+    }
+}


### PR DESCRIPTION
When moving from omeka-classic to omeka-s and using [Omeka2Importer](https://github.com/omeka-s-modules/Omeka2Importer) module, the process of building all derivatives while getting the metadata is taking a lot of time so I have added a fake thumbnailer that will just return an Exception without building any derivative. 

The idea is to use the [DerivativeImages](https://github.com/Daniel-KM/Omeka-S-module-DerivativeImages) module to create these thumbnails afterwards, when everything is ok with the database and that we are sure that we won't have to rerun an import.