### PR TITLE
Fix incorrect relationship in Resource Template entity.

### DIFF
--- a/application/src/Entity/ResourceTemplate.php
+++ b/application/src/Entity/ResourceTemplate.php
@@ -47,7 +47,7 @@ class ResourceTemplate extends AbstractEntity
     /**
      * @OneToMany(
      *     targetEntity="Resource",
-     *     mappedBy="resourceClass",
+     *     mappedBy="resourceTemplate",
      *     fetch="EXTRA_LAZY"
      * )
      */


### PR DESCRIPTION
When joining to resources from a resource template, the entity was attempting to use the `resource_class_id` field instead of the `resource_template_id` field. I believe this change should fix this issue.

The bug presented itself when browsing resource templates in the admin interface. If you sorted the list by "Items", the list itself would stay sorted by Label. This is because the join to get the count of item resources would produce zero for each resource template as the resource template ID was trying to match the resource class ID field.