### PR TITLE
Returned associated array id-value when option "returnScalar" is used in api.

### DIFF
--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -242,8 +242,8 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
                     $scalarField, $entityClass
                 ));
             }
-            $qb->select('omeka_root.' . $scalarField);
-            $content = array_column($qb->getQuery()->getScalarResult(), $scalarField);
+            $qb->select(['omeka_root.id', 'omeka_root.' . $scalarField]);
+            $content = array_column($qb->getQuery()->getScalarResult(), $scalarField, 'id');
             $response = new Response($content);
             $response->setTotalResults(count($content));
             return $response;

--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -242,8 +242,13 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
                     $scalarField, $entityClass
                 ));
             }
-            $qb->select(['omeka_root.id', 'omeka_root.' . $scalarField]);
-            $content = array_column($qb->getQuery()->getScalarResult(), $scalarField, 'id');
+            if ($scalarField === 'id') {
+                $qb->select('omeka_root.' . $scalarField);
+                $content = array_column($qb->getQuery()->getScalarResult(), $scalarField);
+            } else {
+                $qb->select(['omeka_root.id', 'omeka_root.' . $scalarField]);
+                $content = array_column($qb->getQuery()->getScalarResult(), $scalarField, 'id');
+            }
             $response = new Response($content);
             $response->setTotalResults(count($content));
             return $response;


### PR DESCRIPTION
The option "returnScalar" is useful, but it will be more useful when the id is returned with results too. 

Ideally, it may be possible to return multiple selected columns, but for now, the id is enough.