### PR TITLE
Support text/json+oembed (Soundclound)

### DIFF
--- a/application/src/Media/Ingester/OEmbed.php
+++ b/application/src/Media/Ingester/OEmbed.php
@@ -77,7 +77,7 @@ class OEmbed implements IngesterInterface
 
         $document = $response->getBody();
         $dom = new Query($document);
-        $oEmbedLinks = $dom->queryXpath('//link[@rel="alternate" or @rel="alternative"][@type="application/json+oembed"]');
+        $oEmbedLinks = $dom->queryXpath('//link[@rel="alternate" or @rel="alternative"][@type="application/json+oembed" or @type="text/json+oembed"]');
         if (!count($oEmbedLinks)) {
             $errorStore->addError('o:source', 'No OEmbed links were found at the given URI');
             return;


### PR DESCRIPTION
Hi, 
I tried to embed a _Soundcloud_ link and the the oEmbed directive was not found.
I noticed that they use the type`text/json+oembed` instead of `application/json+oembed`.
After applying the following fix, Soundcloud embedding works.

/Avner