### PR TITLE
Show total in tab "Linked resources" even when there is only one page

### DIFF
--- a/application/view/common/linked-resources.phtml
+++ b/application/view/common/linked-resources.phtml
@@ -55,7 +55,7 @@ $resourcePropertiesSelect->setValueOptions($valueOptions);
             <?php echo $this->formElement($resourcePropertiesSelect); ?>
         </label>
     </div>
-    <?php echo ($totalCount > $perPage) ? $pagination : ''; ?>
+    <?php echo ($totalCount > $perPage) ? $pagination : '<div class="total-resources">' . sprintf($this->translate('%d linked resources'), $totalCount) . '</div>'; ?>
 </div>
 
 <?php foreach ($subjectValues as $values): ?>


### PR DESCRIPTION
Some people want to get the total of linked resources, that is not displayed when there is only one page.