### PR TITLE
Managed api search for modules.

### DIFF
--- a/application/src/View/Helper/Api.php
+++ b/application/src/View/Helper/Api.php
@@ -51,7 +51,7 @@ class Api extends AbstractHelper
         $data['limit'] = 1;
         $response = $this->apiManager->search($resource, $data);
         $content = $response->getContent();
-        $content = is_array($content) && count($content) ? $content[0] : null;
+        $content = is_array($content) && count($content) ? reset($content) : null;
         $response->setContent($content);
         return $response;
     }


### PR DESCRIPTION
The index of api search is not always a numeric key, so the method should manage any key, in particular for modules.