### PR TITLE
Feature/site from item set

### DIFF
--- a/application/src/Api/Adapter/ItemSetAdapter.php
+++ b/application/src/Api/Adapter/ItemSetAdapter.php
@@ -27,6 +27,9 @@ class ItemSetAdapter extends AbstractResourceEntityAdapter
         'is_public' => 'isPublic',
         'thumbnail' => 'thumbnail',
         'is_open' => 'isOpen',
+        'owner' => 'owner',
+        'resource_class' => 'resourceClass',
+        'resource_template' => 'resourceTemplate',
     ];
 
     /**

--- a/application/src/Api/Adapter/MediaAdapter.php
+++ b/application/src/Api/Adapter/MediaAdapter.php
@@ -40,6 +40,9 @@ class MediaAdapter extends AbstractResourceEntityAdapter
         'item' => 'item',
         'lang' => 'lang',
         'alt_text' => 'altText',
+        'owner' => 'owner',
+        'resource_class' => 'resourceClass',
+        'resource_template' => 'resourceTemplate',
     ];
 
     public function getResourceName()

--- a/application/src/Api/Representation/ItemSetRepresentation.php
+++ b/application/src/Api/Representation/ItemSetRepresentation.php
@@ -15,6 +15,11 @@ class ItemSetRepresentation extends AbstractResourceEntityRepresentation
 
     public function getResourceJsonLd()
     {
+        $sites = [];
+        foreach ($this->sites() as $siteRepresentation) {
+            $sites[] = $siteRepresentation->getReference();
+        }
+
         $url = $this->getViewHelper('Url');
         $itemsUrl = $url(
             'api/default',
@@ -27,6 +32,7 @@ class ItemSetRepresentation extends AbstractResourceEntityRepresentation
         return [
             'o:is_open' => $this->isOpen(),
             'o:items' => ['@id' => $itemsUrl],
+            'o:site' => $sites,
         ];
     }
 

--- a/application/src/Controller/Admin/ItemSetController.php
+++ b/application/src/Controller/Admin/ItemSetController.php
@@ -24,6 +24,8 @@ class ItemSetController extends AbstractActionController
         if ($this->getRequest()->isPost()) {
             $data = $this->params()->fromPost();
             $data = $this->mergeValuesJson($data);
+            // Prevent the API from setting sites automatically if no sites are set.
+            $data['o:site'] ??= [];
             $form->setData($data);
             if ($form->isValid()) {
                 $response = $this->api($form)->create('item_sets', $data);
@@ -59,6 +61,7 @@ class ItemSetController extends AbstractActionController
         $view = new ViewModel;
         $view->setVariable('form', $form);
         $view->setVariable('itemSet', $itemSet);
+        $view->setVariable('resource', $itemSet);
         if ($this->getRequest()->isPost()) {
             $data = $this->params()->fromPost();
             $data = $this->mergeValuesJson($data);

--- a/application/src/Form/UserForm.php
+++ b/application/src/Form/UserForm.php
@@ -194,10 +194,25 @@ class UserForm extends Form
                 'class' => 'chosen-select',
                 'data-placeholder' => 'Select sites', // @translate
                 'multiple' => true,
-                'id' => 'default_sites',
+                'id' => 'default_item_sites',
             ],
             'options' => [
                 'label' => 'Default sites for items', // @translate
+                'empty_option' => '',
+            ],
+        ]);
+        $settingsFieldset->add([
+            'name' => 'default_item_set_sites',
+            'type' => SiteSelect::class,
+            'attributes' => [
+                'value' => $userId ? $this->userSettings->get('default_item_sets_sites', null, $userId) : [],
+                'class' => 'chosen-select',
+                'data-placeholder' => 'Select sites', // @translate
+                'multiple' => true,
+                'id' => 'default_item_set_sites',
+            ],
+            'options' => [
+                'label' => 'Default sites for item sets', // @translate
                 'empty_option' => '',
             ],
         ]);

--- a/application/src/Form/UserForm.php
+++ b/application/src/Form/UserForm.php
@@ -205,7 +205,7 @@ class UserForm extends Form
             'name' => 'default_item_set_sites',
             'type' => SiteSelect::class,
             'attributes' => [
-                'value' => $userId ? $this->userSettings->get('default_item_sets_sites', null, $userId) : [],
+                'value' => $userId ? $this->userSettings->get('default_item_set_sites', null, $userId) : [],
                 'class' => 'chosen-select',
                 'data-placeholder' => 'Select sites', // @translate
                 'multiple' => true,

--- a/application/view/omeka/admin/item-set/form.phtml
+++ b/application/view/omeka/admin/item-set/form.phtml
@@ -11,6 +11,7 @@ $form->prepare();
 
 <?php echo $this->sectionNav([
     'resource-values' => $translate('Values'),
+    'sites' => $translate('Sites'),
     'advanced-settings' => $translate('Advanced'),
 ], $sectionNavEvent); ?>
 
@@ -21,6 +22,12 @@ $form->prepare();
     'resource' => $itemSet,
     'action' => $action,
 ]); ?>
+
+<fieldset id="sites" class="section" aria-labelledby="sites-label">
+    <?php echo $this->partial('omeka/admin/item-set/manage-sites', [
+        'itemSet' => $itemSet,
+    ]); ?>
+</fieldset>
 
 <div id="page-actions">
     <?php if ($itemSet && $itemSet->isOpen()): ?>

--- a/application/view/omeka/admin/item-set/manage-sites.phtml
+++ b/application/view/omeka/admin/item-set/manage-sites.phtml
@@ -1,0 +1,57 @@
+<?php
+if ($itemSet) {
+    $siteRepresentations = $itemSet->sites();
+} else {
+    $siteRepresentations = [];
+    /*
+    $siteRepresentations = $this->api()->search('sites', ['assign_new_items' => true])->getContent();
+
+    $userDefaultSites = $this->userSetting('default_item_sites');
+    if (is_array($userDefaultSites)) {
+        $userDefaultSiteRepresentations = $this->api()->search('sites', ['id' => $userDefaultSites])->getContent();
+        $siteRepresentations = array_merge($siteRepresentations, $userDefaultSiteRepresentations);
+    }
+    */
+}
+
+$sites = [];
+foreach ($siteRepresentations as $siteRepresentation) {
+    $sites[] = [
+        'id' => $siteRepresentation->id(),
+    ];
+}
+
+$siteTemplate = '
+<tr class="resource-row">
+    <td class="data-value" data-row-key="child-search"></td>
+    <td class="data-value" data-row-key="resource-email"></td>
+    <td>
+        <ul class="actions">
+            <li>' . $this->hyperlink('', '#', ['class' => 'o-icon-delete', 'title' => $this->translate('Unassign from site')]) . '</li>
+        </ul>
+        <input type="hidden" name="o:site[]" class="resource-id">
+    </td>
+</tr>';
+?>
+<table id="item-set-sites" data-existing-rows="<?php echo $this->escapeHtml(json_encode(array_values($sites))); ?>" data-row-template="<?php echo $this->escapeHtml($siteTemplate); ?>" data-tablesaw-mode="stack" class="selector-table tablesaw tablesaw-stack <?php echo ($itemSet && (count($sites) > 0)) ? '' : 'empty'; ?>">
+    <thead>
+    <tr>
+        <th><?php echo $this->translate('Title'); ?></th>
+        <th><?php echo $this->translate('Owner'); ?></th>
+        <th></th>
+    </tr>
+    </thead>
+    <tbody class="resource-rows"></tbody>
+</table>
+
+<div class="no-resources">
+    <p><?php echo $this->translate('This item is part of no sites. Add it to a site using the interface to the right.'); ?></p>
+</div>
+
+<button id="site-selector-button" class="mobile-only"><?php echo $this->translate('Assign to site'); ?></button>
+
+<?php echo $this->siteSelector(); ?>
+
+<script>
+    Omeka.initializeSelector('#item-set-sites', '#site-selector');
+</script>

--- a/application/view/omeka/admin/item-set/manage-sites.phtml
+++ b/application/view/omeka/admin/item-set/manage-sites.phtml
@@ -2,16 +2,15 @@
 if ($itemSet) {
     $siteRepresentations = $itemSet->sites();
 } else {
-    $siteRepresentations = [];
-    /*
+    // For now, use the same key "assign_new_items". In fact, there should be two
+    // columns (or a site setting) or one "assign_new_resources". The same for acl.
     $siteRepresentations = $this->api()->search('sites', ['assign_new_items' => true])->getContent();
 
-    $userDefaultSites = $this->userSetting('default_item_sites');
-    if (is_array($userDefaultSites)) {
+    $userDefaultSites = $this->userSetting('default_item_set_sites');
+    if (is_array($userDefaultSites) && !empty($userDefaultSites)) {
         $userDefaultSiteRepresentations = $this->api()->search('sites', ['id' => $userDefaultSites])->getContent();
         $siteRepresentations = array_merge($siteRepresentations, $userDefaultSiteRepresentations);
     }
-    */
 }
 
 $sites = [];

--- a/application/view/omeka/admin/item-set/show-details.phtml
+++ b/application/view/omeka/admin/item-set/show-details.phtml
@@ -18,6 +18,15 @@ $escape = $this->plugin('escapeHtml');
         <div class="value"><?php echo ($resource->isPublic()) ? $translate('Public') : $translate('Private'); ?></div>
         <div class="value"><?php echo ($resource->isOpen()) ? $escape($translate('Open to additions')) : $escape($translate('Closed to additions')); ?></div>
     </div>
+    <?php $sites = $resource->sites(); ?>
+    <?php if ($sites): ?>
+    <div class="meta-group">
+        <h4><?php echo $translate('Sites'); ?></h4>
+        <?php foreach ($sites as $site): ?>
+        <div class="value sites"><?php echo $site->link($site->title()); ?></div>
+        <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
     <div class="meta-group">
         <h4><?php echo $translate('Items'); ?></h4>
         <div class="value"><?php echo $this->hyperlink($resource->itemCount(), $this->url('admin/default', ['controller' => 'item', 'action' => 'browse'], ['query' => ['item_set_id' => $resource->id()]])); ?></div>

--- a/application/view/omeka/admin/item-set/show.phtml
+++ b/application/view/omeka/admin/item-set/show.phtml
@@ -82,6 +82,15 @@ $sectionNavs = [
         <div class="value"><?php echo ($itemSet->isPublic()) ? $escape($translate('Public')) : $escape($translate('Private')); ?></div>
         <div class="value"><?php echo ($itemSet->isOpen()) ? $escape($translate('Open to additions')) : $escape($translate('Closed to additions')); ?></div>
     </div>
+    <?php $sites = $itemSet->sites(); ?>
+    <?php if (count($sites) > 0): ?>
+    <div class="meta-group">
+        <h4><?php echo $translate('Sites'); ?></h4>
+        <?php foreach ($sites as $site): ?>
+        <div class="value item-sets"><?php echo $site->link($site->title()); ?></div>
+        <?php endforeach; ?>
+    </div>
+    <?php endif; ?>
     <div class="meta-group">
         <h4><?php echo $translate('Items'); ?></h4>
         <div class="value"><?php echo $this->hyperlink($itemSet->itemCount(), $this->url('admin/default', ['controller' => 'item', 'action' => 'browse'], ['query' => ['item_set_id' => $itemSet->id()]])); ?></div>

--- a/application/view/omeka/admin/item/manage-sites.phtml
+++ b/application/view/omeka/admin/item/manage-sites.phtml
@@ -5,7 +5,7 @@ if ($item) {
     $siteRepresentations = $this->api()->search('sites', ['assign_new_items' => true])->getContent();
 
     $userDefaultSites = $this->userSetting('default_item_sites');
-    if (is_array($userDefaultSites)) {
+    if (is_array($userDefaultSites) && !empty($userDefaultSites)) {
         $userDefaultSiteRepresentations = $this->api()->search('sites', ['id' => $userDefaultSites])->getContent();
         $siteRepresentations = array_merge($siteRepresentations, $userDefaultSiteRepresentations);
     }


### PR DESCRIPTION
In item resource form, it is possible to assign sites, but not in item set resource form. So this feature is added here, and subsequent implications (display sites in item set view, define a user setting for item sets.

There is a last point that is not managed: to add or not to add a site option to assign item sets to it, like it exists for items. For now, the process use the same key "assign_new_items" to manage process. In fact, there are three possibilities: 
- use one column in table `site`, so rename `assign_new_items` to and `assign_new_resources`.
- let existing column and change its meaning (like in this pr).
- let existing column in table `site` and use a site setting to manage the option for item set.
- use two columns in table `site`: `assign_new_items` and `assign_new_item_sets`.

So the point is should we manage items and item sets options separately or not? The same for acl.
