### PR TITLE
Fixed svg media types for assets.

### DIFF
--- a/application/src/Api/Adapter/AssetAdapter.php
+++ b/application/src/Api/Adapter/AssetAdapter.php
@@ -9,7 +9,7 @@ use Omeka\Stdlib\ErrorStore;
 
 class AssetAdapter extends AbstractEntityAdapter
 {
-    const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/svg', 'image/svgz'];
+    const ALLOWED_MEDIA_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/svg', 'image/svgz', 'image/svg+xml'];
 
     protected $sortFields = [
         'id' => 'id',


### PR DESCRIPTION
This is a request that was integrated in 2.1.2 (#1583), but not in the dev version. It may depend on a future merge anyway.