### PR TITLE
Feature/pretty unescaped json

### DIFF
--- a/application/src/Api/Exception/ValidationException.php
+++ b/application/src/Api/Exception/ValidationException.php
@@ -46,7 +46,7 @@ class ValidationException extends BadRequestException
             get_class($this),
             $this->getFile(),
             $this->getLine(),
-            json_encode($this->getErrorStore()->getErrors(), JSON_PRETTY_PRINT),
+            json_encode($this->getErrorStore()->getErrors(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS | JSON_PARTIAL_OUTPUT_ON_ERROR),
             $this->getTraceAsString()
         );
     }

--- a/application/src/Api/Representation/AbstractResourceRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceRepresentation.php
@@ -287,7 +287,7 @@ abstract class AbstractResourceRepresentation extends AbstractRepresentation
     public function embeddedJsonLd()
     {
         echo '<script type="application/ld+json">'
-            . json_encode($this)
+            . json_encode($this, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS)
             . '</script>';
     }
 }

--- a/application/src/Controller/Admin/ResourceTemplateController.php
+++ b/application/src/Controller/Admin/ResourceTemplateController.php
@@ -315,7 +315,7 @@ class ResourceTemplateController extends AbstractActionController
         }
 
         $filename = preg_replace('/[^a-zA-Z0-9]+/', '_', $template->label());
-        $export = json_encode($export, JSON_PRETTY_PRINT);
+        $export = json_encode($export, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS);
 
         $response = $this->getResponse();
         $headers = $response->getHeaders();

--- a/application/src/Controller/Admin/VocabularyController.php
+++ b/application/src/Controller/Admin/VocabularyController.php
@@ -177,7 +177,7 @@ class VocabularyController extends AbstractActionController
                     $diff = $this->rdfImporter->getDiff($strategy, $vocabulary->namespaceUri(), $options);
                     $form = $this->getForm(VocabularyUpdateForm::class);
                     $form->setAttribute('action', $this->url()->fromRoute(null, ['action' => 'update'], true));
-                    $form->get('diff')->setValue(json_encode($diff));
+                    $form->get('diff')->setValue(json_encode($diff, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS));
                     $view->setVariable('diff', $diff);
                     $view->setTemplate('omeka/admin/vocabulary/update');
                 } else {

--- a/application/src/Media/Renderer/IIIF.php
+++ b/application/src/Media/Renderer/IIIF.php
@@ -19,7 +19,7 @@ class IIIF implements RendererInterface
                     id: "iiif-'.$media->id().'",
                     prefixUrl: "'. $prefixUrl . '",
                     tileSources: [
-                        '. json_encode($IIIFData) .'
+                        ' . json_encode($IIIFData, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS) . '
                     ]
                 });
             </script>

--- a/application/src/Stdlib/JsonUnescaped.php
+++ b/application/src/Stdlib/JsonUnescaped.php
@@ -1,0 +1,129 @@
+<?php
+namespace Omeka\Stdlib;
+
+use SplQueue;
+use Zend\Json\Json;
+
+/**
+ * Class for encoding to and decoding from JSON.
+ */
+class JsonUnescaped extends Json
+{
+    /**
+     * Copy of the parent method to allow to access to parent private methods.
+     *
+     * @inheritdoc
+     */
+    public static function encode($valueToEncode, $cycleCheck = false, array $options = [])
+    {
+        if (is_object($valueToEncode)) {
+            if (method_exists($valueToEncode, 'toJson')) {
+                return $valueToEncode->toJson();
+            }
+
+            if (method_exists($valueToEncode, 'toArray')) {
+                return static::encode($valueToEncode->toArray(), $cycleCheck, $options);
+            }
+        }
+
+        // Pre-process and replace javascript expressions with placeholders
+        $javascriptExpressions = new SplQueue();
+        if (isset($options['enableJsonExprFinder'])
+            && $options['enableJsonExprFinder'] == true
+        ) {
+            $valueToEncode = static::recursiveJsonExprFinder($valueToEncode, $javascriptExpressions);
+        }
+
+        // Encoding
+        $prettyPrint = (isset($options['prettyPrint']) && ($options['prettyPrint'] === true));
+        $encodedResult = self::encodeValue($valueToEncode, $cycleCheck, $options, $prettyPrint);
+
+        // Post-process to revert back any Zend\Json\Expr instances.
+        $encodedResult = self::injectJavascriptExpressions($encodedResult, $javascriptExpressions);
+
+        return $encodedResult;
+    }
+
+    /**
+     * Copy of the parent method to allow to access to parent private methods.
+     * @see \Zend\Json\Json::encodeValue()
+     *
+     * Encode a value to JSON.
+     *
+     * Intermediary step between injecting JavaScript expressions.
+     *
+     * Delegates to either the PHP built-in json_encode operation, or the
+     * Encoder component, based on availability of the built-in and/or whether
+     * or not the component encoder is requested.
+     *
+     * @param mixed $valueToEncode
+     * @param bool $cycleCheck
+     * @param array $options
+     * @param bool $prettyPrint
+     * @return string
+     */
+    private static function encodeValue($valueToEncode, $cycleCheck, array $options, $prettyPrint)
+    {
+        if (function_exists('json_encode') && static::$useBuiltinEncoderDecoder !== true) {
+            return self::encodeViaPhpBuiltIn($valueToEncode, $prettyPrint);
+        }
+
+        return self::encodeViaEncoder($valueToEncode, $cycleCheck, $options, $prettyPrint);
+    }
+
+    /**
+     * Encode a value to JSON using the PHP built-in json_encode function.
+     *
+     * Unlike the private parent method, it never escapes tag, apostrophes,
+     * quotes ampersand, unicode character, slashes, and ends of line: it is not
+     * required by the recommandation.
+     *
+     * @see \Zend\Json\Json::encodeViaPhpBuiltIn()
+     *
+     * If $prettyPrint is boolean true, also uses JSON_PRETTY_PRINT.
+     *
+     * @param mixed $valueToEncode
+     * @param bool $prettyPrint
+     * @return string|false Boolean false return value if json_encode is not
+     *     available, or the $useBuiltinEncoderDecoder flag is enabled.
+     */
+    private static function encodeViaPhpBuiltIn($valueToEncode, $prettyPrint = false)
+    {
+        if (! function_exists('json_encode') || static::$useBuiltinEncoderDecoder === true) {
+            return false;
+        }
+
+        $encodeOptions = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS;
+        if ($prettyPrint) {
+            $encodeOptions |= JSON_PRETTY_PRINT;
+        }
+
+        return json_encode($valueToEncode, $encodeOptions);
+    }
+
+    /**
+     * Copy of private parent method.
+     * @see \Zend\Json\Json::injectJavascriptExpressions()
+     *
+     * Inject javascript expressions into the encoded value.
+     *
+     * Loops through each, substituting the "magicKey" of each with its
+     * associated value.
+     *
+     * @param string $encodedValue
+     * @param SplQueue $javascriptExpressions
+     * @return string
+     */
+    private static function injectJavascriptExpressions($encodedValue, SplQueue $javascriptExpressions)
+    {
+        foreach ($javascriptExpressions as $expression) {
+            $encodedValue = str_replace(
+                sprintf('"%s"', $expression['magicKey']),
+                $expression['value'],
+                (string) $encodedValue
+            );
+        }
+
+        return $encodedValue;
+    }
+}

--- a/application/src/View/Helper/JsTranslate.php
+++ b/application/src/View/Helper/JsTranslate.php
@@ -33,6 +33,6 @@ class JsTranslate extends AbstractHelper
 Omeka.jsTranslate = function(str) {
     var jsTranslations = %s;
     return (str in jsTranslations) ? jsTranslations[str] : str;
-};', json_encode($this->jsTranslations)));
+};', json_encode($this->jsTranslations, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS)));
     }
 }

--- a/application/src/View/Renderer/ApiJsonRenderer.php
+++ b/application/src/View/Renderer/ApiJsonRenderer.php
@@ -1,9 +1,15 @@
 <?php
 namespace Omeka\View\Renderer;
 
+use JsonSerializable;
 use Omeka\Api\Exception\ValidationException;
 use Omeka\Api\Response;
-use Zend\Json\Json;
+use Omeka\Stdlib\JsonUnescaped as Json;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+use Zend\View\Exception;
+use Zend\View\Model\JsonModel;
+use Zend\View\Model\ModelInterface as Model;
 use Zend\View\Renderer\JsonRenderer;
 
 /**
@@ -37,13 +43,57 @@ class ApiJsonRenderer extends JsonRenderer
             $this->setJsonpCallback($jsonpCallback);
         }
 
-        $output = parent::render($payload);
+        // Copy of \Zend\Json\Json::render(), but with JsonUnescaped as encoding
+        // method in order to use a full pretty print if wanted, in one step.
 
-        if (null !== $model->getOption('pretty_print')) {
-            // Pretty print the JSON.
-            $output = Json::prettyPrint($output);
+        $nameOrModel = &$payload;
+        $values = null;
+        $prettyPrint = null !== $model->getOption('pretty_print');
+
+        // use case 1: View Models
+        // Serialize variables in view model
+        if ($nameOrModel instanceof Model) {
+            if ($nameOrModel instanceof JsonModel) {
+                $children = $this->recurseModel($nameOrModel, false);
+                $this->injectChildren($nameOrModel, $children);
+                $values = $nameOrModel->serialize();
+                // Pretty print the JSON for json serialized outside.
+                if ($prettyPrint) {
+                    $values = Json::prettyPrint($values);
+                }
+            } else {
+                $values = $this->recurseModel($nameOrModel);
+                $values = Json::encode($values, false, ['prettyPrint' => $prettyPrint]);
+            }
+
+            if ($this->hasJsonpCallback()) {
+                $values = $this->jsonpCallback . '(' . $values . ');';
+            }
+            return $values;
         }
 
-        return $output;
+        // use case 2: $nameOrModel is populated, $values is not
+        // Serialize $nameOrModel
+        if (null === $values) {
+            if (! is_object($nameOrModel) || $nameOrModel instanceof JsonSerializable) {
+                $return = Json::encode($nameOrModel, false, ['prettyPrint' => $prettyPrint]);
+            } elseif ($nameOrModel instanceof Traversable) {
+                $nameOrModel = ArrayUtils::iteratorToArray($nameOrModel);
+                $return = Json::encode($nameOrModel, false, ['prettyPrint' => $prettyPrint]);
+            } else {
+                $return = Json::encode(get_object_vars($nameOrModel), false, ['prettyPrint' => $prettyPrint]);
+            }
+
+            if ($this->hasJsonpCallback()) {
+                $return = $this->jsonpCallback . '(' . $return . ');';
+            }
+            return $return;
+        }
+
+        // use case 3: Both $nameOrModel and $values are populated
+        throw new Exception\DomainException(sprintf(
+            '%s: Do not know how to handle operation when both $nameOrModel and $values are populated',
+            __METHOD__
+        ));
     }
 }

--- a/application/view/omeka/admin/job/show.phtml
+++ b/application/view/omeka/admin/job/show.phtml
@@ -48,7 +48,7 @@ if ($owner = $job->owner()) {
 <div class="meta-group">
     <h4><?php echo $translate('Args'); ?></h4>
     <?php if ($job->args()): ?>
-        <?php $args = json_encode($job->args(), JSON_PRETTY_PRINT); ?>
+        <?php $args = json_encode($job->args(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS); ?>
         <div class="value"><pre><?php echo $args; ?></pre></div>
     <?php else: ?>
     <div class="value"><?php echo $translate('[no args]') ?></div>


### PR DESCRIPTION
The [json](https://json.org) standard doesn't require to escape anything, except `"`, "\" and control characters. But php and Zend escape many other characters by default : tags, ampersand, apostrophe and overall the slashes "/" and the unicode characters, making json unreadable in many cases, whereas it's designed to be readable by people and machines. 
So these commits fix this point in the most important cases. There are some other places to fix, but they are useful only for developers, so less important. 
The last commit fixes the api output so it can be readable by people who don't have a json viewer in their browser (and of course it works fine in [Next](https://github.com/Daniel-KM/Omeka-S-module-Next)).