### PR TITLE
Validate remaining language inputs

### DIFF
--- a/application/Module.php
+++ b/application/Module.php
@@ -704,6 +704,7 @@ class Module extends AbstractModule
             ->setAttributes([
                 'value' => $view->resource->lang() ?? null,
                 'id' => 'lang',
+                'class' => 'validate-language',
             ]);
         echo $view->formRow($altTextInput);
         echo $view->formRow($langInput);

--- a/application/asset/js/admin.js
+++ b/application/asset/js/admin.js
@@ -196,7 +196,7 @@
 
         $('.batch-edit td input[type="checkbox"]').change(function() {
             if ($('.select-all:checked').length > 0) {
-                $('.select-all').prop('checked', false); 
+                $('.select-all').prop('checked', false);
             }
             Omeka.manageSelectedActions();
         });
@@ -238,6 +238,13 @@
             Omeka.closeOpenPageActionsMenu(e);
         });
 
+        $(document).on('keyup, change', 'input.validate-language', function(e) {
+            if ('' === this.value || Omeka.langIsValid(this.value)) {
+                this.setCustomValidity('');
+            } else {
+                this.setCustomValidity(Omeka.jsTranslate('Please enter a valid language tag'))
+            }
+        });
 
     });
 

--- a/application/asset/js/resource-template-form.js
+++ b/application/asset/js/resource-template-form.js
@@ -96,7 +96,11 @@ propertyList.on('click', '.property-edit', function(e) {
     $('#data-type').trigger('chosen:updated');
 
     // When the sidebar fieldset is applied, store new values in the row.
-    $('#set-changes').off('click.setchanges').on('click.setchanges', function(e) {
+    $('#set-changes').off('click').on('click', function(e) {
+        if (!$('#default-lang').trigger('change')[0].reportValidity()) {
+            // The default language is invalid.
+            return false;
+        }
         altLabel.val($('#alternate-label').val());
         prop.find('.alternate-label-cell').text($('#alternate-label').val());
         altComment.val($('#alternate-comment').val());

--- a/application/src/Form/ResourceBatchUpdateForm.php
+++ b/application/src/Form/ResourceBatchUpdateForm.php
@@ -171,7 +171,7 @@ class ResourceBatchUpdateForm extends Form
                     'name' => 'language',
                     'type' => Element\Text::class,
                     'attributes' => [
-                        'class' => 'value-language active',
+                        'class' => 'validate-language',
                     ],
                     'options' => [
                         'label' => 'Set language', // @translate

--- a/application/view/omeka/admin/resource-template/form.phtml
+++ b/application/view/omeka/admin/resource-template/form.phtml
@@ -95,7 +95,7 @@ $this->headScript()->appendFile($this->assetUrl('js/resource-template-form.js', 
                 <label for="default-lang">
                     <?php echo $translate('Default language'); ?>
                 </label>
-                <input id="default-lang" type="text">
+                <input id="default-lang" type="text" class="validate-language">
             </div>
             <div class="option">
                 <label for="data-type"><?php echo $translate('Data types'); ?></label>


### PR DESCRIPTION
Adds language validation for resource template form, media form, and media batch edit form. Media batch edit already had validation, but using an unrelated JS file. Had to remove event namespace from resource template form because it somehow interfered with `return false`.