### PR TITLE
Show Locale Label setting

### DIFF
--- a/application/src/Form/SiteSettingsForm.php
+++ b/application/src/Form/SiteSettingsForm.php
@@ -128,12 +128,12 @@ class SiteSettingsForm extends Form
             'name' => 'show_locale_label',
             'type' => 'checkbox',
             'options' => [
-                'label' => 'Show values locale labels', // @translate
+                'label' => 'Show locale labels for values', // @translate
                 'info' => 'Check to show locale labels in front of properties values when applicable. Leave unchecked to hide those labels.',
             ],
             'attributes' => [
                 'id' => 'show_locale_label',
-                'value' => (bool) $settings->get('show_locale_label', false),
+                'value' => (bool) $settings->get('show_locale_label', true),
             ],
         ]);
 

--- a/application/src/Form/SiteSettingsForm.php
+++ b/application/src/Form/SiteSettingsForm.php
@@ -124,6 +124,19 @@ class SiteSettingsForm extends Form
             ],
         ]);
 
+        $generalFieldset->add([
+            'name' => 'show_locale_label',
+            'type' => 'checkbox',
+            'options' => [
+                'label' => 'Show values locale labels', // @translate
+                'info' => 'Check to show locale labels in front of properties values when applicable. Leave unchecked to hide those labels.',
+            ],
+            'attributes' => [
+                'id' => 'show_locale_label',
+                'value' => (bool) $settings->get('show_locale_label', false),
+            ],
+        ]);
+
         // Browse section
         $this->add([
             'type' => 'fieldset',

--- a/application/view/common/resource-values.phtml
+++ b/application/view/common/resource-values.phtml
@@ -2,7 +2,7 @@
 $translate = $this->plugin('translate');
 $escape = $this->plugin('escapeHtml');
 $labelInfo = $this->setting('property_label_information');
-$showLocale = (bool) $this->siteSetting('show_locale_label');
+$showLocale = (bool) $this->siteSetting('show_locale_label', true);
 ?>
 <?php foreach ($values as $term => $propertyData): ?>
     <div class="property">

--- a/application/view/common/resource-values.phtml
+++ b/application/view/common/resource-values.phtml
@@ -2,6 +2,7 @@
 $translate = $this->plugin('translate');
 $escape = $this->plugin('escapeHtml');
 $labelInfo = $this->setting('property_label_information');
+$showLocale = (bool) $this->siteSetting('show_locale_label');
 ?>
 <?php foreach ($values as $term => $propertyData): ?>
     <div class="property">
@@ -33,7 +34,7 @@ $labelInfo = $this->setting('property_label_information');
             }
             ?>
             <div class="<?php echo implode(' ', $class); ?>" lang="<?php echo $escape($value->lang()); ?>">
-                <?php if ($language = $value->lang()): ?>
+                <?php if ($showLocale && ($language = $value->lang())): ?>
                 <span class="language"><?php echo $language; ?></span>
                 <?php endif; ?>
                 <?php echo $value->asHtml(); ?>


### PR DESCRIPTION
New site setting "Show values locale labels": this conditionally shows or hides the language label on item-sets browse and item show views.
Useful when combined with #1692.