### PR TITLE
Passed resource and value annotation to template for displayValues().

### DIFF
--- a/application/src/Api/Adapter/ResourceAdapter.php
+++ b/application/src/Api/Adapter/ResourceAdapter.php
@@ -33,7 +33,6 @@ class ResourceAdapter extends AbstractEntityAdapter
      *
      * This version simply proxies to the "real" getRepresentation for each resource's adapter.
      *
-     * @param string|int $id The unique identifier of the resource
      * @param mixed $data Whatever data is needed to compose the representation.
      * @return ResourceInterface|null
      */

--- a/application/src/Api/Adapter/ValueAnnotationAdapter.php
+++ b/application/src/Api/Adapter/ValueAnnotationAdapter.php
@@ -2,7 +2,9 @@
 namespace Omeka\Api\Adapter;
 
 use Omeka\Api\Representation\ValueAnnotationRepresentation;
+use Omeka\Api\Representation\ValueRepresentation;
 use Omeka\Api\Request;
+use Omeka\Api\ResourceInterface;
 use Omeka\Entity\ValueAnnotation;
 
 class ValueAnnotationAdapter extends AbstractResourceEntityAdapter
@@ -45,5 +47,24 @@ class ValueAnnotationAdapter extends AbstractResourceEntityAdapter
     public function delete(Request $request)
     {
         return AbstractAdapter::delete($request);
+    }
+
+    /**
+     * Compose a resource representation object.
+     *
+     * The value is not directly available in ValueAnnotation data, because
+     * their one-to-one relation is unidirectional, so append it here.
+     *
+     * @param mixed $data Whatever data is needed to compose the representation.
+     * @param ValueRepresentation|null
+     * @return ResourceInterface|null
+     */
+    public function getRepresentation(ResourceInterface $data = null, ?ValueRepresentation $value = null)
+    {
+        if (!$data instanceof ValueAnnotation || !$value) {
+            // Do not attempt to compose a null representation.
+            return null;
+        }
+        return new ValueAnnotationRepresentation($data, $this, $value);
     }
 }

--- a/application/src/Api/Representation/ValueAnnotationRepresentation.php
+++ b/application/src/Api/Representation/ValueAnnotationRepresentation.php
@@ -1,8 +1,28 @@
 <?php
 namespace Omeka\Api\Representation;
 
+use Omeka\Api\Adapter\ValueAnnotationAdapter;
+use Omeka\Entity\ValueAnnotation;
+
 class ValueAnnotationRepresentation extends AbstractResourceEntityRepresentation
 {
+    /**
+     * @var \Omeka\Api\Representation\ValueRepresentation
+     */
+    protected $value;
+
+    /**
+     * Construct the value annotation representation object.
+     */
+    public function __construct(
+        ValueAnnotation $valueAnnotation,
+        ValueAnnotationAdapter $adapter,
+        ValueRepresentation $value
+    ) {
+        parent::__construct($valueAnnotation, $adapter);
+        $this->value = $value;
+    }
+
     public function getResourceJsonLdType()
     {
         return 'o:ValueAnnotation';
@@ -13,12 +33,31 @@ class ValueAnnotationRepresentation extends AbstractResourceEntityRepresentation
         return [];
     }
 
+    /**
+     * Get the resource representation.
+     */
+    public function resource(): AbstractResourceEntityRepresentation
+    {
+        return $this->value->resource();
+    }
+
+    /**
+     * Get the value representation.
+     */
+    public function resourceValue(): ValueRepresentation
+    {
+        return $this->value;
+    }
+
     public function displayValues(array $options = [])
     {
         $eventManager = $this->getEventManager();
         $args = $eventManager->prepareArgs(['values' => $this->values()]);
         $eventManager->trigger('rep.resource.value_annotation_display_values', $this, $args);
+        $options['resource'] = $this->resource();
+        $options['valueAnnotation'] = $this;
         $options['values'] = $args['values'];
+        $options['templateProperties'] = [];
 
         $partial = $this->getViewHelper('partial');
         return $partial('common/value-annotation-resource-values', $options);

--- a/application/src/Api/Representation/ValueRepresentation.php
+++ b/application/src/Api/Representation/ValueRepresentation.php
@@ -202,7 +202,7 @@ class ValueRepresentation extends AbstractRepresentation
     public function valueAnnotation()
     {
         $valueAnnotation = $this->value->getValueAnnotation();
-        return $valueAnnotation ? $this->getAdapter('value_annotations')->getRepresentation($valueAnnotation) : null;
+        return $valueAnnotation ? $this->getAdapter('value_annotations')->getRepresentation($valueAnnotation, $this) : null;
     }
 
     /**


### PR DESCRIPTION


The resource value annotations use the same template than resource values, so it should pass the resource too.

By the way, there is an important missing feature about value annotation : there is no template, so the user should select the properties and the datatype one by one. Most of the time, it's only one or two properties, but it should be listed somewhere, so it can be filled in one click.

So is it better I improve the module Advanced Resource Template for that or to push request here to avoid a future re-implementation, because it is probably something people will want later.

As for many other things, is there a way to know what will be inside the core and what will remain in the modules to avoid to develop the same thing multiple times with subtle variants?
