### PR TITLE
Fixed GD thumbnailing of an image with an icc profile.

### DIFF
--- a/application/src/File/Thumbnailer/Gd.php
+++ b/application/src/File/Thumbnailer/Gd.php
@@ -28,6 +28,11 @@ class Gd extends AbstractThumbnailer
     protected $origHeight;
 
     /**
+     * @var string The profile icc of the original image.
+     */
+    protected $icc;
+
+    /**
      * Check whether the GD entension is loaded.
      *
      * @throws Exception\InvalidThumbnailer
@@ -56,6 +61,8 @@ class Gd extends AbstractThumbnailer
                 break;
             case 'image/jpeg':
                 $origImage = imagecreatefromjpeg($sourcePath);
+                $inputPel = new \lsolesen\pel\PelJpeg($sourcePath);
+                $this->icc = $inputPel->getIcc();
                 break;
             case 'image/png':
                 $origImage = imagecreatefrompng($sourcePath);
@@ -71,6 +78,7 @@ class Gd extends AbstractThumbnailer
         if (false === $origImage) {
             throw new Exception\CannotCreateThumbnailException;
         }
+
         $this->origImage = $origImage;
         $this->origWidth = imagesx($origImage);
         $this->origHeight = imagesy($origImage);
@@ -97,7 +105,15 @@ class Gd extends AbstractThumbnailer
         }
 
         imagedestroy($tempImage);
-        return $tempFile->getTempPath();
+
+        $tempPath = $tempFile->getTempPath();
+        if ($this->icc) {
+            $outputPel = new \lsolesen\pel\PelJpeg($tempPath);
+            $outputPel->setIcc($this->icc);
+            $outputPel->saveFile($tempPath);
+        }
+
+        return $tempPath;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
         "zendframework/zendxml": "^1.0.2",
         "omeka/composer-addon-installer": "*",
         "omeka-s-themes/default": "dev-develop",
-        "beberlei/doctrineextensions": "^1.0"
+        "beberlei/doctrineextensions": "^1.0",
+        "lsolesen/pel": "^0.9.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7.23 || ^6.4.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,10 +4,10 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "572ffd8d77c7f5c84a7a204156574de5",
+    "content-hash": "a021dd146b38430a7780faa222bd6393",
     "packages": [
         {
-            "name": "beberlei/DoctrineExtensions",
+            "name": "beberlei/doctrineextensions",
             "version": "v1.2.1",
             "source": {
                 "type": "git",
@@ -1124,6 +1124,61 @@
                 "html"
             ],
             "time": "2018-02-23T01:58:20+00:00"
+        },
+        {
+            "name": "lsolesen/pel",
+            "version": "0.9.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lsolesen/pel.git",
+                "reference": "c9e3919f5db3b85c3c422d4f8d448dbcb2a87a23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lsolesen/pel/zipball/c9e3919f5db3b85c3c422d4f8d448dbcb2a87a23",
+                "reference": "c9e3919f5db3b85c3c422d4f8d448dbcb2a87a23",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.0.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "phpunit/phpunit": "5.7.*",
+                "satooshi/php-coveralls": "1.0.*",
+                "squizlabs/php_codesniffer": "3.0.0RC3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "lsolesen\\pel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Lars Olesen",
+                    "email": "lars@intraface.dk",
+                    "homepage": "http://intraface.dk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Martin Geisler",
+                    "email": "martin@geisler.net",
+                    "homepage": "http://geisler.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Exif Library. A library for reading and writing Exif headers in JPEG and TIFF images using PHP.",
+            "homepage": "http://lsolesen.github.com/pel/",
+            "keywords": [
+                "exif",
+                "image"
+            ],
+            "time": "2017-02-03T11:58:58+00:00"
         },
         {
             "name": "ml/iri",


### PR DESCRIPTION
When an image has an icc profile and gd is used, colors are no kept. This pr fixes it. 
The issue may be the same for imagick, but it depends on the version. A fix for it can be done too, like in https://github.com/Daniel-KM/LibraryDeepzoom/pull/1.
