### PR TITLE
Adding 'Resource template' column to the list of item and item-set.

### DIFF
--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -55,6 +55,18 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             );
         }
 
+        if (isset($query['resource_template_label'])) {
+            $resourceTemplateAlias = $this->createAlias();
+            $qb->innerJoin(
+                'omeka_root.resourceTemplate',
+                $resourceTemplateAlias
+            );
+            $qb->andWhere($qb->expr()->eq(
+                "$resourceTemplateAlias.label",
+                $this->createNamedParameter($qb, $query['resource_template_label']))
+            );
+        }
+
         if (isset($query['resource_class_id'])) {
             $classes = $query['resource_class_id'];
             if (!is_array($classes)) {
@@ -109,6 +121,10 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                 $resourceClassAlias = $this->createAlias();
                 $qb->leftJoin("omeka_root.resourceClass", $resourceClassAlias)
                     ->addOrderBy("$resourceClassAlias.label", $query['sort_order']);
+            } elseif ('resource_template_label' == $query['sort_by']) {
+                $resourceTemplateAlias = $this->createAlias();
+                $qb->leftJoin("omeka_root.resourceTemplate", $resourceTemplateAlias)
+                    ->addOrderBy("$resourceTemplateAlias.label", $query['sort_order']);
             } elseif ('owner_name' == $query['sort_by']) {
                 $ownerAlias = $this->createAlias();
                 $qb->leftJoin("omeka_root.owner", $ownerAlias)

--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -534,6 +534,18 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
     }
 
     /**
+     * Get the display resource template label for this resource.
+     *
+     * @param string|null $default
+     * @return string|null
+     */
+    public function displayResourceTemplateLabel($default = null)
+    {
+        $resourceTemplate = $this->resourceTemplate();
+        return $resourceTemplate ? $resourceTemplate->label() : $default;
+    }
+
+    /**
      * Get a "pretty" link to this resource containing a thumbnail and
      * display title.
      *

--- a/application/view/omeka/admin/item-set/browse.phtml
+++ b/application/view/omeka/admin/item-set/browse.phtml
@@ -16,6 +16,10 @@ $sortHeadings = [
         'value' => 'resource_class_label'
     ],
     [
+        'label' => $translate('Resource template'),
+        'value' => 'resource_template_label'
+    ],
+    [
         'label' => $translate('Owner'),
         'value' => 'owner_name'
     ],
@@ -73,6 +77,7 @@ $sortHeadings = [
                 <?php echo $translate('Title'); ?>
             </th>
             <th><?php echo $translate('Class'); ?></th>
+            <th><?php echo $translate('Resource template'); ?></th>
             <th><?php echo $translate('Owner'); ?></th>
             <th><?php echo $translate('Created'); ?></th>
         </tr>
@@ -126,6 +131,7 @@ $sortHeadings = [
                 </ul>
             </td>
             <td><?php echo $escape($translate($itemSet->displayResourceClassLabel())); ?></td>
+            <td><?php echo $escape($translate($itemSet->displayResourceTemplateLabel())); ?></td>
             <td><?php echo $ownerText; ?></td>
             <td><?php echo $escape($this->i18n()->dateFormat($itemSet->created())); ?></td>
         </tr>

--- a/application/view/omeka/admin/item/browse.phtml
+++ b/application/view/omeka/admin/item/browse.phtml
@@ -16,6 +16,10 @@ $sortHeadings = [
         'value' => 'resource_class_label'
     ],
     [
+        'label' => $translate('Resource template'),
+        'value' => 'resource_template_label'
+    ],
+    [
         'label' => $translate('Owner'),
         'value' => 'owner_name'
     ],
@@ -71,6 +75,7 @@ $sortHeadings = [
         <tr>
             <th><input type="checkbox" class="select-all" aria-label="<?php echo $translate('Select all'); ?>"><?php echo $translate('Title'); ?></th>
             <th><?php echo $translate('Class'); ?></th>
+            <th><?php echo $translate('Resource template'); ?></th>
             <th><?php echo $translate('Owner'); ?></th>
             <th><?php echo $translate('Created'); ?></th>
         </tr>
@@ -124,6 +129,7 @@ $sortHeadings = [
                 </ul>
             </td>
             <td><?php echo $escape($translate($item->displayResourceClassLabel())); ?></td>
+            <td><?php echo $escape($translate($item->displayResourceTemplateLabel())); ?></td>
             <td><?php echo $ownerText; ?></td>
             <td><?php echo $escape($this->i18n()->dateFormat($item->created())); ?></td>
         </tr>

--- a/application/view/omeka/admin/media/browse.phtml
+++ b/application/view/omeka/admin/media/browse.phtml
@@ -18,6 +18,10 @@ $sortHeadings = [
         'value' => 'resource_class_label'
     ],
     [
+        'label' => $translate('Resource template'),
+        'value' => 'resource_template_label'
+    ],
+    [
         'label' => $translate('Owner'),
         'value' => 'owner_name'
     ],
@@ -79,6 +83,7 @@ $sortHeadings = [
                 <?php echo $translate('Title'); ?>
             </th>
             <th><?php echo $translate('Class'); ?></th>
+            <th><?php echo $translate('Resource template'); ?></th>
             <th><?php echo $translate('Owner'); ?></th>
             <th><?php echo $translate('Created'); ?></th>
         </tr>
@@ -134,6 +139,7 @@ $sortHeadings = [
                 </ul>
             </td>
             <td><?php echo $escape($translate($media->displayResourceClassLabel())); ?></td>
+            <td><?php echo $escape($translate($media->displayResourceTemplateLabel())); ?></td>
             <td><?php echo $ownerText; ?></td>
             <td><?php echo $escape($this->i18n()->dateFormat($media->created())); ?></td>
         </tr>


### PR DESCRIPTION
If your archive heavily uses resource templates, you may want to sort your item/item-set list by resource template.

This patch adds the column of 'Resource template' to the list of items/item-sets and allows you to sort the items by the order of the label of the resource template.

A disadvantage of this patch is that the items/item-sets list becomes a little complicated. Here's a screenshot. In the case of our archive, we could hide the 'Class' column, because all items are generated from one of the resource templates.

![Untitled](https://user-images.githubusercontent.com/637330/71637058-be180200-2c7d-11ea-8c16-abf5139c15ea.png)
