### PR TITLE
Fix unset of raw JSON values from form data

### DIFF
--- a/application/src/Mvc/Controller/Plugin/MergeValuesJson.php
+++ b/application/src/Mvc/Controller/Plugin/MergeValuesJson.php
@@ -26,7 +26,7 @@ class MergeValuesJson extends AbstractPlugin
         if (json_last_error() !== JSON_ERROR_NONE) {
             throw new Exception\InvalidJsonException('JSON error: ' . json_last_error_msg());
         }
-        unset($data['values-json']);
+        unset($data['values_json']);
         return array_merge($data, $jsonData);
     }
 }


### PR DESCRIPTION
Mistyping of values_json key meant that the encoded values where still present in the returned data after merge.