### PR TITLE
Allowed to authenticate via local session for api requests (fix #1613).

### DIFF
--- a/application/src/Mvc/MvcListeners.php
+++ b/application/src/Mvc/MvcListeners.php
@@ -263,8 +263,9 @@ class MvcListeners extends AbstractListenerAggregate
             return;
         }
 
-        $identity = $event->getRequest()->getQuery('key_identity');
-        $credential = $event->getRequest()->getQuery('key_credential');
+        $request = $event->getRequest();
+        $identity = $request->getQuery('key_identity');
+        $credential = $request->getQuery('key_credential');
 
         if (is_null($identity) || is_null($credential)) {
             // No identity/credential key to authenticate against.
@@ -273,8 +274,9 @@ class MvcListeners extends AbstractListenerAggregate
 
         $auth = $event->getApplication()->getServiceManager()
             ->get('Omeka\AuthenticationService');
-        $auth->getAdapter()->setIdentity($identity);
-        $auth->getAdapter()->setCredential($credential);
+        $auth->getAdapter()
+            ->setIdentity($identity)
+            ->setCredential($credential);
         $auth->authenticate();
     }
 


### PR DESCRIPTION
This is a simpler way to fix #1613. 
it's included in module [Guest](https://gitlab.com/Daniel-KM/Omeka-S-module-Guest) for now, but probably simpler to manage in core, because it is useful in many current (sidebar, search autocompletion, module [item copy](https://omeka.org/s/modules/ItemCopy/)…) and future cases (ajaxification of the admin user interface).