### PR TITLE
Quick fixes for translations

### DIFF
--- a/application/src/Form/SiteSettingsForm.php
+++ b/application/src/Form/SiteSettingsForm.php
@@ -204,7 +204,7 @@ class SiteSettingsForm extends Form
             'type' => 'checkbox',
             'name' => 'search_restrict_templates',
             'options' => [
-                'label' => 'Restrict to templates',
+                'label' => 'Restrict to templates', // @translate
                 'info' => 'Restrict search results to resources of the selected templates.', // @translate
             ],
             'attributes' => [

--- a/application/src/View/Helper/SearchFilters.php
+++ b/application/src/View/Helper/SearchFilters.php
@@ -53,7 +53,7 @@ class SearchFilters extends AbstractHelper
                             }
                             $filterLabel = $translate('Class');
                             try {
-                                $filterValue = $api->read('resource_classes', $subValue)->getContent()->label();
+                                $filterValue = $translate($api->read('resource_classes', $subValue)->getContent()->label());
                             } catch (NotFoundException $e) {
                                 $filterValue = $translate('Unknown class');
                             }

--- a/application/view/omeka/login/login.phtml
+++ b/application/view/omeka/login/login.phtml
@@ -2,7 +2,6 @@
 $translate = $this->plugin('translate');
 $this->htmlElement('body')->appendAttribute('class', 'login');
 ?>
-<h1><?php echo $translate('Login'); ?></h1>
+<h1><?php echo $translate('Log in'); ?></h1>
 <?php echo $this->form($form); ?>
 <p class="forgot-password"><?php echo $this->hyperlink($translate('Forgot password?'), $this->url('forgot-password')); ?></p>
-


### PR DESCRIPTION
Hello,

A quick PR for fixing 2 missing translation tags:
- in site settings page, the "Restrict to templates" label was not marked for translation
- in search filters view helper, the resource class label was not translated

Thank you in advance and have a nice day

Laurent 