### PR TITLE
Update admin browse pages to always have item counts in the sidebar.

### DIFF
--- a/application/view/omeka/admin/property/show-details.phtml
+++ b/application/view/omeka/admin/property/show-details.phtml
@@ -14,4 +14,8 @@ $translate = $this->plugin('translate');
     <h4><?php echo $translate('Comment'); ?></h4>
     <div class="value"><?php echo $this->escapeHtml($translate($property->comment())); ?></div>
 </div>
+<div class="meta-group">
+    <h4><?php echo $translate('Items'); ?></h4>
+    <div class="value"><?php echo $this->hyperlink($property->itemCount(), $this->url('admin/default', ['controller' => 'item', 'action' => 'browse'], ['query' => ['property[0][property]' => $property->id(), 'property[0][type]' => 'ex',]])); ?></div>
+</div>
 <?php $this->trigger('view.details', array('entity' => $property)); ?>

--- a/application/view/omeka/admin/resource-class/show-details.phtml
+++ b/application/view/omeka/admin/resource-class/show-details.phtml
@@ -14,4 +14,8 @@ $translate = $this->plugin('translate');
     <h4><?php echo $translate('Comment'); ?></h4>
     <div class="value"><?php echo $this->escapeHtml($translate($resourceClass->comment())); ?></div>
 </div>
+<div class="meta-group">
+    <h4><?php echo $translate('Items'); ?></h4>
+    <div class="value"><?php echo $this->hyperlink($resourceClass->itemCount(), $this->url('admin/default', ['controller' => 'item', 'action' => 'browse'], ['query' => ['resource_class_id' => $resourceClass->id()]])); ?></div>
+</div>
 <?php $this->trigger('view.details', array('entity' => $resourceClass)); ?>

--- a/application/view/omeka/admin/resource-template/browse.phtml
+++ b/application/view/omeka/admin/resource-template/browse.phtml
@@ -43,7 +43,6 @@ $sortHeadings = [
             <th><?php echo $translate('Label'); ?></th>
             <th><?php echo $translate('Class'); ?></th>
             <th><?php echo $translate('Owner'); ?></th>
-            <th><?php echo $translate('Items'); ?></th>
         </tr>
     </thead>
     <tbody>
@@ -88,7 +87,6 @@ $sortHeadings = [
             </td>
             <td><?php echo $escape($translate($resourceTemplate->displayResourceClassLabel())); ?></td>
             <td><?php echo $ownerText; ?></td>
-            <td><?php echo $this->hyperlink($resourceTemplate->itemCount(), $this->url('admin/default', ['controller' => 'item', 'action' => 'browse'], ['query' => ['resource_template_id' => $resourceTemplate->id()]])); ?></td>
         </tr>
         <?php endforeach; ?>
     </tbody>

--- a/application/view/omeka/admin/resource-template/show-details.phtml
+++ b/application/view/omeka/admin/resource-template/show-details.phtml
@@ -14,4 +14,8 @@ $propertyAltComment = $escape($resourceTemplateProperty->alternateComment());
     <div class="comment"><?php echo ($propertyAltComment) ? $propertyAltComment : $escape($translate($property->comment())); ?></div>
 </div>
 <?php endforeach; ?>
+<div class="meta-group">
+    <h4><?php echo $translate('Items'); ?></h4>
+    <div class="value"><?php echo $this->hyperlink($resource->itemCount(), $this->url('admin/default', ['controller' => 'item', 'action' => 'browse'], ['query' => ['resource_template_id' => $resource->id()]])); ?></div>
+</div>
 <?php $this->trigger('view.details', array('entity' => $resource)); ?>

--- a/application/view/omeka/admin/vocabulary/classes.phtml
+++ b/application/view/omeka/admin/vocabulary/classes.phtml
@@ -36,7 +36,6 @@ $sortHeadings = [
         <tr>
             <th><?php echo $translate('Label'); ?></th>
             <th><?php echo $translate('Term'); ?></th>
-            <th><?php echo $translate('Items'); ?></th>
         </tr>
     </thead>
     <tbody>
@@ -55,7 +54,6 @@ $sortHeadings = [
                 </ul>
             </td>
             <td><?php echo $escape($translate($resourceClass->term())); ?></td>
-            <td><?php echo $this->hyperlink($resourceClass->itemCount(), $this->url('admin/default', ['controller' => 'item', 'action' => 'browse'], ['query' => ['resource_class_id' => $resourceClass->id()]])); ?></td>
         </tr>
         <?php endforeach; ?>
     </tbody>

--- a/application/view/omeka/admin/vocabulary/properties.phtml
+++ b/application/view/omeka/admin/vocabulary/properties.phtml
@@ -19,7 +19,6 @@ $this->htmlElement('body')->appendAttribute('class', 'browse vocabularies vocabu
         <tr>
             <th><?php echo $this->sortLink($translate('Label'), 'label'); ?></th>
             <th><?php echo $this->sortLink($translate('Term'), 'local_name'); ?></th>
-            <th><?php echo $this->sortLink($translate('Items'), 'item_count'); ?></th>
         </tr>
     </thead>
     <tbody>
@@ -38,7 +37,6 @@ $this->htmlElement('body')->appendAttribute('class', 'browse vocabularies vocabu
                 </ul>
             </td>
             <td><?php echo $escape($translate($property->term())); ?></td>
-            <td><?php echo $this->hyperlink($property->itemCount(), $this->url('admin/default', ['controller' => 'item', 'action' => 'browse'], ['query' => ['property[0][property]' => $property->id(), 'property[0][type]' => 'ex',]])); ?></td>
         </tr>
         <?php endforeach; ?>
     </tbody>


### PR DESCRIPTION
We are currently working on an Omeka-S installation that has hundreds of thousands of items. In doing so, we've found that browsing properties on a vocabulary would time out, due to retrieving a count of items with each property.

To mitigate that issue, this pull request changes browse pages for properties, resource classes and resource templates in the admin interface. The pages will display item count/link to items in the sidebar instead of the rows of the results. This is similar to what already happens while browsing item sets.

The downside is that you would no longer be able to tell at-a-glance which properties, classes or templates are being used and in what amount.


