### PR TITLE
Set custom element values to strings on error

### DIFF
--- a/application/src/Controller/Admin/ItemController.php
+++ b/application/src/Controller/Admin/ItemController.php
@@ -295,6 +295,8 @@ class ItemController extends AbstractActionController
                 $this->messenger()->addSuccess('Items successfully edited'); // @translate
                 return $this->redirect()->toRoute(null, ['action' => 'browse'], true);
             } else {
+                $form->get('set_value_visibility')->setValue('');
+                $form->get('value')->setValue('');
                 $this->messenger()->addFormErrors($form);
             }
         }

--- a/application/src/Controller/Admin/ItemController.php
+++ b/application/src/Controller/Admin/ItemController.php
@@ -295,6 +295,8 @@ class ItemController extends AbstractActionController
                 $this->messenger()->addSuccess('Items successfully edited'); // @translate
                 return $this->redirect()->toRoute(null, ['action' => 'browse'], true);
             } else {
+                // Must set the value of these elements to a string because
+                // their POST returns an array, which would result in an error.
                 $form->get('set_value_visibility')->setValue('');
                 $form->get('value')->setValue('');
                 $this->messenger()->addFormErrors($form);

--- a/application/src/Controller/Admin/ItemSetController.php
+++ b/application/src/Controller/Admin/ItemSetController.php
@@ -265,6 +265,10 @@ class ItemSetController extends AbstractActionController
                 $this->messenger()->addSuccess('Item sets successfully edited'); // @translate
                 return $this->redirect()->toRoute(null, ['action' => 'browse'], true);
             } else {
+                // Must set the value of these elements to a string because
+                // their POST returns an array, which would result in an error.
+                $form->get('set_value_visibility')->setValue('');
+                $form->get('value')->setValue('');
                 $this->messenger()->addFormErrors($form);
             }
         }

--- a/application/src/Controller/Admin/MediaController.php
+++ b/application/src/Controller/Admin/MediaController.php
@@ -233,6 +233,10 @@ class MediaController extends AbstractActionController
                 $this->messenger()->addSuccess('Media successfully edited'); // @translate
                 return $this->redirect()->toRoute(null, ['action' => 'browse'], true);
             } else {
+                // Must set the value of these elements to a string because
+                // their POST returns an array, which would result in an error.
+                $form->get('set_value_visibility')->setValue('');
+                $form->get('value')->setValue('');
                 $this->messenger()->addFormErrors($form);
             }
         }


### PR DESCRIPTION
These two elements are custom built in common/property-form-batch-edit.phtml
and will POST arrays. The form knows about the elements via hidden inputs,
which expect strings. If the form has an error, we must set the input values
to empty strings or there will be errors.