### PR TITLE
Allowed to search by id with api endpoint.

### DIFF
--- a/application/src/Controller/ApiController.php
+++ b/application/src/Controller/ApiController.php
@@ -229,18 +229,16 @@ class ApiController extends AbstractRestfulController
     /**
      * Check if the request contains an identifier.
      *
-     * This method overrides parent in order to allow to query on ids.
+     * This method overrides parent in order to allow to query on one or
+     * multiple ids.
      *
      * {@inheritDoc}
      * @see \Laminas\Mvc\Controller\AbstractRestfulController::getIdentifier()
      */
     protected function getIdentifier($routeMatch, $request)
     {
-        $id = parent::getIdentifier($routeMatch, $request);
-        // When the id is an array, it is a query with one or multiple ids.
-        return is_array($id)
-            ? false
-            : $id;
+        $identifier = $this->getIdentifierName();
+        return $routeMatch->getParam($identifier, false);
     }
 
     /**

--- a/application/src/Controller/ApiController.php
+++ b/application/src/Controller/ApiController.php
@@ -227,6 +227,23 @@ class ApiController extends AbstractRestfulController
     }
 
     /**
+     * Check if the request contains an identifier.
+     *
+     * This method overrides parent in order to allow to query on ids.
+     *
+     * {@inheritDoc}
+     * @see \Laminas\Mvc\Controller\AbstractRestfulController::getIdentifier()
+     */
+    protected function getIdentifier($routeMatch, $request)
+    {
+        $id = parent::getIdentifier($routeMatch, $request);
+        // When the id is an array, it is a query with one or multiple ids.
+        return is_array($id)
+            ? false
+            : $id;
+    }
+
+    /**
      * Set an error result to the MvcEvent and return the result.
      *
      * @param MvcEvent $event


### PR DESCRIPTION
In internal api, it is possible now to search with a list of ids. It is not possible by endpoint, so this fixes it.