### PR TITLE
Get values of different types in one time.

### DIFF
--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -309,8 +309,9 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
      *
      * @param string $term The prefix:local_part
      * @param array $options
-     * - type: (null) Get values of this type only. Valid types are "literal",
-     *   "uri", and "resource". Returns all types by default.
+     * - type (array|string): Get values of these types only. Default types are
+     *   "literal", "uri", "resource", "resource:item", "resource:media" and
+     *   "resource:itemset". Returns all types by default.
      * - all: (false) If true, returns all values that match criteria. If false,
      *   returns the first matching value.
      * - default: (null) Default value if no values match criteria. Returns null
@@ -322,9 +323,6 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
     public function value($term, array $options = [])
     {
         // Set defaults.
-        if (!isset($options['type'])) {
-            $options['type'] = null;
-        }
         if (!isset($options['all'])) {
             $options['all'] = false;
         }
@@ -343,12 +341,18 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
             return $options['default'];
         }
 
+        if (empty($options['type'])) {
+            $types = false;
+        } elseif (is_array($options['type'])) {
+            $types = $options['type'];
+        } else {
+            $types = [$options['type']];
+        }
+
         // Match only the representations that fit all the criteria.
         $matchingValues = [];
         foreach ($this->values()[$term]['values'] as $value) {
-            if (!is_null($options['type'])
-                && $value->type() !== $options['type']
-            ) {
+            if ($types && !in_array($value->type(), $types)) {
                 continue;
             }
             if (!is_null($options['lang'])


### PR DESCRIPTION
It will be useful to get value of different types with `resource->value()`, for example to get all resources and all uris at the same time. The main issue here are the types `resource`, `resource:item`, `resource:itemset` and `resource:media`. If I need all linked items, I should get all `resource`, filter them, then get all `resource:item`. This pr avoids two calls, but not the filter. 

In fact, the type `resource` should not be used in the database, only `resource:item`. It is only a shortcut to use in the resource template. So when a link `resource` is saved, it should be saved with the type of the resource. I added an automatic conversion in the [BulkEdit](https://github.com/Daniel-KM/Omeka-S-module-BulkEdit) module, but it should be done during the migration to Omeka S 3. I can pr the small js change and the migration file if you think it's a good thing. 