### PR TITLE
Added the resource to output of displayValue().

### DIFF
--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -484,9 +484,10 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
         $eventManager = $this->getEventManager();
         $args = $eventManager->prepareArgs(['values' => $this->values()]);
         $eventManager->trigger('rep.resource.display_values', $this, $args);
-        $options['values'] = $args['values'];
 
         $template = $this->resourceTemplate();
+        $options['resource'] = $this;
+        $options['values'] = $args['values'];
         $options['templateProperties'] = $template
             ? $template->resourceTemplateProperties()
             : [];


### PR DESCRIPTION
Often in template display-values, the resource is needed to manage theme specificities, but it is not available directly.