### PR TITLE
Allow specifying connection URL in the environment

### DIFF
--- a/application/config/application.config.php
+++ b/application/config/application.config.php
@@ -2,6 +2,13 @@
 namespace Omeka;
 
 $reader = new \Laminas\Config\Reader\Ini;
+
+$database = $reader->fromFile(OMEKA_PATH . '/config/database.ini');
+$url = getenv('OMEKA_DB_CONNECTION_URL');
+if ($url) {
+  $database['url'] = $url;
+}
+
 return [
     'modules' => [
         'Laminas\Form',
@@ -29,5 +36,5 @@ return [
             'Omeka\Status' => Service\StatusFactory::class,
         ],
     ],
-    'connection' => $reader->fromFile(OMEKA_PATH . '/config/database.ini'),
+    'connection' => $database,
 ];

--- a/application/config/application.config.php
+++ b/application/config/application.config.php
@@ -3,10 +3,18 @@ namespace Omeka;
 
 $reader = new \Laminas\Config\Reader\Ini;
 
-$database = $reader->fromFile(OMEKA_PATH . '/config/database.ini');
 $url = getenv('OMEKA_DB_CONNECTION_URL');
-if ($url) {
-  $database['url'] = $url;
+
+try {
+  $database = $reader->fromFile(OMEKA_PATH . '/config/database.ini');
+} catch (\Laminas\Config\Exception\RuntimeException $e) {
+  if (!$url) {
+    throw $e;
+  }
+} finally {
+  if ($url) {
+    $database['url'] = $url;
+  }
 }
 
 return [


### PR DESCRIPTION
Since Omeka just passes through these options to the Doctrine DBAL it
didn't seem elegant to give Omeka 'knowledge' of the individual fields.
Instead 'just' allowing to set the URL is sufficient, since fields from
the URL will overwrite the individual settings.

https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#getting-a-connection

Fixes #1765