### PR TITLE
Adding GraphicsMagick thumbnailer based on ImageMagick's

### DIFF
--- a/application/src/File/Thumbnailer/GraphicsMagick.php
+++ b/application/src/File/Thumbnailer/GraphicsMagick.php
@@ -1,0 +1,14 @@
+<?php
+namespace Omeka\File\Thumbnailer;
+
+class GraphicsMagick extends ImageMagick
+{
+    protected function getCommandArguments($strategy, $constraint, $options = []) {
+        $args = parent::getCommandArguments($strategy, $constraint, $options);
+
+        if (($key = array_search("-alpha remove", $args)) !== false) {
+            unset($args[$key]);
+        }
+        return $args;
+    }
+}

--- a/application/src/File/Thumbnailer/ImageMagick.php
+++ b/application/src/File/Thumbnailer/ImageMagick.php
@@ -42,10 +42,7 @@ class ImageMagick extends AbstractThumbnailer
         }
     }
 
-    public function create($strategy, $constraint, array $options = [])
-    {
-        $origPath = sprintf('%s[%s]', $this->source, $this->getOption('page', 0));
-
+    protected function getCommandArguments($strategy, $constraint, $options = []) {
         switch ($strategy) {
             case 'square':
                 $gravity = isset($options['gravity']) ? $options['gravity'] : 'center';
@@ -67,6 +64,14 @@ class ImageMagick extends AbstractThumbnailer
                     '-thumbnail ' . escapeshellarg(sprintf('%sx%s>', $constraint, $constraint)),
                 ];
         }
+        return $args;
+    }
+
+    public function create($strategy, $constraint, array $options = [])
+    {
+        $origPath = sprintf('%s[%s]', $this->source, $this->getOption('page', 0));
+
+        $args = $this->getCommandArguments($strategy, $constraint, $options);
 
         if ($this->getOption('autoOrient', true)) {
             array_unshift($args, '-auto-orient');

--- a/application/src/Service/File/Thumbnailer/GraphicsMagickFactory.php
+++ b/application/src/Service/File/Thumbnailer/GraphicsMagickFactory.php
@@ -1,0 +1,22 @@
+<?php
+namespace Omeka\Service\File\Thumbnailer;
+
+use Interop\Container\ContainerInterface;
+use Omeka\File\Thumbnailer\GraphicsMagick;
+use Zend\ServiceManager\Factory\FactoryInterface;
+
+class GraphicsMagickFactory implements FactoryInterface
+{
+    /**
+     * Create the GraphicsMagick thumbnailer service.
+     *
+     * @return GraphicsMagick
+     */
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        return new GraphicsMagick(
+            $services->get('Omeka\Cli'),
+            $services->get('Omeka\File\TempFileFactory')
+        );
+    }
+}


### PR DESCRIPTION
I had noticed some months ago (#1358) that it was impossible to generate thumbnail when using [graphicsmagick](http://www.graphicsmagick.org/) instead of imagemagick, even if the two tools are almot identicals.
The reason is that ```-alpha remove``` is not a recognized parameter for graphicsmagick. Until now I had bypassed this by commenting the line in imagemagick thumbnailer, but per @Daniel-KM suggestion on the issue, I have now created a new Thumbnailer.

Rather than rewriting it from scratch as the only difference with ImageMagick is only the alpha remove option, I have extended the ImageMagick class and added a specific function to deal with arguments and remove the faulty one for GraphicsMagick.