### PR TITLE
Use resource template settings in resource edit pages

### DIFF
--- a/application/asset/js/resource-form.js
+++ b/application/asset/js/resource-form.js
@@ -246,6 +246,7 @@
         }
         var value = $('.value.template[data-data-type="' + dataType + '"]').clone(true);
         value.removeClass('template');
+        value.attr('data-term', term);
 
         // Get and display the value's visibility.
         var isPublic = true; // values are public by default
@@ -405,6 +406,10 @@
             originalDescription.hide();
         }
 
+        // Store specific settings of this template property.
+        field.attr('data-template-id', templateId);
+        field.data('settings', templateProperty['o:settings'] ? templateProperty['o:settings'] : {});
+
         // Remove any unchanged default values for this property so we start fresh.
         field.find('.value.default-value').remove();
 
@@ -438,6 +443,11 @@
         var templateId = templateSelect.val();
         var fields = $('#properties .resource-values');
 
+        // Reset settings of the previous template.
+        $('#resource-values').data('template-settings', {});
+        fields.attr('data-template-id', '');
+        fields.data('settings', {});
+
         // Fieldsets may have been marked as required or private in a previous state.
         fields.removeClass('required');
         fields.removeClass('private');
@@ -459,6 +469,9 @@
                             classSelect.trigger('chosen:updated');
                         }
                     }
+
+                    // Store global settings of the template.
+                    $('#resource-values').data('template-settings', data['o:settings'] ? data['o:settings'] : {});
 
                     // Rewrite every property field defined by the template. We
                     // reverse the order so property fields on page that are not

--- a/application/asset/js/resource-form.js
+++ b/application/asset/js/resource-form.js
@@ -10,6 +10,7 @@
             var field = $('[data-property-term = "' + term + '"].field');
             if (!field.length) {
                 field = makeNewField(property);
+                field.addClass('user-added');
             }
             $('#property-selector').removeClass('mobile');
             Omeka.scrollTo(field);
@@ -490,10 +491,9 @@
         }
 
         function finalize() {
-            // Remove empty properties, except the templates ones.
-            // TODO Keep properties selected by user (remove the "default-value"?).
+            // Remove empty fields, except the templates and user added ones, to avoid mix of templates fields.
             fields = templateId ? $('#properties .resource-values[data-template-id!="' + templateId + '"]') : $('#properties .resource-values');
-            fields.each(function() {
+            fields.not('.user-added').each(function() {
                 if ($(this).find('.inputs .values > .value').length === $(this).find('.inputs .values > .value.default-value').length) {
                     $(this).remove();
                 }
@@ -504,7 +504,7 @@
                 makeDefaultTemplate();
             }
 
-            // Add a default value if none already exist in the property.
+            // Add a default empty value if none already exist in the property.
             fields = $('#properties .resource-values');
             fields.each(function(index, field) {
                 field = $(field);

--- a/application/asset/js/resource-form.js
+++ b/application/asset/js/resource-form.js
@@ -245,7 +245,7 @@
         }
         var value = $('.value.template[data-data-type="' + dataType + '"]').clone(true);
         value.removeClass('template');
-        value.data('data-term', term);
+        value.data('term', term);
 
         // Get and display the value's visibility.
         var isPublic = true; // values are public by default

--- a/application/asset/js/resource-form.js
+++ b/application/asset/js/resource-form.js
@@ -516,6 +516,8 @@
             });
 
             fields.find('input.value-language').each(initValueLanguage);
+
+            $('#properties').closest('form').trigger('o:template-applied');
         };
     }
 

--- a/application/asset/js/resource-form.js
+++ b/application/asset/js/resource-form.js
@@ -182,6 +182,7 @@
                     errors.push('The following field is required: ' + propLabel);
                 }
             });
+            thisForm.data('has-error', errors.length > 0);
             if (errors.length) {
                 e.preventDefault();
                 alert(errors.join("\n"));

--- a/application/asset/js/resource-form.js
+++ b/application/asset/js/resource-form.js
@@ -229,7 +229,6 @@
     var makeDefaultValue = function (term, dataType) {
         return makeNewValue(term, dataType)
             .addClass('default-value')
-            // FIXME When the template is removed clicking directly on the cross, this event is skipped, so the content is removed.
             .one('change', '*', function (event) {
                 $(event.delegateTarget).removeClass('default-value');
             });
@@ -246,7 +245,7 @@
         }
         var value = $('.value.template[data-data-type="' + dataType + '"]').clone(true);
         value.removeClass('template');
-        value.attr('data-term', term);
+        value.data('data-term', term);
 
         // Get and display the value's visibility.
         var isPublic = true; // values are public by default

--- a/application/view/omeka/admin/item-set/sidebar-select.phtml
+++ b/application/view/omeka/admin/item-set/sidebar-select.phtml
@@ -5,39 +5,39 @@ $hyperlink = $this->plugin('hyperlink');
 $itemSetsFound = count($itemSets) > 0;
 ?>
 
-<h3><?php echo $translate('Select item set'); ?></h3>
-<div class="search-nav">
-    <div id="sidebar-resource-search" class="resource-search" data-search-url="<?php echo $escape($this->url(null, [], [], true)); ?>">
-        <input type="text" name="search" value="<?php echo $escape($searchValue); ?>" id="resource-list-search">
-        <button type="button" class="o-icon-search"><?php echo $translate('Search'); ?></button>
-    </div>
-    <?php if ($itemSetsFound): ?>
-        <?php echo $this->pagination('common/sidebar-pagination.phtml'); ?>
-    <?php endif; ?>
-</div>
-
-<div class="resource-list">
-    <?php if ($itemSetsFound): ?>
-        <?php
-        foreach ($itemSets as $itemSet): ?>
-        <div class="resource item-set">
-            <?php
-            $content = sprintf(
-                '%s<span class="resource-name">%s</span>',
-                $this->thumbnail($itemSet, 'square'),
-                $escape($itemSet->displayTitle())
-            );
-            echo $hyperlink->raw($content, '#', [
-                'class' => 'sidebar-content select-resource resource-link',
-                'data-sidebar-content-url' => $itemSet->url('show-details'),
-                'data-sidebar-selector' => '#resource-details',
-            ]);
-            ?>
+<div id="item-set-results">
+    <h3><?php echo $translate('Select item set'); ?></h3>
+    <div class="search-nav">
+        <div id="sidebar-resource-search" class="resource-search" data-search-url="<?php echo $escape($this->url(null, [], [], true)); ?>">
+            <input type="text" name="search" value="<?php echo $escape($searchValue); ?>" id="resource-list-search">
+            <button type="button" class="o-icon-search"><?php echo $translate('Search'); ?></button>
         </div>
-        <?php endforeach; ?>
-    <?php else: ?>
-        <span class="no-resources"><?php echo $translate(sprintf('No %s found.', $translate('item sets'))); ?></span>
-    <?php endif; ?>
+        <?php if ($itemSetsFound): ?>
+            <?php echo $this->pagination('common/sidebar-pagination.phtml'); ?>
+        <?php endif; ?>
+    </div>
+
+    <div class="resource-list">
+        <?php if ($itemSetsFound): ?>
+            <?php
+            foreach ($itemSets as $itemSet): ?>
+            <div class="resource item-set">
+                <?php
+                $content = sprintf(
+                    '%s<span class="resource-name">%s</span>',
+                    $this->thumbnail($itemSet, 'square'),
+                    $escape($itemSet->displayTitle())
+                );
+                echo $hyperlink->raw($content, '#', [
+                    'class' => 'sidebar-content select-resource resource-link',
+                    'data-sidebar-content-url' => $itemSet->url('show-details'),
+                    'data-sidebar-selector' => '#resource-details',
+                ]);
+                ?>
+            </div>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <span class="no-resources"><?php echo $translate(sprintf('No %s found.', $translate('item sets'))); ?></span>
+        <?php endif; ?>
+    </div>
 </div>
-
-

--- a/application/view/omeka/admin/media/sidebar-select.phtml
+++ b/application/view/omeka/admin/media/sidebar-select.phtml
@@ -5,36 +5,38 @@ $hyperlink = $this->plugin('hyperlink');
 $mediaFound = count($media) > 0;
 ?>
 
-<h3><?php echo $translate('Select media'); ?></h3>
-<div class="search-nav">
-    <div id="sidebar-resource-search" class="resource-search" data-search-url="<?php echo $escape($this->url(null, [], [], true)); ?>">
-        <input type="text" name="search" value="<?php echo $escape($searchValue); ?>" id="resource-list-search">
-        <button type="button" class="o-icon-search"><?php echo $translate('Search'); ?></button>
-    </div>
-    <?php if ($mediaFound): ?>
-    <?php echo $this->pagination('common/sidebar-pagination.phtml'); ?>
-    <?php endif; ?>
-</div>
-
-<div class="resource-list">
-    <?php if ($mediaFound): ?>
-        <?php foreach ($media as $m):?>
-        <div class="resource item-set">
-            <?php
-            $content = sprintf(
-                '%s<span class="resource-name">%s</span>',
-                $this->thumbnail($m, 'square'),
-                $escape($m->displayTitle())
-            );
-            echo $hyperlink->raw($content, '#', [
-                'class' => 'sidebar-content select-resource resource-link',
-                'data-sidebar-content-url' => $m->url('show-details'),
-                'data-sidebar-selector' => '#resource-details',
-            ]);
-            ?>
+<div id="media-results">
+    <h3><?php echo $translate('Select media'); ?></h3>
+    <div class="search-nav">
+        <div id="sidebar-resource-search" class="resource-search" data-search-url="<?php echo $escape($this->url(null, [], [], true)); ?>">
+            <input type="text" name="search" value="<?php echo $escape($searchValue); ?>" id="resource-list-search">
+            <button type="button" class="o-icon-search"><?php echo $translate('Search'); ?></button>
         </div>
-        <?php endforeach; ?>
-    <?php else: ?>
-        <span class="no-resources"><?php echo $translate(sprintf('No %s found.', $translate('media'))); ?></span>
-    <?php endif; ?>
+        <?php if ($mediaFound): ?>
+        <?php echo $this->pagination('common/sidebar-pagination.phtml'); ?>
+        <?php endif; ?>
+    </div>
+
+    <div class="resource-list">
+        <?php if ($mediaFound): ?>
+            <?php foreach ($media as $m):?>
+            <div class="resource item-set">
+                <?php
+                $content = sprintf(
+                    '%s<span class="resource-name">%s</span>',
+                    $this->thumbnail($m, 'square'),
+                    $escape($m->displayTitle())
+                );
+                echo $hyperlink->raw($content, '#', [
+                    'class' => 'sidebar-content select-resource resource-link',
+                    'data-sidebar-content-url' => $m->url('show-details'),
+                    'data-sidebar-selector' => '#resource-details',
+                ]);
+                ?>
+            </div>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <span class="no-resources"><?php echo $translate(sprintf('No %s found.', $translate('media'))); ?></span>
+        <?php endif; ?>
+    </div>
 </div>


### PR DESCRIPTION
In fact, only the js is updated to make the settings working in resource edit pages, so this pr is not based on #1622. So it cleans and factorizes some parts of the code in order to be able to apply the settings in all cases, and add a new trigger "o:template-applied" in order to be able to let modules to know when a template is applied. It can be merged with the event "o:form-loaded" if needed, because to load or remove a template is nearly the same.