### PR TITLE
Sanitize the item's description in browse view.

### DIFF
--- a/application/view/omeka/site/item/browse.phtml
+++ b/application/view/omeka/site/item/browse.phtml
@@ -62,7 +62,7 @@ foreach ($items as $item):
         <?php echo $item->linkRaw($this->thumbnail($item, 'medium')); ?>
         <h4><?php echo $item->link($heading); ?></h4>
         <?php if ($body): ?>
-        <div class="description"><?php echo $body; ?></div>
+        <div class="description"><?php echo $escape($body); ?></div>
         <?php endif; ?>
     </li>
 <?php endforeach; ?>


### PR DESCRIPTION
When you use the default theme and see the item's properties, the texts are sanitized by escapeHtml().
![Screenshot from 2020-01-04 14-21-02](https://user-images.githubusercontent.com/637330/71760235-d26a3200-2efd-11ea-89a0-5b8052c619ab.png)

But in the list view of the items, the text of the description property is not sanitized.
![Screenshot from 2020-01-04 14-20-04](https://user-images.githubusercontent.com/637330/71760237-d7c77c80-2efd-11ea-92c2-d90be918d7a8.png)

This patch simply solves the problem by encapsulating the text with $escape().
![Screenshot from 2020-01-04 14-20-43](https://user-images.githubusercontent.com/637330/71760238-dc8c3080-2efd-11ea-982a-edb45eb9c2e0.png)

