### PR TITLE
Use faster counts for items and item sets on representations.

### DIFF
--- a/application/src/Api/Representation/ItemSetRepresentation.php
+++ b/application/src/Api/Representation/ItemSetRepresentation.php
@@ -39,9 +39,8 @@ class ItemSetRepresentation extends AbstractResourceEntityRepresentation
     {
         $response = $this->getServiceLocator()->get('Omeka\ApiManager')
             ->search('items', [
-                'item_set_id' => $this->id(),
-                'limit' => 0,
-            ]);
+                'item_set_id' => $this->id()
+            ], ['returnScalar' => 'id']);
         return $response->getTotalResults();
     }
 

--- a/application/src/Api/Representation/ItemSetRepresentation.php
+++ b/application/src/Api/Representation/ItemSetRepresentation.php
@@ -39,7 +39,7 @@ class ItemSetRepresentation extends AbstractResourceEntityRepresentation
     {
         $response = $this->getServiceLocator()->get('Omeka\ApiManager')
             ->search('items', [
-                'item_set_id' => $this->id()
+                'item_set_id' => $this->id(),
             ], ['returnScalar' => 'id']);
         return $response->getTotalResults();
     }

--- a/application/src/Api/Representation/PropertyRepresentation.php
+++ b/application/src/Api/Representation/PropertyRepresentation.php
@@ -28,8 +28,7 @@ class PropertyRepresentation extends AbstractVocabularyMemberRepresentation
                         'type' => 'ex',
                     ],
                 ],
-                'limit' => 0,
-            ]);
+            ], ['returnScalar' => 'id']);
         return $response->getTotalResults();
     }
 }

--- a/application/src/Api/Representation/ResourceClassRepresentation.php
+++ b/application/src/Api/Representation/ResourceClassRepresentation.php
@@ -23,8 +23,7 @@ class ResourceClassRepresentation extends AbstractVocabularyMemberRepresentation
         $response = $this->getServiceLocator()->get('Omeka\ApiManager')
             ->search('items', [
                 'resource_class_id' => $this->id(),
-                'limit' => 0,
-            ]);
+            ], ['returnScalar' => 'id']);
         return $response->getTotalResults();
     }
 }

--- a/application/src/Api/Representation/ResourceTemplateRepresentation.php
+++ b/application/src/Api/Representation/ResourceTemplateRepresentation.php
@@ -115,8 +115,7 @@ class ResourceTemplateRepresentation extends AbstractEntityRepresentation
         $response = $this->getServiceLocator()->get('Omeka\ApiManager')
             ->search('items', [
                 'resource_template_id' => $this->id(),
-                'limit' => 0,
-            ]);
+            ], ['returnScalar' => 'id']);
         return $response->getTotalResults();
     }
 }

--- a/application/src/Api/Representation/UserRepresentation.php
+++ b/application/src/Api/Representation/UserRepresentation.php
@@ -75,8 +75,7 @@ class UserRepresentation extends AbstractEntityRepresentation
         $response = $this->getServiceLocator()->get('Omeka\ApiManager')
             ->search('items', [
                 'owner_id' => $this->id(),
-                'limit' => 0,
-            ]);
+            ], ['returnScalar' => 'id']);
         return $response->getTotalResults();
     }
 
@@ -90,8 +89,7 @@ class UserRepresentation extends AbstractEntityRepresentation
         $response = $this->getServiceLocator()->get('Omeka\ApiManager')
             ->search('item_sets', [
                 'owner_id' => $this->id(),
-                'limit' => 0,
-            ]);
+            ], ['returnScalar' => 'id']);
         return $response->getTotalResults();
     }
 }


### PR DESCRIPTION
Related to #1404, we're working on improving admin interface responsiveness when having hundreds of thousands of items. It appears that one of the things causing item counts to be retrieved slowly is the amount of data retrieved and steps taken with that data after it is retrieved and before it is counted.

One of the easier changes found to remedy this was to specify that counts should be taken from a single field via the returnScalar option, which also prevents the finalize tasks from being performed. This pull request changes Item Sets, Properties, Resource Classes, Resource Templates and Users to retrieve item counts with that option. Users are also changed to retrieve item set counts the same way.

With this change, item counts remained the same but were performed noticeably faster. These methods appear to only be used for retrieving counts in the admin interface. I'm not certain if finalize would ever impact the counts.