### PR TITLE
Add title to property and class select options

### DIFF
--- a/application/src/Form/Element/AbstractVocabularyMemberSelect.php
+++ b/application/src/Form/Element/AbstractVocabularyMemberSelect.php
@@ -70,6 +70,7 @@ abstract class AbstractVocabularyMemberSelect extends Select implements EventMan
             } elseif ('resource_classes' === $resourceName) {
                 $attributes['data-resource-class-id'] = $member->id();
             }
+            $attributes['title'] = $member->comment();
             $option = [
                 'label' => $member->label(),
                 'value' => $termAsValue ? $member->term() : $member->id(),

--- a/application/src/Form/Element/AbstractVocabularyMemberSelect.php
+++ b/application/src/Form/Element/AbstractVocabularyMemberSelect.php
@@ -70,7 +70,7 @@ abstract class AbstractVocabularyMemberSelect extends Select implements EventMan
             } elseif ('resource_classes' === $resourceName) {
                 $attributes['data-resource-class-id'] = $member->id();
             }
-            $attributes['title'] = $member->comment();
+            $attributes['title'] = $member->term();
             $option = [
                 'label' => $member->label(),
                 'value' => $termAsValue ? $member->term() : $member->id(),

--- a/application/src/Form/Element/PropertySelect.php
+++ b/application/src/Form/Element/PropertySelect.php
@@ -44,6 +44,7 @@ class PropertySelect extends AbstractVocabularyMemberSelect
                         'attributes' => [
                             'data-term' => $property->term(),
                             'data-property-id' => $property->id(),
+                            'title' => $member->comment(),
                         ],
                     ];
                 }

--- a/application/src/Form/Element/PropertySelect.php
+++ b/application/src/Form/Element/PropertySelect.php
@@ -44,7 +44,7 @@ class PropertySelect extends AbstractVocabularyMemberSelect
                         'attributes' => [
                             'data-term' => $property->term(),
                             'data-property-id' => $property->id(),
-                            'title' => $member->comment(),
+                            'title' => $member->term(),
                         ],
                     ];
                 }


### PR DESCRIPTION
It is possible for one vocabulary to have more than one distinct but identically labeled properties and classes. This ambiguity can cause [problems](https://forum.omeka.org/t/alternate-label-not-displaying-in-two-cases/19270/14). This PR adds a title attribute to vocabulary member select options, which contains the member comment, which is probably enough to disambiguate them. Maybe it should include the local name as well?