### PR TITLE
Addd block layout template for page title

### DIFF
--- a/application/src/Site/BlockLayout/PageTitle.php
+++ b/application/src/Site/BlockLayout/PageTitle.php
@@ -22,7 +22,7 @@ class PageTitle extends AbstractBlockLayout
     public function render(PhpRenderer $view, SitePageBlockRepresentation $block)
     {
         return $view->partial('common/block-layout/page-title', [
-            'pageTitle' => $view->escapeHtml($block->page()->title()),
+            'pageTitle' => $block->page()->title(),
         ]);
     }
 }

--- a/application/src/Site/BlockLayout/PageTitle.php
+++ b/application/src/Site/BlockLayout/PageTitle.php
@@ -21,6 +21,8 @@ class PageTitle extends AbstractBlockLayout
 
     public function render(PhpRenderer $view, SitePageBlockRepresentation $block)
     {
-        return sprintf('<h2>%s</h2>', $view->escapeHtml($block->page()->title()));
+        return $view->partial('common/block-layout/page-title', [
+            'pageTitle' => $view->escapeHtml($block->page()->title()),
+        ]);
     }
 }

--- a/application/view/common/block-layout/page-title.phtml
+++ b/application/view/common/block-layout/page-title.phtml
@@ -1,0 +1,1 @@
+<h2><?php echo $pageTitle; ?></h2>

--- a/application/view/common/block-layout/page-title.phtml
+++ b/application/view/common/block-layout/page-title.phtml
@@ -1,1 +1,2 @@
-<h2><?php echo $pageTitle; ?></h2>
+<?php $escape = $this->plugin('escapeHtml'); ?>
+<h2><?php echo $escape($pageTitle); ?></h2>


### PR DESCRIPTION
The page title for sites was hardcoded to H2.
Now one can change it to suit their needs.