### PR TITLE
Trimmed vocabulary metadata in adapter.

### DIFF
--- a/application/src/Api/Adapter/VocabularyAdapter.php
+++ b/application/src/Api/Adapter/VocabularyAdapter.php
@@ -72,13 +72,13 @@ class VocabularyAdapter extends AbstractEntityAdapter
         $this->hydrateOwner($request, $entity);
 
         if ($this->shouldHydrate($request, 'o:namespace_uri')) {
-            $entity->setNamespaceUri($request->getValue('o:namespace_uri'));
+            $entity->setNamespaceUri(trim($request->getValue('o:namespace_uri')));
         }
         if ($this->shouldHydrate($request, 'o:prefix')) {
-            $entity->setPrefix($request->getValue('o:prefix'));
+            $entity->setPrefix(trim($request->getValue('o:prefix')));
         }
         if ($this->shouldHydrate($request, 'o:label')) {
-            $entity->setLabel($request->getValue('o:label'));
+            $entity->setLabel(trim($request->getValue('o:label')));
         }
         if ($this->shouldHydrate($request, 'o:comment')) {
             $entity->setComment($request->getValue('o:comment'));


### PR DESCRIPTION
When a vocabulary is customized manually during import, there may be an added space in the prefix, so it creates some issues, and it can't be fixed by the user in the vocabulary form. So a trim is added in the adapter.