### PR TITLE
Introduce a valuesFiltered member method in AbstractResourceEntityRepresentation

### DIFF
--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -364,21 +364,23 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
             }
             $filteredValues[$term] = $values[$term];
 
-            $matchingValues = [];
-            foreach ($filteredValues[$term]['values'] as $value) {
-                if ($types && empty($types[strtolower($value->type())])) {
-                    continue;
+            if ($langs || $types) {
+                $matchingValues = [];
+                foreach ($filteredValues[$term]['values'] as $value) {
+                    if ($types && empty($types[strtolower($value->type())])) {
+                        continue;
+                    }
+                    if ($langs && empty($langs[strtolower($value->lang())])) {
+                        continue;
+                    }
+                    $matchingValues[] = $value;
                 }
-                if ($langs && empty($langs[strtolower($value->lang())])) {
-                    continue;
-                }
-                $matchingValues[] = $value;
-            }
 
-            if (!count($matchingValues)) {
-                unset($filteredValues[$term]);
-            } else {
-                $filteredValues[$term]['values'] = $matchingValues;
+                if (!count($matchingValues)) {
+                    unset($filteredValues[$term]);
+                } else {
+                    $filteredValues[$term]['values'] = $matchingValues;
+                }
             }
         }
 


### PR DESCRIPTION
Continuing this discussion: https://github.com/omeka/omeka-s/pull/1692#issuecomment-859936488

This implementation provides a unique method to implement value filters, instead of having view-specific filters live along with those in `value()`.