### PR TITLE
Added an event to get linked resources via subject values.

### DIFF
--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -557,7 +557,6 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             'propertyId' => $propertyId,
             'resourceType' => $resourceType,
             'siteId' => $siteId,
-            'isSimple' => false,
         ]);
         $this->getEventManager()->triggerEvent($event);
         $results = $qb->getQuery()->getResult();
@@ -583,13 +582,12 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             ->join('value.property', 'property')
             ->join('property.vocabulary', 'vocabulary')
             ->select("CONCAT(vocabulary.prefix, ':', property.localName) term, IDENTITY(value.resource) id, resource.title title");
-        $event = new Event('api.subject_values.query', $this, [
+        $event = new Event('api.subject_values_simple.query', $this, [
             'queryBuilder' => $qb,
             'resource' => $resource,
             'propertyId' => $propertyId,
             'resourceType' => $resourceType,
             'siteId' => $siteId,
-            'isSimple' => true,
         ]);
         $this->getEventManager()->triggerEvent($event);
         return $qb->getQuery()->getResult();

--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -4,6 +4,7 @@ namespace Omeka\Api\Adapter;
 use DateTime;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\QueryBuilder;
+use Laminas\EventManager\Event;
 use Omeka\Api\Representation\ValueRepresentation;
 use Omeka\Api\Request;
 use Omeka\Entity\EntityInterface;
@@ -550,6 +551,15 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             ->orderBy('property.id, resource_template_property.alternateLabel, resource.title')
             ->setMaxResults($perPage)
             ->setFirstResult($offset);
+        $event = new Event('api.subject_values.query', $this, [
+            'queryBuilder' => $qb,
+            'resource' => $resource,
+            'propertyId' => $propertyId,
+            'resourceType' => $resourceType,
+            'siteId' => $siteId,
+            'isSimple' => false,
+        ]);
+        $this->getEventManager()->triggerEvent($event);
         $results = $qb->getQuery()->getResult();
         return $results;
     }
@@ -573,6 +583,15 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             ->join('value.property', 'property')
             ->join('property.vocabulary', 'vocabulary')
             ->select("CONCAT(vocabulary.prefix, ':', property.localName) term, IDENTITY(value.resource) id, resource.title title");
+        $event = new Event('api.subject_values.query', $this, [
+            'queryBuilder' => $qb,
+            'resource' => $resource,
+            'propertyId' => $propertyId,
+            'resourceType' => $resourceType,
+            'siteId' => $siteId,
+            'isSimple' => true,
+        ]);
+        $this->getEventManager()->triggerEvent($event);
         return $qb->getQuery()->getResult();
     }
 


### PR DESCRIPTION
Some people want to order subject values not by title, but by something else, for example by bibo:volume and bibo:issue. The feature is already implemented in module [Advanced Resource Template](https://gitlab.com/Daniel-KM/Omeka-S-module-AdvancedResourceTemplate), but an event is needed for that.