### PR TITLE
Allow modules to add/modify API output formats

### DIFF
--- a/application/Module.php
+++ b/application/Module.php
@@ -1,14 +1,17 @@
 <?php
 namespace Omeka;
 
+use EasyRdf\Graph;
 use Omeka\Api\Adapter\FulltextSearchableInterface;
 use Omeka\Api\Representation\AbstractResourceEntityRepresentation;
+use Omeka\Api\Representation\RepresentationInterface;
 use Omeka\Entity\Item;
 use Omeka\Entity\Media;
 use Omeka\Module\AbstractModule;
 use Laminas\EventManager\Event as ZendEvent;
 use Laminas\EventManager\SharedEventManagerInterface;
 use Laminas\Form\Element;
+use Laminas\Json\Json;
 use Laminas\View\Renderer\PhpRenderer;
 
 /**
@@ -171,6 +174,18 @@ class Module extends AbstractModule
             'Omeka\Controller\Site\Item',
             'view.browse.after',
             [$this, 'noindexItemSet']
+        );
+
+        $sharedEventManager->attach(
+            '*',
+            'api.output.serialize',
+            [$this, 'serializeApiOutputJsonLd']
+        );
+
+        $sharedEventManager->attach(
+            '*',
+            'api.output.serialize',
+            [$this, 'serializeApiOutputRdf']
         );
 
         $sharedEventManager->attach(
@@ -758,6 +773,99 @@ class Module extends AbstractModule
             return;
         }
         $this->noindexResourceShow($view, $view->itemSet);
+    }
+
+    /**
+     * Serialize the API output to JSON-LD.
+     */
+    public function serializeApiOutputJsonLd(ZendEvent $event)
+    {
+        $renderer = $event->getTarget();
+        $model = $event->getParam('model');
+        $format = $event->getParam('format');
+        $payload = $event->getParam('payload');
+        $output = $event->getParam('output');
+
+        if ('jsonld' !== $format) {
+            return;
+        }
+
+        $eventManager = $this->getServiceLocator()->get('EventManager');
+
+        if ($payload instanceof RepresentationInterface) {
+            $args = $eventManager->prepareArgs(['jsonLd' => $output]);
+            $eventManager->trigger('rep.resource.json_output', $payload, $args);
+            $output = $args['jsonLd'];
+        }
+
+        if (null !== $model->getOption('pretty_print')) {
+            // Pretty print the JSON.
+            $output = Json::prettyPrint($output);
+        }
+
+        $jsonpCallback = (string) $model->getOption('callback');
+        if (!empty($jsonpCallback)) {
+            // Wrap the JSON in a JSONP callback. Normally this would be done
+            // via `$this->setJsonpCallback()` but we don't want to pass the
+            // wrapped string to `rep.resource.json_output` handlers.
+            $output = sprintf('%s(%s);', $jsonpCallback, $output);
+            $renderer->setHasJsonpCallback(true);
+        }
+
+        $event->setParam('output', $output);
+    }
+
+    /**
+     * Serialize the API output to RDF formats (rdfxml, n3, turtle, ntriples).
+     */
+    public function serializeApiOutputRdf(ZendEvent $event)
+    {
+        $renderer = $event->getTarget();
+        $model = $event->getParam('model');
+        $format = $event->getParam('format');
+        $payload = $event->getParam('payload');
+        $output = $event->getParam('output');
+
+        if (!in_array($format, ['rdfxml', 'n3', 'turtle', 'ntriples'])) {
+            return;
+        }
+
+        $eventManager = $this->getServiceLocator()->get('EventManager');
+
+        $serializeRdf = function ($jsonLd) use ($format) {
+            $graph = new Graph;
+            $graph->parse(Json::encode($jsonLd), 'jsonld');
+            return $graph->serialise($format);
+        };
+
+        $getJsonLdWithContext = function (RepresentationInterface $representation) use ($eventManager) {
+            // Add the @context by encoding the output as JSON, then decoding to an array.
+            static $context;
+            if (!$context) {
+                // Get the JSON-LD @context
+                $args = $eventManager->prepareArgs(['context' => []]);
+                $eventManager->trigger('api.context', null, $args);
+                $context = $args['context'];
+            }
+            $jsonLd = Json::decode(Json::encode($representation), true);
+            $jsonLd['@context'] = $context;
+            return $jsonLd;
+        };
+
+        // Render a single representation (get).
+        if ($payload instanceof RepresentationInterface) {
+            $jsonLd = $getJsonLdWithContext($payload);
+            $output = $serializeRdf($jsonLd);
+        // Render multiple representations (getList);
+        } elseif (is_array($payload) && array_filter($payload, fn ($object) => ($object instanceof RepresentationInterface))) {
+            $jsonLd = [];
+            foreach ($payload as $representation) {
+                $jsonLd[] = $getJsonLdWithContext($representation);
+            }
+            $output = $serializeRdf($jsonLd);
+        }
+
+        $event->setParam('output', $output);
     }
 
     /**

--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -246,6 +246,7 @@ return [
             'Omeka\Logger' => Service\LoggerFactory::class,
             'Omeka\MigrationManager' => Service\MigrationManagerFactory::class,
             'Omeka\ViewApiJsonStrategy' => Service\ViewApiJsonStrategyFactory::class,
+            'Omeka\ViewApiJsonRenderer' => Service\ViewApiJsonRendererFactory::class,
             'Omeka\HttpClient' => Service\HttpClientFactory::class,
             'Omeka\Mailer' => Service\MailerFactory::class,
             'Omeka\HtmlPurifier' => Service\HtmlPurifierFactory::class,
@@ -288,7 +289,6 @@ return [
             'ModuleRouteListener' => \Laminas\Mvc\ModuleRouteListener::class,
             'Omeka\MvcExceptionListener' => Mvc\ExceptionListener::class,
             'Omeka\MvcListeners' => Mvc\MvcListeners::class,
-            'Omeka\ViewApiJsonRenderer' => View\Renderer\ApiJsonRenderer::class,
         ],
         'delegators' => [
             'Laminas\I18n\Translator\TranslatorInterface' => [

--- a/application/src/Service/ViewApiJsonRendererFactory.php
+++ b/application/src/Service/ViewApiJsonRendererFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Omeka\Service;
+
+use Omeka\View\Renderer\ApiJsonRenderer;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Interop\Container\ContainerInterface;
+
+class ViewApiJsonRendererFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $serviceLocator, $requestedName, array $options = null)
+    {
+        $eventManager = $serviceLocator->get('EventManager');
+        $jsonRenderer = new ApiJsonRenderer($eventManager);
+        return $jsonRenderer;
+    }
+}

--- a/application/src/Service/ViewApiJsonStrategyFactory.php
+++ b/application/src/Service/ViewApiJsonStrategyFactory.php
@@ -22,7 +22,8 @@ class ViewApiJsonStrategyFactory implements FactoryInterface
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, array $options = null)
     {
         $jsonRenderer = $serviceLocator->get('Omeka\ViewApiJsonRenderer');
-        $jsonStrategy = new ApiJsonStrategy($jsonRenderer);
+        $eventManager = $serviceLocator->get('EventManager');
+        $jsonStrategy = new ApiJsonStrategy($jsonRenderer, $eventManager);
         return $jsonStrategy;
     }
 }

--- a/application/src/View/Renderer/ApiJsonRenderer.php
+++ b/application/src/View/Renderer/ApiJsonRenderer.php
@@ -2,7 +2,6 @@
 namespace Omeka\View\Renderer;
 
 use Omeka\Api\Exception\ValidationException;
-use Omeka\Api\Representation\RepresentationInterface;
 use Omeka\Api\Response;
 use Laminas\EventManager\EventManager;
 use Laminas\Json\Json;

--- a/application/src/View/Renderer/ApiJsonRenderer.php
+++ b/application/src/View/Renderer/ApiJsonRenderer.php
@@ -77,7 +77,7 @@ class ApiJsonRenderer extends JsonRenderer
                 return $this->serializeJsonLdToFormat($this->format, $jsonLd, [$payload]);
             }
             // Render multiple representations (getList);
-            if (is_array($payload) && array_filter($payload, fn($object) => ($object instanceof RepresentationInterface))) {
+            if (is_array($payload) && array_filter($payload, fn ($object) => ($object instanceof RepresentationInterface))) {
                 $jsonLd = [];
                 foreach ($payload as $representation) {
                     $jsonLd[] = $this->getJsonLdWithContext($representation);

--- a/application/src/View/Renderer/ApiJsonRenderer.php
+++ b/application/src/View/Renderer/ApiJsonRenderer.php
@@ -19,11 +19,6 @@ class ApiJsonRenderer extends JsonRenderer
     protected $hasJsonpCallback = false;
 
     /**
-     * @var array The JSON-LD context
-     */
-    protected $context;
-
-    /**
      * @var string The output format
      */
     protected $format;
@@ -49,6 +44,11 @@ class ApiJsonRenderer extends JsonRenderer
         return $this->hasJsonpCallback;
     }
 
+    public function setHasJsonpCallback(bool $hasJsonpCallback)
+    {
+        $this->hasJsonpCallback = $hasJsonpCallback;
+    }
+
     public function render($model, $values = null)
     {
         $response = $model->getApiResponse();
@@ -69,89 +69,14 @@ class ApiJsonRenderer extends JsonRenderer
             return null;
         }
 
-        // Render a format that is not JSON-LD, if requested.
-        if ('jsonld' !== $this->format) {
-            // Render a single representation (get).
-            if ($payload instanceof RepresentationInterface) {
-                $jsonLd = $this->getJsonLdWithContext($payload);
-                return $this->serializeJsonLdToFormat($this->format, $jsonLd, [$payload]);
-            }
-            // Render multiple representations (getList);
-            if (is_array($payload) && array_filter($payload, fn ($object) => ($object instanceof RepresentationInterface))) {
-                $jsonLd = [];
-                foreach ($payload as $representation) {
-                    $jsonLd[] = $this->getJsonLdWithContext($representation);
-                }
-                return $this->serializeJsonLdToFormat($this->format, $jsonLd, $payload);
-            }
-        }
-
         $output = parent::render($payload);
 
-        if ($payload instanceof RepresentationInterface) {
-            $args = $this->eventManager->prepareArgs(['jsonLd' => $output]);
-            $this->eventManager->trigger('rep.resource.json_output', $payload, $args);
-            $output = $args['jsonLd'];
-        }
-
-        if (null !== $model->getOption('pretty_print')) {
-            // Pretty print the JSON.
-            $output = Json::prettyPrint($output);
-        }
-
-        $jsonpCallback = (string) $model->getOption('callback');
-        if (!empty($jsonpCallback)) {
-            // Wrap the JSON in a JSONP callback. Normally this would be done
-            // via `$this->setJsonpCallback()` but we don't want to pass the
-            // wrapped string to `rep.resource.json_output` handlers.
-            $output = sprintf('%s(%s);', $jsonpCallback, $output);
-            $this->hasJsonpCallback = true;
-        }
-
-        return $output;
-    }
-
-    /**
-     * Get the JSON-LD array of a representation, adding the @context.
-     *
-     * @param RepresentationInterface $representation
-     * @return array
-     */
-    public function getJsonLdWithContext(RepresentationInterface $representation)
-    {
-        // Add the @context by encoding the output as JSON, then decoding to an array.
-        $jsonLd = Json::decode(Json::encode($representation), true);
-        if (!$this->context) {
-            // Get the JSON-LD @context
-            $args = $this->eventManager->prepareArgs(['context' => []]);
-            $this->eventManager->trigger('api.context', null, $args);
-            $this->context = $args['context'];
-        }
-        $jsonLd['@context'] = $this->context;
-        return $jsonLd;
-    }
-
-    /**
-     * Serialize JSON-LD to another format.
-     *
-     * @param array $jsonLd
-     * @param string $format
-     * @param string
-     */
-    public function serializeJsonLdToFormat(string $format, array $jsonLd, array $representations)
-    {
-        $output = null;
-        if (in_array($format, ['rdfxml', 'n3', 'turtle', 'ntriples'])) {
-            $graph = new \EasyRdf\Graph;
-            $graph->parse(Json::encode($jsonLd), 'jsonld');
-            $output = $graph->serialise($format);
-        }
         // Allow modules to return custom output.
         $args = $this->eventManager->prepareArgs([
-            'format' => $format,
-            'jsonLd' => $jsonLd,
+            'model' => $model,
+            'payload' => $payload,
+            'format' => $this->format,
             'output' => $output,
-            'representations' => $representations,
         ]);
         $this->eventManager->trigger('api.output.serialize', $this, $args);
         return $args['output'];

--- a/application/src/View/Strategy/ApiJsonStrategy.php
+++ b/application/src/View/Strategy/ApiJsonStrategy.php
@@ -28,6 +28,8 @@ class ApiJsonStrategy extends JsonStrategy
         'jsonld' => 'application/ld+json',
     ];
 
+    protected $eventManager;
+
     /**
      * Constructor, sets the renderer object
      *

--- a/application/test/OmekaTest/View/Renderer/ApiJsonRendererTest.php
+++ b/application/test/OmekaTest/View/Renderer/ApiJsonRendererTest.php
@@ -14,6 +14,12 @@ class ApiJsonRendererTest extends TestCase
     public function setUp(): void
     {
         $this->eventManager = $this->createMock('Laminas\EventManager\EventManager');
+        $this->eventManager->expects($this->any())
+            ->method('prepareArgs')
+            ->will($this->returnCallback(function ($arg) {
+                return $arg;
+            })
+        );
     }
 
     public function testRendererUsesApiResponse()

--- a/application/test/OmekaTest/View/Renderer/ApiJsonRendererTest.php
+++ b/application/test/OmekaTest/View/Renderer/ApiJsonRendererTest.php
@@ -9,6 +9,13 @@ use Omeka\Test\TestCase;
 
 class ApiJsonRendererTest extends TestCase
 {
+    protected $eventManager;
+
+    public function setUp(): void
+    {
+        $this->eventManager = $this->createMock('Laminas\EventManager\EventManager');
+    }
+
     public function testRendererUsesApiResponse()
     {
         $testValue = ['test' => 'foo'];
@@ -22,7 +29,7 @@ class ApiJsonRendererTest extends TestCase
               ->method('getApiResponse')
               ->will($this->returnValue($response));
 
-        $renderer = new ApiJsonRenderer;
+        $renderer = new ApiJsonRenderer($this->eventManager);
         $this->assertEquals(Json::encode($testValue), $renderer->render($model));
     }
 
@@ -38,7 +45,7 @@ class ApiJsonRendererTest extends TestCase
               ->method('getApiResponse')
               ->will($this->returnValue($response));
 
-        $renderer = new ApiJsonRenderer;
+        $renderer = new ApiJsonRenderer($this->eventManager);
         $this->assertEquals(null, $renderer->render($model));
     }
 
@@ -57,7 +64,7 @@ class ApiJsonRendererTest extends TestCase
               ->method('getException')
               ->will($this->returnValue($exception));
 
-        $renderer = new ApiJsonRenderer;
+        $renderer = new ApiJsonRenderer($this->eventManager);
         $this->assertEquals(Json::encode(['errors' => ['foo' => ['bar']]]), $renderer->render($model));
     }
 }

--- a/application/test/OmekaTest/View/Strategy/ApiJsonStrategyTest.php
+++ b/application/test/OmekaTest/View/Strategy/ApiJsonStrategyTest.php
@@ -11,14 +11,22 @@ use Omeka\Test\TestCase;
 class ApiJsonStrategyTest extends TestCase
 {
     public $renderer;
+    public $eventManager;
     public $strategy;
     public $event;
 
     public function setUp(): void
     {
         $this->renderer = $this->createMock('Omeka\View\Renderer\ApiJsonRenderer');
+        $this->eventManager = $this->createMock('Laminas\EventManager\EventManager');
+        $this->eventManager->expects($this->any())
+            ->method('prepareArgs')
+            ->will($this->returnCallback(function ($arg) {
+                return $arg;
+            })
+        );
 
-        $this->strategy = new ApiJsonStrategy($this->renderer);
+        $this->strategy = new ApiJsonStrategy($this->renderer, $this->eventManager);
 
         $this->event = new ViewEvent;
         $httpResponse = new HttpResponse;


### PR DESCRIPTION
Looking at [this post](https://forum.omeka.org/t/export-data-and-lido/18271) and it occurs to me that we don't have a way for modules to add output formats. We recently added the RDF outputs provided by EasyRdf, but it would be great to add an event or events where a module could transform the JSON-LD to, say, LIDO.

This PR adds two events that modules can use to customize the output:

- `api.output.formats`: Attach a handler to add a format/mime-type.
- `api.output.serialize`: Attach a handler to detect the format and set a custom output string

Implementations would look something like this:

```php
$sharedEventManager->attach(
    '*',
    'api.output.formats',
    function (ZendEvent $event) {
        $formats = $event->getParam('formats');
        $formats['xml'] = 'application/xml';
        $event->setParam('formats', $formats);
    }
);
$sharedEventManager->attach(
    '*',
    'api.output.serialize',
    function (ZendEvent $event) {
        $renderer = $event->getTarget();
        $model = $event->getParam('model');
        $format = $event->getParam('format');
        $payload = $event->getParam('payload');
        $output = $event->getParam('output');
        if ($format !== 'xml') {
            return;
        }
        $output = '<xml><foo>foobar</foo></xml>';
        $event->setParam('output', $output);
    }
);
```