### PR TITLE
Add events to allow modules to select values used in fulltext search

### DIFF
--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -694,7 +694,14 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
         $services = $this->getServiceLocator();
         $dataTypes = $services->get('Omeka\DataTypeManager');
         $view = $services->get('ViewRenderer');
+        $eventManager = $this->getEventManager();
+
         $criteria = Criteria::create()->where(Criteria::expr()->eq('isPublic', true));
+        $args = $eventManager->prepareArgs(['resource' => $resource, 'criteria' => $criteria]);
+        $event = new Event('api.get_fulltext_text.value_criteria', $this, $args);
+        $eventManager->triggerEvent($event);
+        $criteria = $args['criteria'];
+
         $texts = [];
         foreach ($resource->getValues()->matching($criteria) as $value) {
             $valueRepresentation = new ValueRepresentation($value, $services);
@@ -702,7 +709,17 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             // Add value annotation text, if any.
             $valueAnnotation = $value->getValueAnnotation();
             if ($valueAnnotation) {
-                foreach ($valueAnnotation->getValues()->matching($criteria) as $value) {
+                $valueAnnotationCriteria = Criteria::create()->where(Criteria::expr()->eq('isPublic', true));
+                $args = $eventManager->prepareArgs([
+                    'resource' => $resource,
+                    'value' => $value,
+                    'criteria' => $valueAnnotationCriteria,
+                ]);
+                $event = new Event('api.get_fulltext_text.value_annotation_criteria', $this, $args);
+                $eventManager->triggerEvent($event);
+                $valueAnnotationCriteria = $args['criteria'];
+
+                foreach ($valueAnnotation->getValues()->matching($valueAnnotationCriteria) as $value) {
                     $valueRepresentation = new ValueRepresentation($value, $services);
                     $texts[] = $dataTypes->getForExtract($value)->getFulltextText($view, $valueRepresentation);
                 }


### PR DESCRIPTION
Some values may not be wanted in the full-text index, either because of their content size (trying to index large amounts of text can seriously impact overall performances of the application) or because their content is irrelevant or add too much noise to the search results

This patch adds two new events:
- api.get_fulltext_text.value_criteria
- api.get_fulltext_text.value_annotation_criteria

Both events have `resource` and `criteria` as arguments and can modify `criteria`.
api.get_fulltext_text.value_annotation_criteria has an additional argument, `value`.