### PR TITLE
After login, redirect to admin only if user is allowed

### DIFF
--- a/application/src/Controller/LoginController.php
+++ b/application/src/Controller/LoginController.php
@@ -60,7 +60,10 @@ class LoginController extends AbstractActionController
                     if ($redirectUrl = $session->offsetGet('redirect_url')) {
                         return $this->redirect()->toUrl($redirectUrl);
                     }
-                    return $this->redirect()->toRoute('admin');
+                    if ($this->userIsAllowed('Omeka\Controller\Admin\Index', 'browse')) {
+                        return $this->redirect()->toRoute('admin');
+                    }
+                    return $this->redirect()->toRoute('top');
                 } else {
                     $this->messenger()->addError('Email or password is invalid'); // @translate
                 }


### PR DESCRIPTION
By default all roles have access to administration dashboard but modules can change permissions or create new roles that forbid access to it. Users with that kind of role should not be redirected to the admin dashboard, as they will land on an error page (with a confusing "Successfully logged in" message)

This patch verify that the user is allowed to see the admin dashboard before redirecting to it. If the user is not allowed, it will be redirected to the front page

To test:
- Install https://omeka.org/s/modules/GuestRole
- Create a user with the role "guest"
- Log out
- Go to /login (do not click on "Admin dashboard" link to go to the login form or you will still be redirected to /admin after login)
- Try to login with the guest user. You should be redirected to the front page
- Log out
- Try to login with an admin user. You should be redirected to the admin dashboard