### PR TITLE
Added a trigger to finish preparation of values of a resource.

### DIFF
--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -276,7 +276,7 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
             $values[$term]['values'][] = $value;
         }
 
-        // Order this resource's values according to the template order.
+        // Order this resource's properties according to the template order.
         $sortedValues = [];
         foreach ($values as $term => $valueInfo) {
             foreach ($templateInfo as $templateTerm => $templateAlternates) {
@@ -287,7 +287,13 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
             }
         }
 
-        $this->values = $sortedValues + $values;
+        $values = $sortedValues + $values;
+
+        $eventManager = $this->getEventManager();
+        $args = $eventManager->prepareArgs(['values' => $values]);
+        $eventManager->trigger('rep.resource.values', $this, $args);
+
+        $this->values = $args['values'];
         return $this->values;
     }
 


### PR DESCRIPTION
Hi,

There is no possibility currently to reorder the values of a property of a resource. The only possibility is to manage the display of the values, that is useful, but doesn't allow to manage many things. The other possibility is to reorder them at entity levels, but it's complex for the values. So a simple trigger placed in the method values() is userful.

In fact, the module [Internationalisation](https://github.com/Daniel-KM/Omeka-S-module-Internationalisation) needs them : to display the metadata of a resource in a selected language (with managed fallbacks, the simple way is to reorder/filter them. When reordered, the other methods like displayTitle, etc. can be used directly, without change (so it avoids to fix themes). 

The module Internationalisation is working, but not yet finished for an easier management of sites/pages by group of translations.

Sincerely,