### PR TITLE
Check instanceof when validating value resource

### DIFF
--- a/application/src/DataType/Resource/AbstractResource.php
+++ b/application/src/DataType/Resource/AbstractResource.php
@@ -61,7 +61,14 @@ abstract class AbstractResource extends AbstractDataType
             );
         }
         // Limit value resources to those that are valid for the data type.
-        if (!in_array(get_class($valueResource), $this->getValidValueResources())) {
+        $isValid = false;
+        foreach ($this->getValidValueResources() as $validValueResource) {
+            if ($valueResource instanceof $validValueResource) {
+                $isValid = true;
+                break;
+            }
+        }
+        if (!$isValid) {
             $message = new Message(sprintf(
                 'Invalid value resource %s for type %s', // @translate
                 get_class($valueResource),


### PR DESCRIPTION
Before we just checked if the object's class name was in an array of valid
class names. This does not work when the object is a Doctrine proxy. To fix
this, we check if the object is an instanceof one of the valid class names.