### PR TITLE
Rejected Google Chrome flock tracking

### DIFF
--- a/.htaccess.dist
+++ b/.htaccess.dist
@@ -36,3 +36,7 @@ RewriteRule ^(.*)$ %{ENV:BASE}/index.php [E=OMEKA_REQ:"1",L]
         Deny from all
     </IfModule>
 </FilesMatch>
+
+<IfModule mod_headers.c>
+    Header always set Permissions-Policy: interest-cohort=()
+</IfModule>


### PR DESCRIPTION
This adds a HTTP header to the site to invite Google not to track visitors with a flock identifier via Chrome and derivative browsers.

Indeed, with the new versions of Chrome and derivative browsers, Google steals directly your browsing history even if you forbid it, creates a profile, and gives access to it to any other tracking tool via a unique flock identifier.

Of course, this tracking is currently illegal in most of the countries, whatever Google says, but now this header is required to invite Google to respect the law (there will be a small fine in some years). More information to [clean up the web](https://cleanuptheweb.org) or [in French](https://framablog.org/2021/04/20/developpeurs-developpeuses-nettoyez-le-web).

You can check your current browser on [amifloced.org](https://amifloced.org).

The module [No Google Chrome Flock Tracking](https://gitlab.com/Daniel-KM/Omeka-S-module-NoGoogleChromeFlockTracking) does the same, but it's more secure to include it in core.
