### PR TITLE
Added status API to api-local route.

### DIFF
--- a/application/config/routes.config.php
+++ b/application/config/routes.config.php
@@ -247,6 +247,7 @@ return [
                 'options' => [
                     'route' => '/api-local',
                     'defaults' => [
+                        '__API__' => true,
                         'controller' => 'Omeka\Controller\ApiLocal',
                     ],
                 ],


### PR DESCRIPTION
Is there a reason why api-local has no `__API__`?