### PR TITLE
Fix TypeError when building user batch update form

### DIFF
--- a/application/src/Service/Form/UserBatchUpdateFormFactory.php
+++ b/application/src/Service/Form/UserBatchUpdateFormFactory.php
@@ -9,7 +9,7 @@ class UserBatchUpdateFormFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
     {
-        $form = new UserBatchUpdateForm(null, $options);
+        $form = new UserBatchUpdateForm(null, $options ?? []);
         $form->setEventManager($services->get('EventManager'));
         return $form;
     }


### PR DESCRIPTION
Trying to edit users in batch causes this TypeError:

    Laminas\Form\Fieldset::__construct(): Argument #2 ($options) must be of type array, null given, called in .../application/src/Service/Form/UserBatchUpdateFormFactory.php on line 12