### PR TITLE
Allow to pass return_scalar to the REST API (getList)

### DIFF
--- a/application/src/Controller/ApiController.php
+++ b/application/src/Controller/ApiController.php
@@ -72,7 +72,15 @@ class ApiController extends AbstractRestfulController
         }
 
         $query = $this->params()->fromQuery();
-        $response = $this->api->search($resource, $query);
+
+        $options = [
+            'responseContent' => $query['response_content'] ?? 'representation',
+            'returnScalar' => $query['return_scalar'] ?? false,
+        ];
+        unset($query['response_content']);
+        unset($query['return_scalar']);
+
+        $response = $this->api->search($resource, $query, $options);
 
         $this->paginator->setCurrentPage($query['page']);
         if (isset($query['per_page'])) {

--- a/application/src/Controller/ApiController.php
+++ b/application/src/Controller/ApiController.php
@@ -74,10 +74,8 @@ class ApiController extends AbstractRestfulController
         $query = $this->params()->fromQuery();
 
         $options = [
-            'responseContent' => $query['response_content'] ?? 'representation',
             'returnScalar' => $query['return_scalar'] ?? false,
         ];
-        unset($query['response_content']);
         unset($query['return_scalar']);
 
         $response = $this->api->search($resource, $query, $options);


### PR DESCRIPTION
Sometimes we don't need the full representation of the resource,
sometimes we only want the title or the id.
Having these options available allow fast response times for such cases

A practical use case is this:
- All public items are harvested into another database using module OaiPmhRepository
- New and updated items are kept in sync regularly.
The problem is OaiPmhRepository (or Omeka S) does not keep track of deleted items, or items that go from public to private. Being able to obtain quickly all items identifiers allow to know which previously harvested items have "disappeared" (deleted or made private) from Omeka, and should be deleted from the other database.

With `return_scalar=id` i can query a page of 10000 ids in 1 second. This would take a lot more time without this parameter.