### PR TITLE
Display linked resources titles as body value instead of URI in Browse and Browse Preview

### DIFF
--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -557,8 +557,10 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
             $descriptionTerm = 'dcterms:description';
         }
 
-        if ($lang !== null) {
-            if ($descriptionValue = $this->value($descriptionTerm, ['default' => $default, 'lang' => $lang])) {
+        if ($descriptionValue = $this->value($descriptionTerm, ['default' => $default, 'lang' => $lang])) {
+            if (!empty($descriptionValue->valueResource())) {
+                $description = $descriptionValue->valueResource()->displayTitle(null, $lang);
+            } else {
                 $description = (string) $descriptionValue->value();
             }
         }

--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -559,14 +559,10 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
 
         if ($descriptionValue = $this->value($descriptionTerm, ['default' => $default, 'lang' => $lang])) {
             if (!empty($descriptionValue->valueResource())) {
-                $description = $descriptionValue->valueResource()->displayTitle(null, $lang);
+                $description = $descriptionValue->valueResource()->displayTitle($default, $lang);
             } else {
                 $description = (string) $descriptionValue->value();
             }
-        }
-
-        if ($description === null) {
-            $description = (string) $this->value($descriptionTerm, ['default' => $default]);
         }
 
         $eventManager = $this->getEventManager();

--- a/application/view/common/block-layout/browse-preview.phtml
+++ b/application/view/common/block-layout/browse-preview.phtml
@@ -21,7 +21,10 @@ $lang = $this->lang();
 
 foreach ($this->resources as $resource):
 $heading = $headingTerm ? $resource->value($headingTerm, ['default' => $translate('[Untitled]')]) : $resource->displayTitle(null, ($filterLocale ? $lang : null));
-$body = $bodyTerm ? $resource->value($bodyTerm) : $resource->displayDescription(null, ($filterLocale ? $lang : null));
+$body = false;
+if ($bodyTermValue = $bodyTerm ? $resource->value($bodyTerm, ['lang' => ($filterLocale ? [$lang, ''] : null)]) : $resource->displayDescription(null, ($filterLocale ? [$lang, ''] : null))) {
+    $body = (is_string($bodyTermValue)) ? $bodyTermValue : $bodyTermValue->valueResource()->displayTitle(null, ($filterLocale ? [$lang, ''] : null));
+}
 ?>
     <li class="<?php echo $this->resourceType; ?> resource">
         <?php

--- a/application/view/omeka/site/item-set/browse.phtml
+++ b/application/view/omeka/site/item-set/browse.phtml
@@ -22,9 +22,12 @@ $this->htmlElement('body')->appendAttribute('class', 'item-set resource browse')
 <?php
 $headingTerm = $this->siteSetting('browse_heading_property_term');
 $bodyTerm = $this->siteSetting('browse_body_property_term');
+$body = false;
 foreach ($itemSets as $itemSet):
 $heading = $headingTerm ? $itemSet->value($headingTerm, ['default' => $translate('[Untitled]'), 'lang' => ($filterLocale ? [$lang, ''] : null)]) : $itemSet->displayTitle(null, ($filterLocale ? [$lang, ''] : null));
-$body = $bodyTerm ? $itemSet->value($bodyTerm, ['lang' => ($filterLocale ? [$lang, ''] : null)]) : $itemSet->displayDescription(null, ($filterLocale ? [$lang, ''] : null));
+if ($bodyTermValue = $bodyTerm ? $itemSet->value($bodyTerm, ['lang' => ($filterLocale ? [$lang, ''] : null)]) : $itemSet->displayDescription(null, ($filterLocale ? [$lang, ''] : null))) {
+    $body = (is_string($bodyTermValue)) ? $bodyTermValue : $bodyTermValue->valueResource()->displayTitle(null, ($filterLocale ? [$lang, ''] : null));
+}
 ?>
     <li class="item-set resource">
         <?php if($itemSetThumbnail = $this->thumbnail($itemSet, 'medium')): ?>

--- a/application/view/omeka/site/item/browse.phtml
+++ b/application/view/omeka/site/item/browse.phtml
@@ -59,7 +59,10 @@ $headingTerm = $this->siteSetting('browse_heading_property_term');
 $bodyTerm = $this->siteSetting('browse_body_property_term');
 foreach ($items as $item):
     $heading = $headingTerm ? $item->value($headingTerm, ['default' => $translate('[Untitled]'), 'lang' => ($filterLocale ? [$lang, ''] : null)]) : $item->displayTitle(null, ($filterLocale ? [$lang, ''] : null));
-    $body = $bodyTerm ? $item->value($bodyTerm, ['lang' => ($filterLocale ? [$lang, ''] : null)]) : $item->displayDescription(null, ($filterLocale ? [$lang, ''] : null));
+    $body = false;
+    if ($bodyTermValue = $bodyTerm ? $item->value($bodyTerm, ['lang' => ($filterLocale ? [$lang, ''] : null)]) : $item->displayDescription(null, ($filterLocale ? [$lang, ''] : null))) {
+        $body = (is_string($bodyTermValue)) ? $bodyTermValue : $bodyTermValue->valueResource()->displayTitle(null, ($filterLocale ? [$lang, ''] : null));
+    }
 ?>
     <li class="item resource">
         <?php if ($itemThumbnail = $this->thumbnail($item, 'medium')): ?>


### PR DESCRIPTION
Hello

Continuing the discussion in https://github.com/omeka/omeka-s/pull/1692#issuecomment-859790693 
This actually is a reworked version of #1357, focusing on description only.

When displaying item/item sets in browse view, the default behavior for description values of type `resource:item` is to display the URI for linked resources.

This modifies the behavior:
- for `displayDescription()` by displaying the title of the potential linked resource that serves as description term value
- for site-specific description (body) term, retrieving in the same way the title from the potential linked resource for that term value.

Overall this checks for `$value->resourceValue()`, thus also covering non core value types (e.g. custom vocab).