### PR TITLE
Fix missing translation in search result

### DIFF
--- a/application/view/omeka/site/index/search.phtml
+++ b/application/view/omeka/site/index/search.phtml
@@ -30,14 +30,17 @@ $resourceControllers = [
     <?php foreach ($results as $resourceName => $result): ?>
 <div class="<?php echo $resourceName; ?> results">
     <h2><?php echo $translate($resourceLabels[$resourceName]); ?></h2>
-
-        <?php $titleMethod = $resourceName === 'site_pages' ? 'title' : 'displayTitle'; ?>
     <ul>
         <?php foreach ($result['resources'] as $resource): ?>
         <?php $hasThumbnail = $resource->primaryMedia(); ?>
         <li>
             <?php if (!$hasThumbnail): ?>
-            <?php echo $resource->link($resource->$titleMethod()); ?>
+                <?php if ($resourceName === 'site_pages') {
+                    echo $resource->link($resource->title());
+                } else {
+                    echo $resource->link($resource->displayTitle(null, ($filterLocale ? $lang : null)));
+                }
+                ?>
             <?php else: ?>
             <?php echo $resource->linkPretty('square', null, null, null, ($filterLocale ? $lang : null)); ?>
             <?php endif; ?>

--- a/application/view/omeka/site/index/search.phtml
+++ b/application/view/omeka/site/index/search.phtml
@@ -3,6 +3,9 @@ $translate = $this->plugin('translate');
 $hyperlink = $this->plugin('hyperlink');
 $url = $this->plugin('url');
 $this->htmlElement('body')->appendAttribute('class', 'index search');
+
+$filterLocale = (bool) $this->siteSetting('filter_locale_values');
+$lang = $this->lang();
 ?>
 
 <?php echo $this->pageTitle(sprintf($translate('Search results for “%s”'), $query)); ?>
@@ -36,7 +39,7 @@ $resourceControllers = [
             <?php if (!$hasThumbnail): ?>
             <?php echo $resource->link($resource->$titleMethod()); ?>
             <?php else: ?>
-            <?php echo $resource->linkPretty(); ?>
+            <?php echo $resource->linkPretty('square', null, null, null, ($filterLocale ? $lang : null)); ?>
             <?php endif; ?>
         </li>
         <?php endforeach; ?>


### PR DESCRIPTION
Hello,

The site specific search results should display resource titles according to the selected language, if any. This was caused by a missing modification to a `linkPretty` call in the site/index/search view.

Have a nice day

Laurent