### PR TITLE
Translate linked resources alternate labels and classes

### DIFF
--- a/application/view/common/linked-resources.phtml
+++ b/application/view/common/linked-resources.phtml
@@ -44,12 +44,12 @@ $pagination->setFragment($fragment);
         <td><?php echo $value->resource()->linkPretty(); ?></td>
         <td>
         <?php if ($altLabel): ?>
-        <span class="alternate-label"><?php echo $this->escapeHtml($altLabel); ?></span>
+        <span class="alternate-label"><?php echo $translate($this->escapeHtml($altLabel)); ?></span>
         <?php endif; ?>
         </td>
         <td>
         <?php if ($value->resource()->resourceClass()): ?>
-        <span class="resource-class"><?php echo $this->escapeHtml($value->resource()->resourceClass()->label()); ?></span>
+        <span class="resource-class"><?php echo $translate($this->escapeHtml($value->resource()->resourceClass()->label())); ?></span>
         <?php endif; ?>
         </td>
     </tr>


### PR DESCRIPTION
Hello

Linked resources listed on item show pages often have translated class names. The same goes with alternate labels.
This PR adds translator calls on those labels.

Best regards

Laurent