### PR TITLE
Feature/scalar fields more

### DIFF
--- a/application/src/Api/Adapter/AssetAdapter.php
+++ b/application/src/Api/Adapter/AssetAdapter.php
@@ -18,6 +18,16 @@ class AssetAdapter extends AbstractEntityAdapter
         'extension' => 'extension',
     ];
 
+    protected $scalarFields = [
+        'id' => 'id',
+        'media_type' => 'mediaType',
+        'name' => 'name',
+        'extension' => 'extension',
+        'storage_id' => 'storageId',
+        'alt_text' => 'altText',
+        'owner' => 'owner',
+    ];
+
     public function getResourceName()
     {
         return 'assets';

--- a/application/src/Api/Adapter/JobAdapter.php
+++ b/application/src/Api/Adapter/JobAdapter.php
@@ -16,6 +16,16 @@ class JobAdapter extends AbstractEntityAdapter
         'ended' => 'ended',
     ];
 
+    protected $scalarFields = [
+        'id' => 'id',
+        // 'pid' => 'pid',
+        'status' => 'status',
+        'class' => 'class',
+        'started' => 'started',
+        'ended' => 'ended',
+        'owner' => 'owner',
+    ];
+
     public function getResourceName()
     {
         return 'jobs';

--- a/application/src/Api/Adapter/PropertyAdapter.php
+++ b/application/src/Api/Adapter/PropertyAdapter.php
@@ -17,6 +17,15 @@ class PropertyAdapter extends AbstractEntityAdapter
         'comment' => 'comment',
     ];
 
+    protected $scalarFields = [
+        'id' => 'id',
+        'local_name' => 'localName',
+        'label' => 'label',
+        'comment' => 'comment',
+        'owner' => 'owner',
+        'vocabulary' => 'vocabulary',
+    ];
+
     public function getResourceName()
     {
         return 'properties';

--- a/application/src/Api/Adapter/ResourceClassAdapter.php
+++ b/application/src/Api/Adapter/ResourceClassAdapter.php
@@ -17,6 +17,15 @@ class ResourceClassAdapter extends AbstractEntityAdapter
         'comment' => 'comment',
     ];
 
+    protected $scalarFields = [
+        'id' => 'id',
+        'local_name' => 'localName',
+        'label' => 'label',
+        'comment' => 'comment',
+        'owner' => 'owner',
+        'vocabulary' => 'vocabulary',
+    ];
+
     public function getResourceName()
     {
         return 'resource_classes';

--- a/application/src/Api/Adapter/ResourceTemplateAdapter.php
+++ b/application/src/Api/Adapter/ResourceTemplateAdapter.php
@@ -14,6 +14,15 @@ class ResourceTemplateAdapter extends AbstractEntityAdapter
         'label' => 'label',
     ];
 
+    protected $scalarFields = [
+        'id' => 'id',
+        'label' => 'label',
+        'owner' => 'owner',
+        'resource_class' => 'resourceClass',
+        'title_property' => 'titleProperty',
+        'description_property' => 'descriptionProperty',
+    ];
+
     public function getResourceName()
     {
         return 'resource_templates';

--- a/application/src/Api/Adapter/SiteAdapter.php
+++ b/application/src/Api/Adapter/SiteAdapter.php
@@ -24,6 +24,20 @@ class SiteAdapter extends AbstractEntityAdapter
         'slug' => 'slug',
     ];
 
+    protected $scalarFields = [
+        'id' => 'id',
+        'slug' => 'slug',
+        'theme' => 'theme',
+        'title' => 'title',
+        'is_public' => 'isPublic',
+        'created' => 'created',
+        'modified' => 'modified',
+        'homepage' => 'homepage',
+        'owner' => 'owner',
+        'summary' => 'summary',
+        'thumbnail' => 'thumbnail',
+    ];
+
     public function getResourceName()
     {
         return 'sites';

--- a/application/src/Api/Adapter/SitePageAdapter.php
+++ b/application/src/Api/Adapter/SitePageAdapter.php
@@ -24,6 +24,16 @@ class SitePageAdapter extends AbstractEntityAdapter implements FulltextSearchabl
         'slug' => 'slug',
     ];
 
+    protected $scalarFields = [
+        'id' => 'id',
+        'slug' => 'slug',
+        'title' => 'title',
+        'is_public' => 'isPublic',
+        'site' => 'site',
+        'created' => 'created',
+        'modified' => 'modified',
+    ];
+
     public function getResourceName()
     {
         return 'site_pages';

--- a/application/src/Api/Adapter/UserAdapter.php
+++ b/application/src/Api/Adapter/UserAdapter.php
@@ -19,6 +19,16 @@ class UserAdapter extends AbstractEntityAdapter
         'role' => 'role',
     ];
 
+    protected $scalarFields = [
+        'id' => 'id',
+        'email' => 'email',
+        'name' => 'name',
+        'created' => 'created',
+        'modified' => 'modified',
+        'role' => 'role',
+        'is_active' => 'isActive',
+    ];
+
     public function getResourceName()
     {
         return 'users';

--- a/application/src/Api/Adapter/VocabularyAdapter.php
+++ b/application/src/Api/Adapter/VocabularyAdapter.php
@@ -17,6 +17,15 @@ class VocabularyAdapter extends AbstractEntityAdapter
         'comment' => 'comment',
     ];
 
+    protected $scalarFields = [
+        'id' => 'id',
+        'namespace_uri' => 'namespaceUri',
+        'prefix' => 'prefix',
+        'label' => 'label',
+        'comment' => 'comment',
+        'owner' => 'owner',
+    ];
+
     /**
      * @var array Reserved vocabulary prefixes
      */


### PR DESCRIPTION
Some entities have not available fields to get return via scalar fields. It's interesting in particular for site pages, but it can be improved for all of them. Or is there a reason to limit this feature to item, item set and media?