### PR TITLE
Remove need to install gulp globally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ cache:
     - build/cache
 
 before_install:
- - nvm install 7
- - nvm use 7
+ - nvm install 8
+ - nvm use 8
   
 install:
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   
 install:
   - npm install
-  - ./node_modules/gulp/bin/gulp.js init
+  - npx gulp init
 
 before_script:
   - mysql -e "create database IF NOT EXISTS omeka_test;" -uroot

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ options in the [documentation](https://omeka.org/s/docs/user-manual/configuratio
    * `$ cd omeka-s`
 1. Perform first-time setup:
    * `$ npm install`
-   * `$ npm install --global gulp-cli` (if you do not already have `gulp` installed)
-   * `$ gulp init`
+   * `$ npx gulp init`
 1. Open `config/database.ini` and add your MySQL username, password, database
    name, and host name. The user and database must be created before this step.
 1. Make sure the `files/` directory is writable by Apache.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1703,6 +1703,40 @@
         }
       }
     },
+    "gulp-cli": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",
+      "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^1.0.1",
+        "archy": "^1.0.0",
+        "array-sort": "^1.0.0",
+        "color-support": "^1.1.3",
+        "concat-stream": "^1.6.0",
+        "copy-props": "^2.0.1",
+        "fancy-log": "^1.3.2",
+        "gulplog": "^1.0.0",
+        "interpret": "^1.4.0",
+        "isobject": "^3.0.1",
+        "liftoff": "^3.1.0",
+        "matchdep": "^2.0.0",
+        "mute-stdout": "^1.0.0",
+        "pretty-hrtime": "^1.0.0",
+        "replace-homedir": "^1.0.0",
+        "semver-greatest-satisfied-range": "^1.1.0",
+        "v8flags": "^3.2.0",
+        "yargs": "^7.1.0"
+      },
+      "dependencies": {
+        "interpret": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+          "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+          "dev": true
+        }
+      }
+    },
     "gulp-postcss": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-8.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dateformat": "^3.0.3",
     "glob": "^7.1.1",
     "gulp": "^4.0.2",
+    "gulp-cli": "^2.3.0",
     "gulp-postcss": "^8.0.0",
     "gulp-rename": "^1.4.0",
     "gulp-replace": "^1.0.0",


### PR DESCRIPTION
Use npx to run gulp-cli from node_modules instead of needing to install
globally. All currently supported versions of Node.js (as of this
writing 10.x, 12.x, and 14.x) ship with versions of npm that include
npx.