### PR TITLE
Used the filtered values for the resource title.

### DIFF
--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -488,9 +488,12 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
      */
     public function displayTitle($default = null)
     {
-        $title = $this->title();
-        if (null !== $title) {
-            return $title;
+        $template = $this->resourceTemplate();
+        if ($template && $template->titleProperty()) {
+            $title = $this->value($template->titleProperty()->term());
+            if (null !== $title) {
+                return $title;
+            }
         }
 
         if ($default === null) {
@@ -498,7 +501,9 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
             $default = $translator->translate('[Untitled]');
         }
 
-        return $default;
+        return (string) $this->value('dcterms:title', [
+            'default' => $default,
+        ]);
     }
 
     /**


### PR DESCRIPTION
Since v2.0, the function `displayTitle()` doesn't use the method `values()` any more, so this value cannot be filtered any more. As it's an important method used nearly anywhere, it should use the same process than other properties. Furthermore, it's now nearly a duplicate of `title()`. 
So this fix reverts the behavior to make it usable like `displayDescription()` and any other `value()`. This fix is required for the module [Internationalisation](https://github.com/Daniel-KM/Omeka-S-module-Internationalisation) and for next improvements of it.