### PR TITLE
Fixed item set alias for api queries.

### DIFF
--- a/application/src/Api/Adapter/ItemSetAdapter.php
+++ b/application/src/Api/Adapter/ItemSetAdapter.php
@@ -38,6 +38,8 @@ class ItemSetAdapter extends AbstractResourceEntityAdapter
 
     public function buildQuery(QueryBuilder $qb, array $query)
     {
+        $this->siteItemSetsAlias = null;
+
         parent::buildQuery($qb, $query);
 
         // Select item sets to which the current user can assign an item.


### PR DESCRIPTION
When events are used, the query should be reset between calls.