### PR TITLE
Enable search operation for API resource adapter

### DIFF
--- a/application/src/Api/Adapter/ResourceAdapter.php
+++ b/application/src/Api/Adapter/ResourceAdapter.php
@@ -7,7 +7,7 @@ use Omeka\Entity\EntityInterface;
 use Omeka\Entity\Resource as ResourceEntity;
 use Omeka\Stdlib\ErrorStore;
 
-class ResourceAdapter extends AbstractEntityAdapter
+class ResourceAdapter extends AbstractResourceEntityAdapter
 {
     public function getResourceName()
     {
@@ -48,11 +48,6 @@ class ResourceAdapter extends AbstractEntityAdapter
         return $adapter->getRepresentation($data);
     }
 
-    public function search(Request $request)
-    {
-        AbstractAdapter::search($request);
-    }
-
     public function create(Request $request)
     {
         AbstractAdapter::create($request);
@@ -65,7 +60,12 @@ class ResourceAdapter extends AbstractEntityAdapter
 
     public function update(Request $request)
     {
-        AbstractAdapter::batchCreate($request);
+        AbstractAdapter::update($request);
+    }
+
+    public function batchUpdate(Request $request)
+    {
+        AbstractAdapter::batchUpdate($request);
     }
 
     public function delete(Request $request)

--- a/application/src/Service/AclFactory.php
+++ b/application/src/Service/AclFactory.php
@@ -270,6 +270,7 @@ class AclFactory implements FactoryInterface
         $acl->allow(
             null,
             [
+                'Omeka\Api\Adapter\ResourceAdapter',
                 'Omeka\Api\Adapter\ItemSetAdapter',
                 'Omeka\Api\Adapter\ItemAdapter',
                 'Omeka\Api\Adapter\MediaAdapter',
@@ -289,7 +290,6 @@ class AclFactory implements FactoryInterface
         $acl->allow(
             null,
             [
-                'Omeka\Api\Adapter\ResourceAdapter',
                 'Omeka\Entity\ItemSet',
                 'Omeka\Entity\Item',
                 'Omeka\Entity\Media',


### PR DESCRIPTION
See this forum post https://forum.omeka.org/t/query-multiple-resources-by-ids/16833

I don't remember if there was a reason why we disabled the `search` operation for the ResourceAdapter. Also, I don't remember if there was a reason why we enabled the `batchUpdate` operation, or if it was an oversight.