### PR TITLE
Add more events to filter output

### DIFF
--- a/application/src/Api/Representation/AbstractResourceRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceRepresentation.php
@@ -286,8 +286,9 @@ abstract class AbstractResourceRepresentation extends AbstractRepresentation
      */
     public function embeddedJsonLd()
     {
-        echo '<script type="application/ld+json">'
-            . json_encode($this)
-            . '</script>';
+        $eventManager = $this->getEventManager();
+        $args = $eventManager->prepareArgs(['jsonLd' => json_encode($this)]);
+        $eventManager->trigger('rep.resource.json_output', $this, $args);
+        return sprintf('<script type="application/ld+json">%s</script>', $args['jsonLd']);
     }
 }

--- a/application/src/Api/Representation/ValueRepresentation.php
+++ b/application/src/Api/Representation/ValueRepresentation.php
@@ -38,7 +38,12 @@ class ValueRepresentation extends AbstractRepresentation
      */
     public function __toString()
     {
-        return $this->dataType->toString($this);
+        $eventManager = $this->getEventManager();
+        $args = $eventManager->prepareArgs([
+            'string' => $this->dataType->toString($this),
+        ]);
+        $eventManager->trigger('rep.value.string', $this, $args);
+        return $args['string'];
     }
 
     /**
@@ -69,7 +74,12 @@ class ValueRepresentation extends AbstractRepresentation
         if (!is_array($jsonLd)) {
             $jsonLd = [];
         }
-        return $valueObject + $jsonLd;
+        $eventManager = $this->getEventManager();
+        $args = $eventManager->prepareArgs([
+            'json' => $valueObject + $jsonLd,
+        ]);
+        $eventManager->trigger('rep.value.json', $this, $args);
+        return $args['json'];
     }
 
     /**

--- a/application/src/View/Renderer/ApiJsonRenderer.php
+++ b/application/src/View/Renderer/ApiJsonRenderer.php
@@ -2,6 +2,7 @@
 namespace Omeka\View\Renderer;
 
 use Omeka\Api\Exception\ValidationException;
+use Omeka\Api\Representation\RepresentationInterface;
 use Omeka\Api\Response;
 use Laminas\Json\Json;
 use Laminas\View\Renderer\JsonRenderer;
@@ -31,17 +32,26 @@ class ApiJsonRenderer extends JsonRenderer
             return null;
         }
 
-        $jsonpCallback = $model->getOption('callback');
-        if (null !== $jsonpCallback) {
-            // Wrap the JSON in a JSONP callback.
-            $this->setJsonpCallback($jsonpCallback);
-        }
-
         $output = parent::render($payload);
+
+        if ($payload instanceof RepresentationInterface) {
+            $eventManager = $payload->getEventManager();
+            $args = $eventManager->prepareArgs(['jsonLd' => $output]);
+            $eventManager->trigger('rep.resource.json_output', $payload, $args);
+            $output = $args['jsonLd'];
+        }
 
         if (null !== $model->getOption('pretty_print')) {
             // Pretty print the JSON.
             $output = Json::prettyPrint($output);
+        }
+
+        $jsonpCallback = $model->getOption('callback');
+        if (null !== $jsonpCallback) {
+            // Wrap the JSON in a JSONP callback. Normally this would be done
+            // via `$this->setJsonpCallback()` but we don't want to pass the
+            // wrapped string to `rep.resource.json_output` handlers.
+            $output = sprintf('%s(%s)', $jsonpCallback, $output);
         }
 
         return $output;


### PR DESCRIPTION
Provides a way for modules to alter the JSON-LD string immediately before API output. Adds the following event:

### rep.resource.json_output

- **jsonLd**: The JSON-LD string.

All classes that implement `Omeka\Api\Representation\RepresentationInterface` trigger this event.

Triggered immediately before API output. To modify the JSON-LD, listeners may modify the `jsonLd` parameter and set it back to the event.

