### PR TITLE
Allow theme to overwrite ckeditor config

### DIFF
--- a/application/src/View/Helper/CkEditor.php
+++ b/application/src/View/Helper/CkEditor.php
@@ -14,7 +14,7 @@ class CkEditor extends AbstractHelper
     public function __invoke()
     {
         $view = $this->getView();
-        $customConfigUrl = $view->escapeJs($view->assetUrl('js/ckeditor_config.js', 'Omeka'));
+        $customConfigUrl = $view->escapeJs($view->assetUrl('js/ckeditor_config.js', 'Omeka', true));
         $view->headScript()->appendFile($view->assetUrl('vendor/ckeditor/ckeditor.js', 'Omeka'));
         $view->headScript()->appendFile($view->assetUrl('vendor/ckeditor/adapters/jquery.js', 'Omeka'));
         $view->headScript()->appendScript("CKEDITOR.config.customConfig = '$customConfigUrl'");


### PR DESCRIPTION
This is a small but rather important change IMHO, as now one can set theme specific styles etc. for ckeditor (i.e. the default style settings do not make to much sense for a specific theme and maybe somebody wants more or less tools in the toolbar).