### PR TITLE
Return nothing when resource has no subject values

### DIFF
--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -548,10 +548,19 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
         $perPage = $options['perPage'] ?? null;
         $siteId = $options['siteId'] ?? null;
 
+        $subjectValuePropertiesItems = $adapter->getSubjectValueProperties($this->resource, 'items', $siteId);
+        $subjectValuePropertiesItemSets = $adapter->getSubjectValueProperties($this->resource, 'item_sets', $siteId);
+        $subjectValuePropertiesMedia = $adapter->getSubjectValueProperties($this->resource, 'media', $siteId);
+
+        if (!$subjectValuePropertiesItems && !$subjectValuePropertiesItemSets && !$subjectValuePropertiesMedia) {
+            // This resource has no subject values;
+            return null;
+        }
+
         $resourcePropertiesAll = [
-            'items' => $adapter->getSubjectValueProperties($this->resource, 'items', $siteId),
-            'item_sets' => $adapter->getSubjectValueProperties($this->resource, 'item_sets', $siteId),
-            'media' => $adapter->getSubjectValueProperties($this->resource, 'media', $siteId),
+            'items' => $subjectValuePropertiesItems,
+            'item_sets' => $subjectValuePropertiesItemSets,
+            'media' => $subjectValuePropertiesMedia,
         ];
         // Find the default resource property by detecting the first resource
         // type that has properties.


### PR DESCRIPTION
Otherwise public resource pages will display empty linked resource tables.