### PR TITLE
Add title attribute to YouTube media iframe to improve accessibility

### DIFF
--- a/application/src/Media/Renderer/Youtube.php
+++ b/application/src/Media/Renderer/Youtube.php
@@ -23,6 +23,13 @@ class Youtube implements RendererInterface
         if (!isset($options['allowfullscreen'])) {
             $options['allowfullscreen'] = self::ALLOWFULLSCREEN;
         }
+        if (!isset($options['title'])) {
+	    if ($media->displayTitle() != $media->source()) {
+                $options['title'] = $media->displayTitle();
+	    } else {
+	        $options['title'] = 'YouTube video';
+	    }
+        }
 
         // Compose the YouTube embed URL and build the markup.
         $data = $media->mediaData();
@@ -36,7 +43,8 @@ class Youtube implements RendererInterface
         }
         $url->setQuery($query);
         $embed = sprintf(
-            '<iframe width="%s" height="%s" src="%s" frameborder="0"%s></iframe>',
+            '<iframe title="%s" width="%s" height="%s" src="%s" frameborder="0"%s></iframe>',
+            $view->escapeHtml($options['title']),
             $view->escapeHtml($options['width']),
             $view->escapeHtml($options['height']),
             $view->escapeHtml($url),


### PR DESCRIPTION
Adds a "title" attribute to the iframe for YouTube media to improve accessibility.

If no title was set on the media a default title is set instead.

Previous discussion on the forum:
* https://forum.omeka.org/t/youtube-media-iframe-elements-do-not-have-a-title/20198
* https://forum.omeka.org/t/how-do-i-add-alt-text-on-images-and-other-accessibility-features-for-screen-reader-users-when-the-alt-text-module-does-not-appear-to-do-that/12719