### PR TITLE
Moved creation of thumbnail urls from MediaRepresentation to ThumbnailManager.

### DIFF
--- a/application/src/Api/Representation/AbstractRepresentation.php
+++ b/application/src/Api/Representation/AbstractRepresentation.php
@@ -97,7 +97,7 @@ abstract class AbstractRepresentation implements RepresentationInterface
     /**
      * Get one thumbnail of this representation.
      *
-     * @return Asset
+     * @return AssetRepresentation
      */
     public function thumbnail()
     {

--- a/application/src/Api/Representation/MediaRepresentation.php
+++ b/application/src/Api/Representation/MediaRepresentation.php
@@ -60,48 +60,24 @@ class MediaRepresentation extends AbstractResourceEntityRepresentation
      *
      * @param string $type The type of thumbnail
      * @return string
+     *
+     * @uses \Omeka\File\ThumbnailManager::thumbnailUrl()
      */
     public function thumbnailUrl($type)
     {
-        $thumbnailManager = $this->getServiceLocator()->get('Omeka\File\ThumbnailManager');
-
-        if (!$this->hasThumbnails() || !$thumbnailManager->typeExists($type)) {
-            $fallbacks = $thumbnailManager->getFallbacks();
-            $mediaType = $this->mediaType();
-            $topLevelType = strstr((string) $mediaType, '/', true);
-
-            if (isset($fallbacks[$mediaType])) {
-                // Prioritize a match against the full media type, e.g. "image/jpeg"
-                $fallback = $fallbacks[$mediaType];
-            } elseif ($topLevelType && isset($fallbacks[$topLevelType])) {
-                // Then fall back on a match against the top-level type, e.g. "image"
-                $fallback = $fallbacks[$topLevelType];
-            } else {
-                $fallback = $thumbnailManager->getDefaultFallback();
-            }
-
-            $assetUrl = $this->getServiceLocator()->get('ViewHelperManager')->get('assetUrl');
-            return $assetUrl($fallback[0], $fallback[1], true, false, true);
-        }
-        return $this->getFileUrl($type, $this->storageId(), 'jpg');
+        return $this->getServiceLocator()->get('Omeka\File\ThumbnailManager')->thumbnailUrl($this, $type);
     }
 
     /**
      * Get all thumbnail URLs, keyed by type.
      *
      * @return array
+     *
+     * @uses \Omeka\File\ThumbnailManager::thumbnailUrls()
      */
     public function thumbnailUrls()
     {
-        if (!$this->hasThumbnails()) {
-            return [];
-        }
-        $thumbnailManager = $this->getServiceLocator()->get('Omeka\File\ThumbnailManager');
-        $urls = [];
-        foreach ($thumbnailManager->getTypes() as $type) {
-            $urls[$type] = $this->thumbnailUrl($type);
-        }
-        return $urls;
+        return $this->getServiceLocator()->get('Omeka\File\ThumbnailManager')->thumbnailUrls($this);
     }
 
     /**


### PR DESCRIPTION
To make media more generic, the creation of the thumbnail urls may be moved into the thumbnail manager. It will make creation of thumbnails more flexible, in particular for media iiif, where the image server can create thumbnail itself, but it will be for a next pr if this one is passed.