### PR TITLE
Add the ability to search and sort by resource template label

### DIFF
--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -62,6 +62,18 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             }
         }
 
+        if (isset($query['resource_template_label'])) {
+            $resourceTemplateAlias = $this->createAlias();
+            $qb->innerJoin(
+                'omeka_root.resourceTemplate',
+                $resourceTemplateAlias
+            );
+            $qb->andWhere($qb->expr()->eq(
+                "$resourceTemplateAlias.label",
+                $this->createNamedParameter($qb, $query['resource_template_label']))
+            );
+        }
+
         if (isset($query['resource_template_id'])) {
             $templates = $query['resource_template_id'];
             if (!is_array($templates)) {
@@ -102,6 +114,10 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                 $resourceClassAlias = $this->createAlias();
                 $qb->leftJoin("omeka_root.resourceClass", $resourceClassAlias)
                     ->addOrderBy("$resourceClassAlias.label", $query['sort_order']);
+            } elseif ('resource_template_label' == $query['sort_by']) {
+                $resourceTemplateAlias = $this->createAlias();
+                $qb->leftJoin("omeka_root.resourceTemplate", $resourceTemplateAlias)
+                    ->addOrderBy("$resourceTemplateAlias.label", $query['sort_order']);
             } elseif ('owner_name' == $query['sort_by']) {
                 $ownerAlias = $this->createAlias();
                 $qb->leftJoin("omeka_root.owner", $ownerAlias)


### PR DESCRIPTION
This enables `resource_template_label=foo` and `sort_by=resource_template_label` in the search query, following the pattern set by `resource_class`. It does _not_ add a GUI to search or sort by resource template, given that we don't expose the template anywhere but the resource add/edit pages. This PR is a "nice to have" to complete some minor functionality in the Faceted Browse module. It's not required.