### PR TITLE
Add site permissions management to add-user and edit-user views

### DIFF
--- a/application/Module.php
+++ b/application/Module.php
@@ -38,6 +38,12 @@ class Module extends AbstractModule
     public function attachListeners(SharedEventManagerInterface $sharedEventManager)
     {
         $sharedEventManager->attach(
+            'Omeka\Api\Adapter\UserAdapter',
+            'api.execute.post',
+            [$this, 'batchUpdatePostUser']
+        );
+
+        $sharedEventManager->attach(
             'Laminas\View\Helper\Navigation\AbstractHelper',
             'isAllowed',
             [$this, 'navigationPageIsAllowed']
@@ -438,7 +444,17 @@ class Module extends AbstractModule
         // events of Site.
         // TODO Replace $fileData by $relatedData in ApiManager, so any related
         // entity will be able to be updated with the main entity.
-        $userIds = array_intersect_key($response->getRequest()->getIds(), $response->getContent());
+        
+        if (empty($requestIds = $response->getRequest()->getIds())) {
+            //Single user creation or update
+            $responseContent[] = $response->getContent();
+            $requestIds[] = $response->getContent()->getId();
+        } else {
+            //Batch user update
+            $responseContent = $response->getContent();
+        }
+
+        $userIds = array_intersect_key($requestIds, $responseContent);
         foreach ($siteIds as $siteId) {
             $site = is_object($siteId)
                 ? $siteId

--- a/application/src/Controller/Admin/UserController.php
+++ b/application/src/Controller/Admin/UserController.php
@@ -94,11 +94,13 @@ class UserController extends AbstractActionController
         $changeRole = $this->userIsAllowed('Omeka\Entity\User', 'change-role');
         $changeRoleAdmin = $this->userIsAllowed('Omeka\Entity\User', 'change-role-admin');
         $activateUser = $this->userIsAllowed('Omeka\Entity\User', 'activate-user');
+        $addSiteRole = $this->userIsAllowed('Omeka\Api\Adapter\UserAdapter', 'batch_update');
 
         $form = $this->getForm(UserForm::class, [
             'include_role' => $changeRole,
             'include_admin_roles' => $changeRoleAdmin,
             'include_is_active' => $activateUser,
+            'include_site_role_add' => $addSiteRole,
         ]);
 
         if ($this->getRequest()->isPost()) {
@@ -143,6 +145,7 @@ class UserController extends AbstractActionController
         $changeRole = $this->userIsAllowed($userEntity, 'change-role');
         $changeRoleAdmin = $this->userIsAllowed($userEntity, 'change-role-admin');
         $activateUser = $this->userIsAllowed($userEntity, 'activate-user');
+        $addSiteRole = $this->userIsAllowed($userEntity, 'batch_update');
 
         $form = $this->getForm(UserForm::class, [
             'user_id' => $id,
@@ -152,6 +155,8 @@ class UserController extends AbstractActionController
             'current_password' => $currentUser,
             'include_password' => true,
             'include_key' => true,
+            'include_site_role_remove' => $addSiteRole,
+            'include_site_role_add' => $addSiteRole,
         ]);
         $form->setAttribute('action', $this->getRequest()->getRequestUri());
 

--- a/application/src/Form/UserForm.php
+++ b/application/src/Form/UserForm.php
@@ -8,6 +8,7 @@ use Omeka\Settings\UserSettings;
 use Laminas\Form\Form;
 use Laminas\EventManager\EventManagerAwareTrait;
 use Laminas\EventManager\Event;
+use Omeka\Form\Element\SiteSelect;
 
 class UserForm extends Form
 {
@@ -23,6 +24,8 @@ class UserForm extends Form
         'current_password' => false,
         'include_password' => false,
         'include_key' => false,
+        'include_site_role_remove' => false,
+        'include_site_role_add' => false,
     ];
 
     /**
@@ -157,6 +160,63 @@ class UserForm extends Form
             ],
         ]);
 
+        if ($this->getOption('include_site_role_remove')) {
+            $this->get('user-information')->add([
+                'name' => 'remove_from_site_permission',
+                'type' => SiteSelect::class,
+                'attributes' => [
+                    'id' => 'remove-from-site-permission-select',
+                    'class' => 'chosen-select',
+                    'multiple' => true,
+                    'data-placeholder' => 'Select sites…', // @translate
+                    'data-collection-action' => 'remove',
+                ],
+                'options' => [
+                    'label' => 'Remove from site permission', // @translate
+                    'empty_option' => '[No change]', // @translate
+                    'prepend_value_options' => ['-1' => '[All sites]'], // @translate
+                ],
+            ]);
+        }
+
+        if ($this->getOption('include_site_role_add')) {
+            $this->get('user-information')->add([
+                'name' => 'add_to_site_permission',
+                'type' => SiteSelect::class,
+                'attributes' => [
+                    'id' => 'add-to-site-permission-select',
+                    'class' => 'chosen-select',
+                    'multiple' => true,
+                    'data-placeholder' => 'Select sites…', // @translate
+                    'data-collection-action' => 'append',
+                ],
+                'options' => [
+                    'label' => 'Add to site permission', // @translate
+                    'empty_option' => '[No change]', // @translate
+                    'prepend_value_options' => ['-1' => '[All sites]'], // @translate
+                ],
+            ]);
+
+            $this->get('user-information')->add([
+                'name' => 'add_to_site_permission_role',
+                'type' => 'Select',
+                'attributes' => [
+                    'id' => 'add-to-site-permission-role-select',
+                    'data-placeholder' => 'Select permission…', // @translate
+                    'data-collection-action' => 'append',
+                ],
+                'options' => [
+                    'label' => 'Add to site permission as', // @translate
+                    'empty_option' => '[No change]', // @translate
+                    'value_options' => [
+                        'viewer' => 'Viewer', // @translate
+                        'editor' => 'Editor', // @translate
+                        'admin' => 'Admin', // @translate
+                    ],
+                ],
+            ]);
+        }
+
         if ($this->getOption('include_password')) {
             if ($this->getOption('current_password')) {
                 $this->get('change-password')->add([
@@ -206,6 +266,18 @@ class UserForm extends Form
         $inputFilter->get('user-settings')->add([
             'name' => 'default_resource_template',
             'allow_empty' => true,
+        ]);
+        $inputFilter->get('user-information')->add([
+            'name' => 'remove_from_site_permission',
+            'required' => false,
+        ]);
+        $inputFilter->get('user-information')->add([
+            'name' => 'add_to_site_permission',
+            'required' => false,
+        ]);
+        $inputFilter->get('user-information')->add([
+            'name' => 'add_to_site_permission_role',
+            'required' => false,
         ]);
 
         if ($this->getOption('include_key')) {


### PR DESCRIPTION
Adds site permission form elements to add-user and edit-user forms.

These modifications are based on the existing feature mentioned in #1537. It only adds existing core form elements to the single user add/edit forms, and handles them properly in the `batchUpdatePostUser` listener method.
This PR embarks #1538 although both are standalone.
