### PR TITLE
Use element groups in batch edit pages

### DIFF
--- a/application/view/common/property-form-batch-edit.phtml
+++ b/application/view/common/property-form-batch-edit.phtml
@@ -50,6 +50,8 @@ $templateUri = '
     </div>
 </div>';
 ?>
+<fieldset>
+<legend><?php echo $translate('Values'); ?></legend>
 <div class="field">
     <div class="field-meta">
         <label>Set value visibility</label>
@@ -77,6 +79,7 @@ $templateUri = '
     <button type="button" class="value-add-button" data-type="resource"><?php echo $translate('Add resource value'); ?></button>
     <button type="button" class="value-add-button" data-type="uri"><?php echo $translate('Add URI value'); ?></button>
 </div>
+</fieldset>
 <script>
 $(document).ready(function() {
     // Add a value field.

--- a/application/view/omeka/admin/item/batch-edit.phtml
+++ b/application/view/omeka/admin/item/batch-edit.phtml
@@ -19,7 +19,7 @@ $this->htmlElement('body')->appendAttribute('class', 'batch-edit items');
     <input type="submit" name="batch_update" value="<?php echo $this->escapeHtml($translate('Submit')); ?>">
 </div>
 
-<?php echo $this->formCollection($form, false); ?>
+<?php echo $this->formCollectionElementGroups($form, false); ?>
 <?php echo $this->partial('common/property-form-batch-edit.phtml', ['resourceType' => 'items']); ?>
 <?php echo $this->form()->closeTag(); ?>
 


### PR DESCRIPTION
Batch edit pages currently don't enable element groups. This PR enables them.