### PR TITLE
Sorting the second-level

### DIFF
--- a/application/src/Form/Element/AbstractGroupByOwnerSelect.php
+++ b/application/src/Form/Element/AbstractGroupByOwnerSelect.php
@@ -85,6 +85,7 @@ abstract class AbstractGroupByOwnerSelect extends Select
                         continue;
                     }
                 }
+                asort($options);
                 $owner = $resourceOwner['owner'];
                 if ($owner instanceof UserRepresentation) {
                     $label = sprintf('%s (%s)', $owner->name(), $owner->email());


### PR DESCRIPTION
Currently the owners are sorted, but the second level of values appear to be randomized. This PR just adds a ```asort``` before returning the values for the select.