### PR TITLE
Improved the link to browse resources in user bar.

### DIFF
--- a/application/src/View/Helper/UserBar.php
+++ b/application/src/View/Helper/UserBar.php
@@ -141,7 +141,7 @@ class UserBar extends AbstractHelper
                 'resource' => $controller,
                 'action' => 'browse',
                 'text' => $translate($mapPluralLabels[$controller]),
-                'url' => $url('admin/default', ['controller' => $controller]),
+                'url' => $url('admin/default', ['controller' => $controller], ['query' => ['site_id' => $site->id()]]),
             ];
 
             if ($id) {


### PR DESCRIPTION
The link to the items should be limited to the current site items.

Another issue: when the site title is long, the user bar is not pretty, but @kimisgold will fix it better than me.