### PR TITLE
Fixed search with boolean arguments.

### DIFF
--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -76,7 +76,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             }
         }
 
-        if (isset($query['is_public'])) {
+        if (isset($query['is_public']) && is_numeric($query['is_public'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.isPublic',
                 $this->createNamedParameter($qb, (bool) $query['is_public'])

--- a/application/src/Api/Adapter/SiteAdapter.php
+++ b/application/src/Api/Adapter/SiteAdapter.php
@@ -298,7 +298,7 @@ class SiteAdapter extends AbstractEntityAdapter
             ));
         }
 
-        if (isset($query['assign_new_items'])) {
+        if (isset($query['assign_new_items']) && is_numeric($query['assign_new_items'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.assignNewItems',
                 $this->createNamedParameter($qb, (bool) $query['assign_new_items'])

--- a/application/src/Api/Adapter/SitePageAdapter.php
+++ b/application/src/Api/Adapter/SitePageAdapter.php
@@ -71,7 +71,7 @@ class SitePageAdapter extends AbstractEntityAdapter implements FulltextSearchabl
             ));
         }
 
-        if (isset($query['is_public'])) {
+        if (isset($query['is_public']) && is_numeric($query['is_public'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.isPublic',
                 $this->createNamedParameter($qb, (bool) $query['is_public'])


### PR DESCRIPTION
When we do an api query with `?…&is_public=0&…` or `?…&is_public=1&…`, it works fine, but sometime the value is `?…&is_public=&…`, it doesn't work, because the empty value `""` is not skipped as a null value, but converted into 0, so private. 

This issue is already fixed for [user is_active](https://github.com/omeka/omeka-s/blob/develop/application/src/Api/Adapter/UserAdapter.php#L95), or [media](https://github.com/omeka/omeka-s/blob/develop/application/src/Api/Adapter/MediaAdapter.php#L44-L72), etc., but not for the resources and the site pages.