### PR TITLE
Increased minimal database versions to mysql/8.0.18 and mariadb/10.2.27.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See the [user manual](https://omeka.org/s/docs/user-manual) for more information
 ### Requirements
 * Linux
 * [Apache](https://www.apache.org/) (with [AllowOverride](https://httpd.apache.org/docs/2.4/mod/core.html#allowoverride) set to "All" and [mod_rewrite](http://httpd.apache.org/docs/current/mod/mod_rewrite.html) enabled)
-* [MySQL](https://www.mysql.com/) 5.6.4+ (or [MariaDB](https://mariadb.org/) 10.0.5+)
+* [MySQL](https://www.mysql.com/) 8.0.18+ (or [MariaDB](https://mariadb.org/) 10.2.27+)
 * [PHP](https://www.php.net/) 7.4+ (latest stable version preferred, with [PDO](http://php.net/manual/en/intro.pdo.php), [pdo_mysql](http://php.net/manual/en/ref.pdo-mysql.php), and [xml](http://php.net/manual/en/intro.xml.php) extensions installed)
 
 ### Generating thumbnails

--- a/application/src/Stdlib/Environment.php
+++ b/application/src/Stdlib/Environment.php
@@ -15,12 +15,12 @@ class Environment
     /**
      * The MySQL minimum version
      */
-    const MYSQL_MINIMUM_VERSION = '5.6.4';
+    const MYSQL_MINIMUM_VERSION = '8.0.18';
 
     /**
      * The MariaDB minimum version
      */
-    const MARIADB_MINIMUM_VERSION = '10.0.5';
+    const MARIADB_MINIMUM_VERSION = '10.2.27';
 
     /**
      * The required PHP extensions


### PR DESCRIPTION
Hi,

For next major version, it's probably time to increase the minimal version of the database, like other parts of the environment (php 7.4, 28 nov 2019). Current minimal versions are mysql 5.6.4 (20 dec 2011) and mariadb 10.0.5 (7 nov 2013). 

The versions available in nov 2019 are mysql 8.0.18 and mariadb 10.2.27. So this is the minimum right version to choose. 

In common distributions using php 7.4 by default, there are debian 11 (14 aug 2021) with mariadb 10.5.11 (no mysql ), ubuntu 20.04 lts with mysql 8.0.19 / mariadb 10.3.22, centos 8 / mysql 8.0.26 / mariadb 10.3.28. So, they are the optimal versions to choose.

There are a lot of new feature, in particular optimized json storage and json queries and spatial sql. And the mysql ad says that "mysql 8 is [up two times faster](https://www.mysql.com/products/enterprise/database/)". 

Note that mysql 8.0.18 and mariadb [10.2](https://mariadb.com/kb/en/changes-improvements-in-mariadb-102/) are no more supported. But this is the same for php 7.4 too ([until 28 nov 2022](https://www.php.net/supported-versions.php)).

So this proposition is very conservative, but something more recent will be better.