### PR TITLE
Added an option to list only used properties and resource classes in advanced search form.

### DIFF
--- a/application/src/Api/Adapter/ResourceClassAdapter.php
+++ b/application/src/Api/Adapter/ResourceClassAdapter.php
@@ -62,13 +62,14 @@ class ResourceClassAdapter extends AbstractEntityAdapter
 
     public function buildQuery(QueryBuilder $qb, array $query)
     {
+        $expr = $qb->expr();
         if (isset($query['owner_id']) && is_numeric($query['owner_id'])) {
             $userAlias = $this->createAlias();
             $qb->innerJoin(
                 'omeka_root.owner',
                 $userAlias
             );
-            $qb->andWhere($qb->expr()->eq(
+            $qb->andWhere($expr->eq(
                 "$userAlias.id",
                 $this->createNamedParameter($qb, $query['owner_id']))
             );
@@ -79,7 +80,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
                 'omeka_root.vocabulary',
                 $vocabularyAlias
             );
-            $qb->andWhere($qb->expr()->eq(
+            $qb->andWhere($expr->eq(
                 "$vocabularyAlias.id",
                 $this->createNamedParameter($qb, $query['vocabulary_id']))
             );
@@ -90,7 +91,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
                 'omeka_root.vocabulary',
                 $vocabularyAlias
             );
-            $qb->andWhere($qb->expr()->eq(
+            $qb->andWhere($expr->eq(
                 "$vocabularyAlias.namespaceUri",
                 $this->createNamedParameter($qb, $query['vocabulary_namespace_uri']))
             );
@@ -101,14 +102,14 @@ class ResourceClassAdapter extends AbstractEntityAdapter
                 'omeka_root.vocabulary',
                 $vocabularyAlias
             );
-            $qb->andWhere($qb->expr()->eq(
+            $qb->andWhere($expr->eq(
                 "$vocabularyAlias.prefix",
                 $this->createNamedParameter($qb, $query['vocabulary_prefix']))
             );
         }
         if (isset($query['local_name'])) {
-            $qb->andWhere($qb->expr()->eq(
-                "omeka_root.localName",
+            $qb->andWhere($expr->eq(
+                'omeka_root.localName',
                 $this->createNamedParameter($qb, $query['local_name']))
             );
         }
@@ -119,12 +120,12 @@ class ResourceClassAdapter extends AbstractEntityAdapter
                 'omeka_root.vocabulary',
                 $vocabularyAlias
             );
-            $qb->andWhere($qb->expr()->eq(
+            $qb->andWhere($expr->eq(
                 "$vocabularyAlias.prefix",
                 $this->createNamedParameter($qb, $prefix))
             );
-            $qb->andWhere($qb->expr()->eq(
-                "omeka_root.localName",
+            $qb->andWhere($expr->eq(
+                'omeka_root.localName',
                 $this->createNamedParameter($qb, $localName))
             );
         }

--- a/application/src/Form/Element/AbstractVocabularyMemberSelect.php
+++ b/application/src/Form/Element/AbstractVocabularyMemberSelect.php
@@ -57,6 +57,10 @@ abstract class AbstractVocabularyMemberSelect extends Select implements EventMan
         if (!isset($query['sort_by'])) {
             $query['sort_by'] = 'label';
         }
+        if ($this->getOption('used_terms')) {
+            $query['used'] = true;
+        }
+
         // Allow handlers to filter the query.
         $args = $events->prepareArgs(['query' => $query]);
         $events->trigger('form.vocab_member_select.query', $this, $args);

--- a/application/src/Form/SiteSettingsForm.php
+++ b/application/src/Form/SiteSettingsForm.php
@@ -297,6 +297,17 @@ class SiteSettingsForm extends Form
             ],
         ]);
         $searchFieldset->add([
+            'type' => \Laminas\Form\Element\Checkbox::class,
+            'name' => 'search_used_terms',
+            'options' => [
+                'label' => 'List only used properties and resources classes', // @translate
+                'info' => 'Restrict the list of properties and resources classes to the used ones in advanced search form (for properties, when option "templates" is not used).', // @translate
+            ],
+            'attributes' => [
+                'value' => $settings->get('search_used_terms', false),
+            ],
+        ]);
+        $searchFieldset->add([
             'type' => 'Omeka\Form\Element\ResourceTemplateSelect',
             'name' => 'search_apply_templates',
             'options' => [

--- a/application/view/common/advanced-search/properties.phtml
+++ b/application/view/common/advanced-search/properties.phtml
@@ -1,5 +1,14 @@
 <?php
 $translate = $this->plugin('translate');
+$escape = $this->plugin('escapeHtml');
+$hyperlink = $this->plugin('hyperlink');
+$propertySelect = $this->plugin('propertySelect');
+$siteSetting = $this->plugin('siteSetting');
+
+$isSiteRequest = $this->status()->isSiteRequest();
+$applyTemplates = $isSiteRequest ? $siteSetting('search_apply_templates') : false;
+$usedTerms = $isSiteRequest ? $siteSetting('search_used_terms') : false;
+
 // Prepare the property queries.
 $properties = isset($query['property']) ? $query['property'] : [];
 $properties = array_filter($properties, function ($value) {
@@ -14,7 +23,7 @@ if (isset($query['search'])) {
     array_unshift($properties, [
         'property' => '',
         'type' => 'in',
-        'text' => $query['search']
+        'text' => $query['search'],
     ]);
 }
 
@@ -25,13 +34,13 @@ $queryOption = function($value, array $search, $key, $text) {
     }
     return sprintf('<option value="%s"%s>%s</option>', $value, $selected, $text);
 };
-$queryText = function(array $search, $index) {
+$queryText = function(array $search, $index) use ($escape, $translate) {
     $text = isset($search['text']) ? $search['text'] : null;
     return sprintf('<input type="text" class="query-text" name="%s" value="%s" aria-label="%s">',
-        $this->escapeHtml("property[$index][text]"),
-        $this->escapeHtml($text),
-        $this->escapeHtml($this->translate('Query text')));
-}
+        $escape("property[$index][text]"),
+        $escape($text),
+        $escape($translate('Query text')));
+};
 ?>
 
 <div id="property-queries" class="field removable multi-value" role="group" aria-labelledby="by-value-label">
@@ -43,14 +52,14 @@ $queryText = function(array $search, $index) {
         <?php
         $index = 0;
         foreach ($properties as $property):
-        $stem = "property[$index]";
+            $stem = "property[$index]";
         ?>
         <div class="value">
-            <select class="joiner" name="<?php echo $this->escapeHtml($stem . '[joiner]'); ?>">
+            <select class="joiner" name="<?php echo $escape($stem . '[joiner]'); ?>">
                 <?php echo $queryOption('and', $property, 'joiner', $translate('AND')); ?>
                 <?php echo $queryOption('or', $property, 'joiner', $translate('OR')); ?>
             </select>
-            <?php echo $this->propertySelect([
+            <?php echo $propertySelect([
                 'name' => $stem . '[property]',
                 'attributes' => [
                     'class' => 'query-property',
@@ -59,10 +68,11 @@ $queryText = function(array $search, $index) {
                 ],
                 'options' => [
                     'empty_option' => '[Any Property]', // @translate
-                    'apply_templates' => $this->status()->isSiteRequest() ? $this->siteSetting('search_apply_templates') : false,
-                ]
+                    'apply_templates' => $applyTemplates,
+                    'used_terms' => $usedTerms,
+                ],
             ]); ?>
-            <select class="query-type" name="<?php echo $this->escapeHtml($stem . '[type]'); ?>" aria-label="<?php echo $translate('Query type'); ?>">
+            <select class="query-type" name="<?php echo $escape($stem . '[type]'); ?>" aria-label="<?php echo $translate('Query type'); ?>">
                 <?php echo $queryOption('eq', $property, 'type', $translate('is exactly')); ?>
                 <?php echo $queryOption('neq', $property, 'type', $translate('is not exactly')); ?>
                 <?php echo $queryOption('in', $property, 'type', $translate('contains')); ?>
@@ -76,7 +86,7 @@ $queryText = function(array $search, $index) {
             <button type="button" class="o-icon-delete remove-value button" aria-label="<?php echo $translate('Remove value'); ?>" title="<?php echo $translate('Remove value'); ?>"></button>
         </div>
         <?php
-        $index++;
+            ++$index;
         endforeach;
         ?>
     </div>

--- a/application/view/common/advanced-search/resource-class.phtml
+++ b/application/view/common/advanced-search/resource-class.phtml
@@ -1,5 +1,11 @@
 <?php
 $translate = $this->plugin('translate');
+$resourceClassSelect = $this->plugin('resourceClassSelect');
+$siteSetting = $this->plugin('siteSetting');
+
+$isSiteRequest = $this->status()->isSiteRequest();
+$usedTerms = $isSiteRequest ? $siteSetting('search_used_terms') : false;
+
 // Prepare the resource class query.
 $ids = isset($query['resource_class_id']) ? $query['resource_class_id'] : [];
 if (!is_array($ids)) {
@@ -22,11 +28,14 @@ if (!$ids) {
     <div class="inputs">
         <?php foreach ($ids as $id): ?>
         <div class="value">
-            <?php echo $this->resourceClassSelect([
+            <?php echo $resourceClassSelect([
                 'name' => 'resource_class_id[]',
                 'attributes' => [
                     'value' => $id,
-                    'aria-labelledby' =>  'by-resource-class-label'
+                    'aria-labelledby' => 'by-resource-class-label',
+                ],
+                'options' => [
+                    'used_terms' => $usedTerms,
                 ],
             ]); ?>
             <button type="button" class="o-icon-delete remove-value button" aria-label="<?php echo $translate('Remove value'); ?>" title="<?php echo $translate('Remove value'); ?>"></button>


### PR DESCRIPTION
A new option is added in site settings : the possibility to display only the used properties and resources classes for the public advanced search form.
Available in module [Next](https://github.com/Daniel-KM/Omeka-S-module-Next) too (version 3.1.2.8) via the trigger `form.vocab_member_select.query` (may avoid to add a key in buildQuery()).