### PR TITLE
Improve helptext for Site thumbnail

### DIFF
--- a/application/src/Form/SiteForm.php
+++ b/application/src/Form/SiteForm.php
@@ -51,7 +51,7 @@ class SiteForm extends Form
             'type' => 'Omeka\Form\Element\Asset',
             'options' => [
                 'label' => 'Thumbnail', // @translate
-                'info' => 'Choose or upload a thumbnail to display with site.', // @translate
+                'info' => 'Choose or upload an image to display with site. The image will be cropped to a square if not already square.', // @translate
             ],
             'attributes' => [
                 'id' => 'thumbnail',


### PR DESCRIPTION
As far as I can see, the thumbnails will always be square, so the helptext should make a note of that.
