### PR TITLE
Allowed to get associated fields when returning scalar from api.

### DIFF
--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -273,8 +273,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
                         $scalarField, $entityClass
                     ));
                 }
-                $qb->join('omeka_root.' . $scalarField, $scalarField . '_');
-                $qb->select(['omeka_root.id', $scalarField . '_.id AS ' . $scalarField]);
+                $qb->select(['omeka_root.id', "IDENTITY(omeka_root.$scalarField) AS $scalarField"]);
             } else {
                 $qb->select(['omeka_root.id', 'omeka_root.' . $scalarField]);
             }


### PR DESCRIPTION
When using the api search, it's not possible to return the scalar values for the foreign key of a table. For example, it's not possible to get a list of user ids of items.