### PR TITLE
Mark browse navigation links as active only when paths and queries match

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -757,8 +757,10 @@ return [
         'invokables' => [
             'page' => Site\Navigation\Link\Page::class,
             'url' => Site\Navigation\Link\Url::class,
-            'browse' => Site\Navigation\Link\Browse::class,
             'browseItemSets' => Site\Navigation\Link\BrowseItemSets::class,
+        ],
+        'factories' => [
+            'browse' => Service\Site\Navigation\Link\BrowseFactory::class,
         ],
     ],
     'media_ingesters' => [

--- a/application/src/Service/Site/Navigation/Link/BrowseFactory.php
+++ b/application/src/Service/Site/Navigation/Link/BrowseFactory.php
@@ -1,0 +1,14 @@
+<?php
+namespace Omeka\Service\Site\Navigation\Link;
+
+use Omeka\Site\Navigation\Link\Browse;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Interop\Container\ContainerInterface;
+
+class BrowseFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        return new Browse($services->get('ViewHelperManager'));
+    }
+}

--- a/application/src/Site/Navigation/Link/Browse.php
+++ b/application/src/Site/Navigation/Link/Browse.php
@@ -1,11 +1,20 @@
 <?php
 namespace Omeka\Site\Navigation\Link;
 
+use Laminas\View\HelperPluginManager;
 use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Site\Navigation\Page\UriWithQuery;
 use Omeka\Stdlib\ErrorStore;
 
 class Browse implements LinkInterface
 {
+    protected $viewHelperManager;
+
+    public function __construct(HelperPluginManager $viewHelperManager)
+    {
+        $this->viewHelperManager = $viewHelperManager;
+    }
+
     public function getName()
     {
         return 'Browse'; // @translate
@@ -29,15 +38,14 @@ class Browse implements LinkInterface
 
     public function toZend(array $data, SiteRepresentation $site)
     {
-        parse_str($data['query'], $query);
+        $urlHelper = $this->viewHelperManager->get('url');
         return [
-            'route' => 'site/resource',
-            'params' => [
-                'site-slug' => $site->slug(),
-                'controller' => 'item',
-                'action' => 'browse',
-            ],
-            'query' => $query,
+            'type' => UriWithQuery::class,
+            'uri' => $urlHelper(
+                'site/resource',
+                ['site-slug' => $site->slug(), 'controller' => 'item', 'action' => 'browse'],
+                ['query' => $data['query']],
+            ),
         ];
     }
 

--- a/application/src/Site/Navigation/Page/UriWithQuery.php
+++ b/application/src/Site/Navigation/Page/UriWithQuery.php
@@ -2,6 +2,7 @@
 namespace Omeka\Site\Navigation\Page;
 
 use Laminas\Http\Request;
+use Laminas\Navigation\Page\AbstractPage;
 use Laminas\Navigation\Page\Uri;
 use Laminas\Uri\UriFactory;
 
@@ -30,6 +31,6 @@ class UriWithQuery extends Uri
                 }
             }
         }
-        return parent::isActive($recursive);
+        return AbstractPage::isActive($recursive);
     }
 }

--- a/application/src/Site/Navigation/Page/UriWithQuery.php
+++ b/application/src/Site/Navigation/Page/UriWithQuery.php
@@ -12,22 +12,24 @@ class UriWithQuery extends Uri
     {
         if (!$this->active) {
             if ($this->getRequest() instanceof Request) {
-                $uriCurrent = $this->getRequest()->getUri();
-                $uriCurrentQuery = $uriCurrent->getQueryAsArray();
-                unset($uriCurrentQuery['page'], $uriCurrentQuery['sort_by'], $uriCurrentQuery['sort_order']);
-                $uriCurrent->setQuery($uriCurrentQuery);
-
                 $uriPage = UriFactory::factory($this->getUri());
-                $uriPageQuery = $uriPage->getQueryAsArray();
-                unset($uriPageQuery['page'], $uriPageQuery['sort_by'], $uriPageQuery['sort_order']);
-                $uriPage->setQuery($uriPageQuery);
+                if (!$uriPage->isAbsolute()) {
+                    $uriPageQuery = $uriPage->getQueryAsArray();
+                    unset($uriPageQuery['page'], $uriPageQuery['sort_by'], $uriPageQuery['sort_order']);
+                    $uriPage->setQuery($uriPageQuery);
 
-                $identicalPaths = $uriCurrent->getPath() === $uriPage->getPath();
-                $identicalQueries = $uriCurrent->getQuery() === $uriPage->getQuery();
+                    $uriCurrent = $this->getRequest()->getUri();
+                    $uriCurrentQuery = $uriCurrent->getQueryAsArray();
+                    unset($uriCurrentQuery['page'], $uriCurrentQuery['sort_by'], $uriCurrentQuery['sort_order']);
+                    $uriCurrent->setQuery($uriCurrentQuery);
 
-                if ($identicalPaths && $identicalQueries) {
-                    $this->active = true;
-                    return true;
+                    $identicalPaths = $uriCurrent->getPath() === $uriPage->getPath();
+                    $identicalQueries = $uriCurrent->getQuery() === $uriPage->getQuery();
+
+                    if ($identicalPaths && $identicalQueries) {
+                        $this->active = true;
+                        return true;
+                    }
                 }
             }
         }

--- a/application/src/Site/Navigation/Page/UriWithQuery.php
+++ b/application/src/Site/Navigation/Page/UriWithQuery.php
@@ -1,0 +1,35 @@
+<?php
+namespace Omeka\Site\Navigation\Page;
+
+use Laminas\Http\Request;
+use Laminas\Navigation\Page\Uri;
+use Laminas\Uri\UriFactory;
+
+class UriWithQuery extends Uri
+{
+    public function isActive($recursive = false)
+    {
+        if (!$this->active) {
+            if ($this->getRequest() instanceof Request) {
+                $uriCurrent = $this->getRequest()->getUri();
+                $uriCurrentQuery = $uriCurrent->getQueryAsArray();
+                unset($uriCurrentQuery['page'], $uriCurrentQuery['sort_by'], $uriCurrentQuery['sort_order']);
+                $uriCurrent->setQuery($uriCurrentQuery);
+
+                $uriPage = UriFactory::factory($this->getUri());
+                $uriPageQuery = $uriPage->getQueryAsArray();
+                unset($uriPageQuery['page'], $uriPageQuery['sort_by'], $uriPageQuery['sort_order']);
+                $uriPage->setQuery($uriPageQuery);
+
+                $identicalPaths = $uriCurrent->getPath() === $uriPage->getPath();
+                $identicalQueries = $uriCurrent->getQuery() === $uriPage->getQuery();
+
+                if ($identicalPaths && $identicalQueries) {
+                    $this->active = true;
+                    return true;
+                }
+            }
+        }
+        return parent::isActive($recursive);
+    }
+}


### PR DESCRIPTION
Before, only paths needed to match, making every browse link in navigation active, regardless if they had distinct queries. (#695)