### PR TITLE
Secured dot-files in htaccess.

### DIFF
--- a/.htaccess.dist
+++ b/.htaccess.dist
@@ -2,6 +2,9 @@ SetEnv APPLICATION_ENV "production"
 
 RewriteEngine On
 
+# Forbid access to all dot files, except well-known.
+RewriteRule (?:^|/)\.(?!well-known(?:/.*)?$) - [F,NC]
+
 # The following rule tells Apache that if the requested filename
 # exists, simply serve it.
 RewriteCond %{REQUEST_FILENAME} -f


### PR DESCRIPTION
A complement to #1556 : it protects all dot files, except the directory used by Lets Encrypt (and #1553).