### PR TITLE
Adding 'copy' action to the item browser.

### DIFF
--- a/application/src/Controller/Admin/ItemController.php
+++ b/application/src/Controller/Admin/ItemController.php
@@ -200,6 +200,11 @@ class ItemController extends AbstractActionController
         return $this->getAddEditView();
     }
 
+    public function copyAction()
+    {
+        return $this->getAddEditView();
+    }
+
     /**
      * Get the add/edit view.
      *
@@ -214,7 +219,7 @@ class ItemController extends AbstractActionController
         $form->setAttribute('enctype', 'multipart/form-data');
         $form->setAttribute('id', '$action-item');
 
-        if ('edit' === $action) {
+        if ('edit' === $action || 'copy' === $action) {
             $item = $this->api()->read('items', $this->params('id'))->getContent();
         }
 
@@ -252,7 +257,7 @@ class ItemController extends AbstractActionController
 
         $view = new ViewModel;
         $view->setVariable('form', $form);
-        if ('edit' === $action) {
+        if ('edit' === $action || 'copy' === $action) {
             $view->setVariable('item', $item);
             $view->setVariable('resource', $item);
         }

--- a/application/src/Controller/Admin/ItemController.php
+++ b/application/src/Controller/Admin/ItemController.php
@@ -192,26 +192,56 @@ class ItemController extends AbstractActionController
 
     public function addAction()
     {
+        return $this->getAddEditView();
+    }
+
+    public function editAction()
+    {
+        return $this->getAddEditView();
+    }
+
+    /**
+     * Get the add/edit view.
+     *
+     * @return ViewModel
+     */
+    protected function getAddEditView()
+    {
+        $action = $this->params('action');
+
         $form = $this->getForm(ResourceForm::class);
         $form->setAttribute('action', $this->url()->fromRoute(null, [], true));
         $form->setAttribute('enctype', 'multipart/form-data');
-        $form->setAttribute('id', 'add-item');
+        $form->setAttribute('id', '$action-item');
+
+        if ('edit' === $action) {
+            $item = $this->api()->read('items', $this->params('id'))->getContent();
+        }
+
         if ($this->getRequest()->isPost()) {
             $data = $this->params()->fromPost();
             $data = $this->mergeValuesJson($data);
             $form->setData($data);
             if ($form->isValid()) {
                 $fileData = $this->getRequest()->getFiles()->toArray();
-                $response = $this->api($form)->create('items', $data, $fileData);
+                if ('edit' === $action) {
+                    $response = $this->api($form)->update('items', $this->params('id'), $data, $fileData);
+                } else {
+                    $response = $this->api($form)->create('items', $data, $fileData);
+                }
                 if ($response) {
-                    $message = new Message(
-                        'Item successfully created. %s', // @translate
-                        sprintf(
-                            '<a href="%s">%s</a>',
-                            htmlspecialchars($this->url()->fromRoute(null, [], true)),
-                            $this->translate('Add another item?')
-                        ));
-                    $message->setEscapeHtml(false);
+                    if ('edit' === $action) {
+                        $message = 'Item successfully updated'; // @translate
+                    } else {
+                        $message = new Message(
+                            'Item successfully created. %s', // @translate
+                            sprintf(
+                                '<a href="%s">%s</a>',
+                                htmlspecialchars($this->url()->fromRoute(null, [], true)),
+                                $this->translate('Add another item?')
+                            ));
+                        $message->setEscapeHtml(false);
+                    }
                     $this->messenger()->addSuccess($message);
                     return $this->redirect()->toUrl($response->getContent()->url());
                 }
@@ -222,38 +252,10 @@ class ItemController extends AbstractActionController
 
         $view = new ViewModel;
         $view->setVariable('form', $form);
-        $view->setVariable('mediaForms', $this->getMediaForms());
-        return $view;
-    }
-
-    public function editAction()
-    {
-        $form = $this->getForm(ResourceForm::class);
-        $form->setAttribute('action', $this->url()->fromRoute(null, [], true));
-        $form->setAttribute('enctype', 'multipart/form-data');
-        $form->setAttribute('id', 'edit-item');
-        $item = $this->api()->read('items', $this->params('id'))->getContent();
-
-        if ($this->getRequest()->isPost()) {
-            $data = $this->params()->fromPost();
-            $data = $this->mergeValuesJson($data);
-            $form->setData($data);
-            if ($form->isValid()) {
-                $fileData = $this->getRequest()->getFiles()->toArray();
-                $response = $this->api($form)->update('items', $this->params('id'), $data, $fileData);
-                if ($response) {
-                    $this->messenger()->addSuccess('Item successfully updated'); // @translate
-                    return $this->redirect()->toUrl($response->getContent()->url());
-                }
-            } else {
-                $this->messenger()->addFormErrors($form);
-            }
+        if ('edit' === $action) {
+            $view->setVariable('item', $item);
+            $view->setVariable('resource', $item);
         }
-
-        $view = new ViewModel;
-        $view->setVariable('form', $form);
-        $view->setVariable('item', $item);
-        $view->setVariable('resource', $item);
         $view->setVariable('mediaForms', $this->getMediaForms());
         return $view;
     }

--- a/application/view/omeka/admin/item/browse.phtml
+++ b/application/view/omeka/admin/item/browse.phtml
@@ -106,6 +106,10 @@ $sortHeadings = [
                         'class' => 'o-icon-edit',
                         'title' => $translate('Edit'),
                     ]); ?></li>
+                    <li><?php echo $item->link('', 'copy', [
+                        'class' => 'o-icon-copy',
+                        'title' => $translate('Copy'),
+                    ]); ?></li>
                     <?php endif; ?>
                     <?php if ($item->userIsAllowed('delete')): ?>
                     <li><?php echo $this->hyperlink('', '#', [

--- a/application/view/omeka/admin/item/copy.phtml
+++ b/application/view/omeka/admin/item/copy.phtml
@@ -1,0 +1,25 @@
+<?php
+$translate = $this->plugin('translate');
+$escape = $this->plugin('escapeHtml');
+$this->htmlElement('body')->appendAttribute('class', 'add items');
+?>
+
+<script type='text/javascript'>
+var valuesJson = <?php echo json_encode($item->values()); ?>;
+</script>
+
+<?php echo $this->pageTitle("Copied from " . $item->displayTitle(), 1, $translate('Items')); ?>
+<?php $this->trigger('view.add.before'); ?>
+<?php
+echo $this->partial('omeka/admin/item/form.phtml', [
+    'form' => $form,
+    'item' => $item,
+    'resource' => $resource,
+    'mediaForms' => $mediaForms,
+    'submitLabel' => $translate('Add'),
+    'sectionNavEvent' => 'view.add.section_nav',
+    'action' => 'add',
+]);
+?>
+
+<?php $this->trigger('view.add.after'); ?>


### PR DESCRIPTION
This patch allows the user to duplicate an item from the admin dashboard.
While the same feature is already implemented as a plugin ([ItemCopy](https://github.com/gegedenice/ItemCopy)), this implementation is much simpler. Plus, the copy action can be used to implement "default values" (see [this discussion](https://forum.omeka.org/t/default-values-for-resource-templates/4966)).

Here's a screenshot.
![Screenshot from 2020-01-16 15-35-46](https://user-images.githubusercontent.com/637330/72500149-29b1c000-3877-11ea-8fc3-c9ee1769477f.png)

This patch uses 'fa-copy' icon introduced by #1501. If #1501 will not be applied to the upstream, please apply the patch included in cc300f468b2 to iconfont.scss.