### PR TITLE
Allow theme config to set server-side required

### DIFF
--- a/application/src/Controller/SiteAdmin/IndexController.php
+++ b/application/src/Controller/SiteAdmin/IndexController.php
@@ -373,18 +373,14 @@ class IndexController extends AbstractActionController
             $form->add($elementSpec);
         }
 
-        // Fix to manage empty values for selects and multicheckboxes.
+        // Set backend required flag according to client-side attr
+        // (also, handle elements that otherwise default to required)
         $inputFilter = $form->getInputFilter();
         foreach ($form->getElements() as $element) {
-            if ($element instanceof \Laminas\Form\Element\MultiCheckbox
-                || ($element instanceof \Laminas\Form\Element\Select
-                    && $element->getOption('empty_option') !== null)
-            ) {
-                $inputFilter->add([
-                    'name' => $element->getName(),
-                    'allow_empty' => true,
-                ]);
-            }
+            $inputFilter->add([
+                'name' => $element->getName(),
+                'required' => (bool) $element->getAttribute('required'),
+            ]);
         }
 
         $oldSettings = $this->siteSettings()->get($theme->getSettingsKey());


### PR DESCRIPTION
Makes "required" fields more robust, and fixes usage of elements that
Laminas defaults as required (here we're defaulting to not-required).

(fix #1779)