### PR TITLE
Update _screen.scss

### DIFF
--- a/application/asset/sass/_screen.scss
+++ b/application/asset/sass/_screen.scss
@@ -2945,7 +2945,7 @@ input[type="text"].value-language,
         position: relative;
         width: 100%;
         overflow: hidden;
-        display: flex;
+        display: inline-block;
         align-items: center;
         word-wrap: break-word;
 


### PR DESCRIPTION
In the administration items or media view. The title table is all over the place. The text for the title does not align-left properly. Removing the flex attribute fixes this. This is my first contributing but when I made the fix. I had to copy gulpfile.js and package.json inside the application folder from theme view. After npm install I was able to run gulp CSS and now the items, media, and items set title column are pretty again.