### PR TITLE
New forms to manage the resource template form with settings.

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -473,6 +473,7 @@ return [
             'Omeka\Form\SettingForm' => Service\Form\SettingFormFactory::class,
             'Omeka\Form\ModuleStateChangeForm' => Service\Form\ModuleStateChangeFormFactory::class,
             'Omeka\Form\ResourceTemplateForm' => Service\Form\ResourceTemplateFormFactory::class,
+            'Omeka\Form\ResourceTemplatePropertyFieldset' => Service\Form\ResourceTemplatePropertyFieldsetFactory::class,
             'Omeka\Form\SiteForm' => Service\Form\SiteFormFactory::class,
             'Omeka\Form\SiteSettingsForm' => Service\Form\SiteSettingsFormFactory::class,
             'Omeka\Form\UserBatchUpdateForm' => Service\Form\UserBatchUpdateFormFactory::class,

--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -472,6 +472,7 @@ return [
             'Omeka\Form\UserForm' => Service\Form\UserFormFactory::class,
             'Omeka\Form\SettingForm' => Service\Form\SettingFormFactory::class,
             'Omeka\Form\ModuleStateChangeForm' => Service\Form\ModuleStateChangeFormFactory::class,
+            'Omeka\Form\ResourceTemplateForm' => Service\Form\ResourceTemplateFormFactory::class,
             'Omeka\Form\SiteForm' => Service\Form\SiteFormFactory::class,
             'Omeka\Form\SiteSettingsForm' => Service\Form\SiteSettingsFormFactory::class,
             'Omeka\Form\UserBatchUpdateForm' => Service\Form\UserBatchUpdateFormFactory::class,

--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -477,6 +477,7 @@ return [
             'Omeka\Form\SiteForm' => Service\Form\SiteFormFactory::class,
             'Omeka\Form\SiteSettingsForm' => Service\Form\SiteSettingsFormFactory::class,
             'Omeka\Form\UserBatchUpdateForm' => Service\Form\UserBatchUpdateFormFactory::class,
+            'Omeka\Form\Element\DataTypeSelect' => Service\Form\Element\DataTypeSelectFactory::class,
             'Omeka\Form\Element\ResourceSelect' => Service\Form\Element\ResourceSelectFactory::class,
             'Omeka\Form\Element\ResourceClassSelect' => Service\Form\Element\ResourceClassSelectFactory::class,
             'Omeka\Form\Element\ResourceTemplateSelect' => Service\Form\Element\ResourceTemplateSelectFactory::class,

--- a/application/src/Form/Element/DataTypeSelect.php
+++ b/application/src/Form/Element/DataTypeSelect.php
@@ -1,0 +1,74 @@
+<?php
+namespace Omeka\Form\Element;
+
+use Omeka\DataType\Manager as DataTypeManager;
+use Zend\Form\Element\Select;
+
+class DataTypeSelect extends Select
+{
+    protected $attributes = [
+        'type' => 'select',
+        'multiple' => false,
+        'class' => 'chosen-select',
+    ];
+
+    /**
+     * @var DataTypeManager
+     */
+    protected $dataTypeManager;
+
+    /**
+     * @var array
+     */
+    protected $dataTypes = [];
+
+    public function getValueOptions()
+    {
+        $options = [];
+        $optgroupOptions = [];
+        foreach ($this->dataTypes as $dataTypeName) {
+            $dataType = $this->dataTypeManager->get($dataTypeName);
+            $label = $dataType->getLabel();
+            if ($optgroupLabel = $dataType->getOptgroupLabel()) {
+                // Hash the optgroup key to avoid collisions when merging with
+                // data types without an optgroup.
+                $optgroupKey = md5($optgroupLabel);
+                // Put resource data types before ones added by modules.
+                $optionsVal = in_array($dataTypeName, ['resource', 'resource:item', 'resource:itemset', 'resource:media'])
+                    ? 'options'
+                    : 'optgroupOptions';
+                if (!isset(${$optionsVal}[$optgroupKey])) {
+                    ${$optionsVal}[$optgroupKey] = [
+                        'label' => $optgroupLabel,
+                        'options' => [],
+                    ];
+                }
+                ${$optionsVal}[$optgroupKey]['options'][$dataTypeName] = $label;
+            } else {
+                $options[$dataTypeName] = $label;
+            }
+        }
+        // Always put data types not organized in option groups before data
+        // types organized within option groups.
+        return array_merge($options, $optgroupOptions);
+    }
+
+    /**
+     * @param DataTypeManager $dataTypeManager
+     * @return self
+     */
+    public function setDataTypeManager(DataTypeManager $dataTypeManager)
+    {
+        $this->dataTypeManager = $dataTypeManager;
+        $this->dataTypes = $dataTypeManager->getRegisteredNames();
+        return $this;
+    }
+
+    /**
+     * @return DataTypeManager
+     */
+    public function getDataTypeManager()
+    {
+        return $this->dataTypeManager;
+    }
+}

--- a/application/src/Form/Element/DataTypeSelect.php
+++ b/application/src/Form/Element/DataTypeSelect.php
@@ -2,7 +2,7 @@
 namespace Omeka\Form\Element;
 
 use Omeka\DataType\Manager as DataTypeManager;
-use Zend\Form\Element\Select;
+use Laminas\Form\Element\Select;
 
 class DataTypeSelect extends Select
 {

--- a/application/src/Form/ResourceTemplateForm.php
+++ b/application/src/Form/ResourceTemplateForm.php
@@ -2,10 +2,14 @@
 namespace Omeka\Form;
 
 use Omeka\Form\Element\ResourceClassSelect;
+use Laminas\EventManager\Event;
+use Laminas\EventManager\EventManagerAwareTrait;
 use Laminas\Form\Form;
 
 class ResourceTemplateForm extends Form
 {
+    use EventManagerAwareTrait;
+
     public function init()
     {
         $this->add([
@@ -49,6 +53,9 @@ class ResourceTemplateForm extends Form
             ],
         ]);
 
+        $event = new Event('form.add_elements', $this);
+        $this->getEventManager()->triggerEvent($event);
+
         $inputFilter = $this->getInputFilter();
         $inputFilter->add([
             'name' => 'o:label',
@@ -58,5 +65,10 @@ class ResourceTemplateForm extends Form
             'name' => 'o:resource_class[o:id]',
             'allow_empty' => true,
         ]);
+
+        // Separate events because calling $form->getInputFilters() resets
+        // everything.
+        $event = new Event('form.add_input_filters', $this, ['inputFilter' => $inputFilter]);
+        $this->getEventManager()->triggerEvent($event);
     }
 }

--- a/application/src/Form/ResourceTemplateForm.php
+++ b/application/src/Form/ResourceTemplateForm.php
@@ -4,6 +4,7 @@ namespace Omeka\Form;
 use Omeka\Form\Element\ResourceClassSelect;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManagerAwareTrait;
+use Laminas\Form\Fieldset;
 use Laminas\Form\Form;
 
 class ResourceTemplateForm extends Form
@@ -50,6 +51,14 @@ class ResourceTemplateForm extends Form
             'type' => 'hidden',
             'attributes' => [
                 'id' => 'description-property-id',
+            ],
+        ]);
+
+        $this->add([
+            'type' => Fieldset::class,
+            'name' => 'o:settings',
+            'options' => [
+                'label' => 'Other settings', // @translate
             ],
         ]);
 

--- a/application/src/Form/ResourceTemplateForm.php
+++ b/application/src/Form/ResourceTemplateForm.php
@@ -4,6 +4,7 @@ namespace Omeka\Form;
 use Omeka\Form\Element\ResourceClassSelect;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManagerAwareTrait;
+use Laminas\Form\Element;
 use Laminas\Form\Fieldset;
 use Laminas\Form\Form;
 
@@ -33,9 +34,9 @@ class ResourceTemplateForm extends Form
                 'empty_option' => '',
             ],
             'attributes' => [
+                'id' => 'o:resource_class[o:id]',
                 'class' => 'chosen-select',
                 'data-placeholder' => 'Select a class',
-                'id' => 'o:resource_class[o:id]',
             ],
         ]);
 
@@ -58,7 +59,30 @@ class ResourceTemplateForm extends Form
             'type' => Fieldset::class,
             'name' => 'o:settings',
             'options' => [
-                'label' => 'Other settings', // @translate
+                'label' => 'Advanced settings', // @translate
+            ],
+            'attributes' => [
+                'class' => 'settings',
+            ],
+        ]);
+
+        $this->add([
+            'type' => Element\Collection::class,
+            'name' => 'o:resource_template_property',
+            'options' => [
+                'label' => 'Properties', // @translate
+                'count' => 0,
+                'allow_add' => true,
+                'allow_remove' => true,
+                'should_create_template' => false,
+                'use_as_base_fieldset' => true,
+                'create_new_objects' => false,
+                'target_element' => [
+                    'type' => ResourceTemplatePropertyFieldset::class,
+                ],
+            ],
+            'attributes' => [
+                'id' => 'properties',
             ],
         ]);
 

--- a/application/src/Form/ResourceTemplatePropertyFieldset.php
+++ b/application/src/Form/ResourceTemplatePropertyFieldset.php
@@ -1,0 +1,156 @@
+<?php
+namespace Omeka\Form;
+
+use Laminas\EventManager\Event;
+use Laminas\EventManager\EventManagerAwareTrait;
+use Laminas\Form\Element;
+use Laminas\Form\Fieldset;
+use Laminas\InputFilter\InputFilterProviderInterface;
+use Omeka\Form\Element\DataTypeSelect;
+
+class ResourceTemplatePropertyFieldset extends Fieldset implements InputFilterProviderInterface
+{
+    use EventManagerAwareTrait;
+
+    public function init()
+    {
+        // Fieldset displayed in the sidebar of the resource template form and
+        // as hidden collection in main part. Values are copied hiddenly in main
+        // part form via js.
+        // The ids are duplicated when there are multiple rows, so they are
+        // managed in the view.
+        $this
+            ->setLabel('Property') // @translate
+            ->add([
+                'name' => 'o:property[o:id]',
+                'type' => Element\Hidden::class,
+                'attributes' => [
+                    // 'id' => 'property-id',
+                    'data-property-key' => 'o:property[o:id]',
+                ],
+            ])
+            ->add([
+                'name' => 'o:alternate_label',
+                'type' => Element\Text::class,
+                'options' => [
+                    'label' => 'Alternate', // @translate
+                ],
+                'attributes' => [
+                    // 'id' => 'alternate-label',
+                    'data-property-key' => 'o:alternate_label',
+                ],
+            ])
+            ->add([
+                'name' => 'o:alternate_comment',
+                'type' => Element\Text::class,
+                'options' => [
+                    'label' => 'Alternate', // @translate
+                ],
+                'attributes' => [
+                    // 'id' => 'alternate-comment',
+                    'data-property-key' => 'o:alternate_comment',
+                ],
+            ])
+            // This value is a template parameter and managed via js.
+            ->add([
+                'name' => 'is-title-property',
+                'type' => Element\Checkbox::class,
+                'options' => [
+                    'label' => 'Use for resource title', // @translate
+                ],
+                'attributes' => [
+                    // 'id' => 'is-title-property',
+                    'data-property-key' => 'is-title-property',
+                ],
+            ])
+            // This value is a template parameter and managed via js.
+            ->add([
+                'name' => 'is-description-property',
+                'type' => Element\Checkbox::class,
+                'options' => [
+                    'label' => 'Use for resource description', // @translate
+                ],
+                'attributes' => [
+                    // 'id' => 'is-description-property',
+                    'data-property-key' => 'is-description-property',
+                ],
+            ])
+            ->add([
+                'name' => 'o:is_required',
+                'type' => Element\Checkbox::class,
+                'options' => [
+                    'label' => 'Required', // @translate
+                ],
+                'attributes' => [
+                    // 'id' => 'is-required',
+                    'data-property-key' => 'o:is_required',
+                ],
+            ])
+            ->add([
+                'name' => 'o:is_private',
+                'type' => Element\Checkbox::class,
+                'options' => [
+                    'label' => 'Private', // @translate
+                ],
+                'attributes' => [
+                    // 'id' => 'is-private',
+                    'data-property-key' => 'o:is_private',
+                ],
+            ])
+            ->add([
+                'name' => 'o:data_type',
+                'type' => DataTypeSelect::class,
+                'options' => [
+                    'label' => 'Data type', // @translate
+                    'empty_option' => '',
+                ],
+                'attributes' => [
+                    // 'id' => 'data-type',
+                    'multiple' => false,
+                    'data-placeholder' => 'Select data type…', // @translate
+                    'data-property-key' => 'o:data_type',
+                ],
+            ])
+            // This fieldset is used only to simplify rendering.
+            // Elements inside this fieldset are not filtered and lost.
+            ->add([
+                'type' => Fieldset::class,
+                'name' => 'o:settings',
+                'options' => [
+                    'label' => 'Advanced settings', // @translate
+                ],
+            ]);
+
+        $event = new Event('form.add_elements', $this);
+        $this->getEventManager()->triggerEvent($event);
+    }
+
+    /**
+     * This method is required when a fieldset is used as a collection, else the
+     * data are not returned with getData().
+     *
+     * {@inheritDoc}
+     * @see \Laminas\InputFilter\InputFilterProviderInterface::getInputFilterSpecification()
+     */
+    public function getInputFilterSpecification()
+    {
+        // Remove required option for attached settings.
+        $spec = [
+            'o:data_type' => [
+                'required' => false,
+            ],
+            'o:settings' => [
+                'required' => false,
+            ],
+        ];
+        foreach ($this->getElements() as $element) {
+            if ($element->getAttribute('data-setting-key')) {
+                $spec[$element->getName()] = [
+                    'required' => false,
+                    'allow_empty' => true,
+                ];
+            }
+        }
+        return $spec;
+    }
+}

--- a/application/src/Service/Form/Element/DataTypeSelectFactory.php
+++ b/application/src/Service/Form/Element/DataTypeSelectFactory.php
@@ -1,0 +1,16 @@
+<?php
+namespace Omeka\Service\Form\Element;
+
+use Interop\Container\ContainerInterface;
+use Omeka\Form\Element\DataTypeSelect;
+use Zend\ServiceManager\Factory\FactoryInterface;
+
+class DataTypeSelectFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        $element = new DataTypeSelect;
+        return $element
+            ->setDataTypeManager($services->get('Omeka\DataTypeManager'));
+    }
+}

--- a/application/src/Service/Form/Element/DataTypeSelectFactory.php
+++ b/application/src/Service/Form/Element/DataTypeSelectFactory.php
@@ -3,7 +3,7 @@ namespace Omeka\Service\Form\Element;
 
 use Interop\Container\ContainerInterface;
 use Omeka\Form\Element\DataTypeSelect;
-use Zend\ServiceManager\Factory\FactoryInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class DataTypeSelectFactory implements FactoryInterface
 {

--- a/application/src/Service/Form/ResourceTemplateFormFactory.php
+++ b/application/src/Service/Form/ResourceTemplateFormFactory.php
@@ -1,0 +1,16 @@
+<?php
+namespace Omeka\Service\Form;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Omeka\Form\ResourceTemplateForm;
+
+class ResourceTemplateFormFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        $form = new ResourceTemplateForm(null, $options);
+        $form->setEventManager($services->get('EventManager'));
+        return $form;
+    }
+}

--- a/application/src/Service/Form/ResourceTemplatePropertyFieldsetFactory.php
+++ b/application/src/Service/Form/ResourceTemplatePropertyFieldsetFactory.php
@@ -1,0 +1,16 @@
+<?php
+namespace Omeka\Service\Form;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Omeka\Form\ResourceTemplatePropertyFieldset;
+
+class ResourceTemplatePropertyFieldsetFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        $form = new ResourceTemplatePropertyFieldset(null, $options);
+        $form->setEventManager($services->get('EventManager'));
+        return $form;
+    }
+}

--- a/application/src/View/Helper/DataType.php
+++ b/application/src/View/Helper/DataType.php
@@ -82,10 +82,12 @@ class DataType extends AbstractHelper
     {
         $view = $this->getView();
         $templates = '';
+        $resource = isset($view->resource) ? $view->resource : null;
+        $partial = $view->plugin('partial');
         foreach ($this->dataTypes as $dataType) {
-            $templates .= $view->partial('common/data-type-wrapper', [
+            $templates .= $partial('common/data-type-wrapper', [
                 'dataType' => $dataType,
-                'resource' => isset($view->resource) ? $view->resource : null,
+                'resource' => $resource,
             ]);
         }
         return $templates;

--- a/application/src/View/Helper/DataType.php
+++ b/application/src/View/Helper/DataType.php
@@ -38,7 +38,7 @@ class DataType extends AbstractHelper
      *   - Data types organized in option groups
      *
      * @param string $name
-     * @param string $value
+     * @param string|array $value
      * @param array $attributes
      */
     public function getSelect($name, $value = null, $attributes = [])
@@ -74,6 +74,9 @@ class DataType extends AbstractHelper
         $element->setEmptyOption('Default')
             ->setValueOptions($options)
             ->setAttributes($attributes);
+        if (!$element->getAttribute('multiple') && is_array($value)) {
+            $value = reset($value);
+        }
         $element->setValue($value);
         return $this->getView()->formSelect($element);
     }

--- a/application/src/View/Helper/DataType.php
+++ b/application/src/View/Helper/DataType.php
@@ -98,6 +98,22 @@ class DataType extends AbstractHelper
         return $this->manager->get($dataType)->form($this->getView());
     }
 
+    public function getLabel($dataType)
+    {
+        return $this->manager->get($dataType)->getLabel();
+    }
+
+    /**
+     * @param string $dataType
+     * @return \Omeka\DataType\DataTypeInterface|null
+     */
+    public function getDataType($dataType)
+    {
+        return $this->manager->has($dataType)
+            ? $this->manager->get($dataType)
+            : null;
+    }
+
     /**
      * Prepare the view to enable the data types.
      */

--- a/application/view/common/data-type-wrapper.phtml
+++ b/application/view/common/data-type-wrapper.phtml
@@ -1,17 +1,19 @@
 <?php
 $translate = $this->plugin('translate');
 $escape = $this->plugin('escapeHtml');
+$hyperlink = $this->plugin('hyperlink');
 ?>
-<div class="template value" data-data-type="<?php echo $escape($this->dataType); ?>" role="group">
+
+<div class="template value" data-data-type="<?php echo $escape($dataType); ?>" role="group">
     <div class="sortable-handle"></div>
     <div class="input-body"><?php echo $this->dataType()->getTemplate($dataType); ?></div>
     <div class="input-footer">
         <span class="restore-value"><?php echo $translate('Value to be removed'); ?></span>
         <ul class="actions">
-            <li><?php echo $this->hyperlink('', '#', ['class' => 'o-icon-delete remove-value', 'title' => $translate('Remove value')]); ?></li>
-            <li><?php echo $this->hyperlink('' , '#', ['class' => 'o-icon-undo restore-value', 'title' => $translate('Restore value')]); ?></li>
+            <li><?php echo $hyperlink('', '#', ['class' => 'o-icon-delete remove-value', 'title' => $translate('Remove value')]); ?></li>
+            <li><?php echo $hyperlink('', '#', ['class' => 'o-icon-undo restore-value', 'title' => $translate('Restore value')]); ?></li>
             <li>
-                <?php echo $this->hyperlink('' , '#', ['class' => 'value-visibility o-icon-public', 'title' => $translate('Make private'), 'aria-label' => $translate('Make private')]); ?>
+                <?php echo $hyperlink('', '#', ['class' => 'value-visibility o-icon-public', 'title' => $translate('Make private'), 'aria-label' => $translate('Make private')]); ?>
                 <input type="hidden" class="is_public">
             </li>
         </ul>


### PR DESCRIPTION
In order to manage settings (#1619), the resource template form should be event aware (to let modules add new settings) and should manage a collection of resource template property fieldsets, that should be event aware too (let modules add specific ones for properties). 

Because it uses the Zend element Collection for properties, the filtering and  the validation of elements (internal or added by modules) of the property fieldsets are simpler if they are real elements, so a select is added for datatype too.