### PR TITLE
Added options to render datatype.

### DIFF
--- a/application/src/Api/Representation/ValueRepresentation.php
+++ b/application/src/Api/Representation/ValueRepresentation.php
@@ -44,14 +44,15 @@ class ValueRepresentation extends AbstractRepresentation
     /**
      * Return this value for display on a webpage.
      *
+     * @param array|string|null $options If string, the options is the lang.
      * @return string
      */
-    public function asHtml($lang = null)
+    public function asHtml($options = [])
     {
         $view = $this->getServiceLocator()->get('ViewRenderer');
         $eventManager = $this->getEventManager();
         $args = $eventManager->prepareArgs([
-            'html' => $this->dataType->render($view, $this, $lang),
+            'html' => $this->dataType->render($view, $this, is_array($options) ? $options : ['lang' => $options]),
         ]);
         $eventManager->trigger('rep.value.html', $this, $args);
         return $args['html'];

--- a/application/src/DataType/DataTypeInterface.php
+++ b/application/src/DataType/DataTypeInterface.php
@@ -71,9 +71,10 @@ interface DataTypeInterface
      *
      * @param PhpRenderer $view
      * @param ValueRepresentation $value
+     * @param array $options A common option is "lang".
      * @return string
      */
-    public function render(PhpRenderer $view, ValueRepresentation $value);
+    public function render(PhpRenderer $view, ValueRepresentation $value, $options = []);
 
     /**
      * Get the value as a simple string.

--- a/application/src/DataType/Literal.php
+++ b/application/src/DataType/Literal.php
@@ -46,7 +46,7 @@ class Literal extends AbstractDataType
         $value->setValueResource(null); // set default
     }
 
-    public function render(PhpRenderer $view, ValueRepresentation $value)
+    public function render(PhpRenderer $view, ValueRepresentation $value, $options = [])
     {
         return nl2br($view->escapeHtml($value->value()));
     }

--- a/application/src/DataType/Resource/AbstractResource.php
+++ b/application/src/DataType/Resource/AbstractResource.php
@@ -81,9 +81,9 @@ abstract class AbstractResource extends AbstractDataType
         $value->setValueResource($valueResource);
     }
 
-    public function render(PhpRenderer $view, ValueRepresentation $value, $lang = null)
+    public function render(PhpRenderer $view, ValueRepresentation $value, $options = [])
     {
-        return $value->valueResource()->linkPretty('square', null, null, null, $lang);
+        return $value->valueResource()->linkPretty('square', null, null, null, is_array($options) ? $options['lang'] ?? [] : $options);
     }
 
     public function toString(ValueRepresentation $value)

--- a/application/src/DataType/Uri.php
+++ b/application/src/DataType/Uri.php
@@ -49,7 +49,7 @@ class Uri extends AbstractDataType
         $value->setValueResource(null); // set default
     }
 
-    public function render(PhpRenderer $view, ValueRepresentation $value)
+    public function render(PhpRenderer $view, ValueRepresentation $value, $options = [])
     {
         $uri = $value->uri();
         $uriLabel = $value->value();


### PR DESCRIPTION
The datatype for value resource append a new argument to render data with the language, but it is not normalized and some other datatypes may need more option than language. 

So I add the argument as an array, to get similar arguments as rendering medias. For compatibility, if the arg is a string in the datatype ValueResource, it's the lang. 

Anyway, this new argument is not used in real life, because  "filter_locale_values" is generally useless, except if locales are exactly the same than the interface, that is rare. Moreover, it requires to update themes to manage a new attribute. After six monthes, no official themes have been updated to add lang except the integrated one. So the compatibility code can be removed in fact.

About language of the value, it is an important thing, and it was also the purpose of the module [Internationalisation](https://gitlab.com/Daniel-KM/Omeka-S-module-Internationalisation) to manage locales similarly, but in the backend, not in the themes: the designers won't have to take care of the language, they have already a lot to do. So the code from #1692 can be modified to remove the option in the views and to check it the in the representation.