### PR TITLE
Separate record and text in full text search

### DIFF
--- a/application/Module.php
+++ b/application/Module.php
@@ -710,7 +710,7 @@ class Module extends AbstractModule
         }
         $qb = $event->getParam('queryBuilder');
 
-        $match = 'MATCH(omeka_fulltext_search.title, omeka_fulltext_search.text) AGAINST (:omeka_fulltext_search)';
+        $match = 'MATCH(omeka_fulltext_search.title, omeka_fulltext_search.record, omeka_fulltext_search.text) AGAINST (:omeka_fulltext_search)';
 
         if ('api.search.query' === $event->getName()) {
 

--- a/application/data/doctrine-proxies/__CG__OmekaEntityFulltextSearch.php
+++ b/application/data/doctrine-proxies/__CG__OmekaEntityFulltextSearch.php
@@ -67,10 +67,10 @@ class FulltextSearch extends \Omeka\Entity\FulltextSearch implements \Doctrine\O
     public function __sleep()
     {
         if ($this->__isInitialized__) {
-            return ['__isInitialized__', 'id', 'resource', 'owner', 'isPublic', 'title', 'text'];
+            return ['__isInitialized__', 'id', 'resource', 'owner', 'isPublic', 'title', 'record', 'text'];
         }
 
-        return ['__isInitialized__', 'id', 'resource', 'owner', 'isPublic', 'title', 'text'];
+        return ['__isInitialized__', 'id', 'resource', 'owner', 'isPublic', 'title', 'record', 'text'];
     }
 
     /**
@@ -271,6 +271,28 @@ class FulltextSearch extends \Omeka\Entity\FulltextSearch implements \Doctrine\O
         $this->__initializer__ && $this->__initializer__->__invoke($this, 'getTitle', []);
 
         return parent::getTitle();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setRecord($record)
+    {
+
+        $this->__initializer__ && $this->__initializer__->__invoke($this, 'setRecord', [$record]);
+
+        return parent::setRecord($record);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRecord()
+    {
+
+        $this->__initializer__ && $this->__initializer__->__invoke($this, 'getRecord', []);
+
+        return parent::getRecord();
     }
 
     /**

--- a/application/data/install/schema.sql
+++ b/application/data/install/schema.sql
@@ -33,6 +33,7 @@ CREATE TABLE `fulltext_search` (
   `text` longtext COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`,`resource`),
   KEY `IDX_AA31FE4A7E3C61F9` (`owner_id`),
+  KEY `is_public` (`is_public`),
   FULLTEXT KEY `IDX_AA31FE4A2B36786B3B8BA7C7` (`title`,`text`),
   CONSTRAINT `FK_AA31FE4A7E3C61F9` FOREIGN KEY (`owner_id`) REFERENCES `user` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/application/data/install/schema.sql
+++ b/application/data/install/schema.sql
@@ -30,11 +30,13 @@ CREATE TABLE `fulltext_search` (
   `owner_id` int DEFAULT NULL,
   `is_public` tinyint(1) NOT NULL,
   `title` longtext COLLATE utf8mb4_unicode_ci,
+  `record` longtext COLLATE utf8mb4_unicode_ci,
   `text` longtext COLLATE utf8mb4_unicode_ci,
   PRIMARY KEY (`id`,`resource`),
   KEY `IDX_AA31FE4A7E3C61F9` (`owner_id`),
   KEY `is_public` (`is_public`),
-  FULLTEXT KEY `IDX_AA31FE4A2B36786B3B8BA7C7` (`title`,`text`),
+  FULLTEXT KEY `IDX_AA31FE4A2B36786B9B349F91` (`title`,`record`),
+  FULLTEXT KEY `IDX_AA31FE4A3B8BA7C7` (`text`),
   CONSTRAINT `FK_AA31FE4A7E3C61F9` FOREIGN KEY (`owner_id`) REFERENCES `user` (`id`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 CREATE TABLE `item` (

--- a/application/data/migrations/20240219000003_AddIndexFullTextIsPublic.php
+++ b/application/data/migrations/20240219000003_AddIndexFullTextIsPublic.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Omeka\Db\Migrations;
+
+use Doctrine\DBAL\Connection;
+use Omeka\Db\Migration\MigrationInterface;
+
+class AddIndexFullTextIsPublic implements MigrationInterface
+{
+    public function up(Connection $conn)
+    {
+        $sql = <<<'SQL'
+ALTER TABLE `fulltext_search` ADD INDEX `is_public` (`is_public`);
+SQL;
+        try {
+            $conn->executeStatement($sql);
+        } catch (\Exception $e) {
+            // Index exists.
+        }
+    }
+}

--- a/application/data/migrations/20240219000004_SeparateRecordAndTextForFullText.php
+++ b/application/data/migrations/20240219000004_SeparateRecordAndTextForFullText.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Omeka\Db\Migrations;
+
+use Doctrine\DBAL\Connection;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Omeka\Db\Migration\ConstructedMigrationInterface;
+use Omeka\Job\Dispatcher as JobDispatcher;
+
+class SeparateRecordAndTextForFullText implements ConstructedMigrationInterface
+{
+    /**
+     * @var \Omeka\Job\Dispatcher
+     */
+    private $jobDispatcher;
+
+    public function __construct(JobDispatcher $jobDispatcher)
+    {
+        $this->jobDispatcher = $jobDispatcher;
+    }
+
+    public function up(Connection $conn)
+    {
+        $sql = <<<'SQL'
+TRUNCATE TABLE `fulltext_search`;
+
+ALTER TABLE `fulltext_search`
+ADD `record` longtext COLLATE 'utf8mb4_unicode_ci' NULL AFTER `title`;
+
+ALTER TABLE `fulltext_search`
+ADD FULLTEXT `IDX_AA31FE4A2B36786B9B349F91` (`title`, `record`),
+ADD FULLTEXT `IDX_AA31FE4A3B8BA7C7` (`text`),
+DROP INDEX `IDX_AA31FE4A2B36786B3B8BA7C7`;
+
+SQL;
+        $conn->executeStatement($sql);
+
+        $this->jobDispatcher->dispatch(\DerivativeMedia\Job\DerivativeItem::class);
+    }
+
+    public static function create(ServiceLocatorInterface $services)
+    {
+        return new self($services->get(\Omeka\Job\Dispatcher::class));
+    }
+}

--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -715,7 +715,17 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
         return $resource->getTitle();
     }
 
+    public function getFulltextRecord($resource)
+    {
+        return $this->getFulltext($resource, 'record');
+    }
+
     public function getFulltextText($resource)
+    {
+        return $this->getFulltext($resource, 'text');
+    }
+
+    protected function getFulltext($resource, string $type)
     {
         $services = $this->getServiceLocator();
         $dataTypes = $services->get('Omeka\DataTypeManager');
@@ -723,7 +733,11 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
         $eventManager = $this->getEventManager();
 
         $criteria = Criteria::create()->where(Criteria::expr()->eq('isPublic', true));
-        $args = $eventManager->prepareArgs(['resource' => $resource, 'criteria' => $criteria]);
+        $args = $eventManager->prepareArgs([
+            'resource' => $resource,
+            'type' => $type,
+            'criteria' => $criteria,
+        ]);
         $event = new Event('api.get_fulltext_text.value_criteria', $this, $args);
         $eventManager->triggerEvent($event);
         $criteria = $args['criteria'];
@@ -738,6 +752,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                 $valueAnnotationCriteria = Criteria::create()->where(Criteria::expr()->eq('isPublic', true));
                 $args = $eventManager->prepareArgs([
                     'resource' => $resource,
+                    'type' => $type,
                     'value' => $value,
                     'criteria' => $valueAnnotationCriteria,
                 ]);

--- a/application/src/Api/Adapter/FulltextSearchableInterface.php
+++ b/application/src/Api/Adapter/FulltextSearchableInterface.php
@@ -28,7 +28,15 @@ interface FulltextSearchableInterface
     public function getFulltextTitle($resource);
 
     /**
-     * Get the the text of the passed resource.
+     * Get the record of the passed resource.
+     *
+     * @param mixed $resource
+     * @return string
+     */
+    public function getFulltextRecord($resource);
+
+    /**
+     * Get the the raw text (transcription, ocr, etc.) of the passed resource.
      *
      * @param mixed $resource
      * @return string

--- a/application/src/Api/Adapter/ItemAdapter.php
+++ b/application/src/Api/Adapter/ItemAdapter.php
@@ -328,6 +328,22 @@ class ItemAdapter extends AbstractResourceEntityAdapter
         return $data;
     }
 
+    public function getFulltextRecord($resource)
+    {
+        $texts = [];
+        $texts[] = parent::getFulltextRecord($resource);
+        // Get media text.
+        $mediaAdapter = $this->getAdapter('media');
+        foreach ($resource->getMedia() as $media) {
+            $texts[] = $mediaAdapter->getFulltextRecord($media);
+        }
+        // Remove empty texts.
+        $texts = array_filter($texts, function ($text) {
+            return !is_null($text) && $text !== '';
+        });
+        return implode("\n", $texts);
+    }
+
     public function getFulltextText($resource)
     {
         $texts = [];

--- a/application/src/Api/Adapter/MediaAdapter.php
+++ b/application/src/Api/Adapter/MediaAdapter.php
@@ -202,6 +202,18 @@ class MediaAdapter extends AbstractResourceEntityAdapter
         return $data;
     }
 
+    public function getFulltextRecord($resource)
+    {
+        $renderer = $this->getServiceLocator()
+            ->get('Omeka\Media\Renderer\Manager')
+            ->get($resource->getRenderer());
+        $fulltextRecord = parent::getFulltextRecord($resource);
+        if ($renderer instanceof FulltextSearchableInterface) {
+            $fulltextRecord .= ' ' . $renderer->getFulltextRecord($this->getRepresentation($resource));
+        }
+        return $fulltextRecord;
+    }
+
     public function getFulltextText($resource)
     {
         $renderer = $this->getServiceLocator()

--- a/application/src/Api/Adapter/SitePageAdapter.php
+++ b/application/src/Api/Adapter/SitePageAdapter.php
@@ -355,6 +355,11 @@ class SitePageAdapter extends AbstractEntityAdapter implements FulltextSearchabl
         return $resource->getTitle();
     }
 
+    public function getFulltextRecord($resource)
+    {
+        return '';
+    }
+
     public function getFulltextText($resource)
     {
         $services = $this->getServiceLocator();

--- a/application/src/Entity/FulltextSearch.php
+++ b/application/src/Entity/FulltextSearch.php
@@ -5,6 +5,7 @@ namespace Omeka\Entity;
  * @Entity
  * @Table(
  *   indexes={
+ *     @Index(name="is_public", columns={"is_public"}),
  *     @Index(columns={"title", "text"}, flags={"fulltext"})
  *   }
  * )

--- a/application/src/Entity/FulltextSearch.php
+++ b/application/src/Entity/FulltextSearch.php
@@ -6,7 +6,8 @@ namespace Omeka\Entity;
  * @Table(
  *   indexes={
  *     @Index(name="is_public", columns={"is_public"}),
- *     @Index(columns={"title", "text"}, flags={"fulltext"})
+ *     @Index(columns={"title", "record"}, flags={"fulltext"}),
+ *     @Index(columns={"text"}, flags={"fulltext"})
  *   }
  * )
  */
@@ -39,6 +40,11 @@ class FulltextSearch
      * @Column(type="text", nullable=true)
      */
     protected $title;
+
+    /**
+     * @Column(type="text", nullable=true)
+     */
+    protected $record;
 
     /**
      * @Column(type="text", nullable=true)
@@ -93,6 +99,16 @@ class FulltextSearch
     public function getTitle()
     {
         return $this->title;
+    }
+
+    public function setRecord($record)
+    {
+        $this->record = $record;
+    }
+
+    public function getRecord()
+    {
+        return $this->record;
     }
 
     public function setText($text)

--- a/application/src/Job/IndexFulltextSearch.php
+++ b/application/src/Job/IndexFulltextSearch.php
@@ -21,7 +21,7 @@ class IndexFulltextSearch extends AbstractJob
 
         // First delete all rows from the fulltext table to clear out the
         // resources that don't belong.
-        $conn->executeStatement('DELETE FROM `fulltext_search`');
+        $conn->executeStatement('TRUNCATE TABLE `fulltext_search`');
 
         // Then iterate through all resource types and index the ones that are
         // fulltext searchable. Note that we don't index "resource" and "value

--- a/application/src/Media/Renderer/FulltextSearchableInterface.php
+++ b/application/src/Media/Renderer/FulltextSearchableInterface.php
@@ -8,7 +8,7 @@ interface FulltextSearchableInterface
     /**
      * Get the the text of the passed media.
      *
-     * @param Media $media
+     * @param MediaRepresentation $media
      * @return string
      */
     public function getFulltextText(MediaRepresentation $media);

--- a/application/src/Stdlib/FulltextSearch.php
+++ b/application/src/Stdlib/FulltextSearch.php
@@ -32,11 +32,11 @@ class FulltextSearch
         $ownerId = $owner ? $owner->getId() : null;
 
         $sql = 'INSERT INTO `fulltext_search` (
-            `id`, `resource`, `owner_id`, `is_public`, `title`, `text`
+            `id`, `resource`, `owner_id`, `is_public`, `title`, `record`, `text`
         ) VALUES (
-            :id, :resource, :owner_id, :is_public, :title, :text
+            :id, :resource, :owner_id, :is_public, :title, :record, :text
         ) ON DUPLICATE KEY UPDATE
-            `owner_id` = :owner_id, `is_public` = :is_public, `title` = :title, `text` = :text';
+            `owner_id` = :owner_id, `is_public` = :is_public, `title` = :title, `record` = :record, `text` = :text';
         $stmt = $this->conn->prepare($sql);
 
         $stmt->bindValue('id', $resourceId, PDO::PARAM_INT);
@@ -44,6 +44,7 @@ class FulltextSearch
         $stmt->bindValue('owner_id', $ownerId, PDO::PARAM_INT);
         $stmt->bindValue('is_public', $adapter->getFulltextIsPublic($resource), PDO::PARAM_BOOL);
         $stmt->bindValue('title', $adapter->getFulltextTitle($resource), PDO::PARAM_STR);
+        $stmt->bindValue('record', $adapter->getFulltextRecord($resource), PDO::PARAM_STR);
         $stmt->bindValue('text', $adapter->getFulltextText($resource), PDO::PARAM_STR);
         $stmt->executeStatement();
     }


### PR DESCRIPTION
The first commit add an index on is_public, that it was missing in last pr. This is important, because all queries use it, so it speed end users queries a lot.

The second commit separate the fulltext field in a field "record" (for the record) and a field "text" (for the text: transcription, ocr, content, etc.). Many librarians make a distinction between to search the record and to search the content and this hard to manage without recreate another search table. This second commit is complete, but requires some more work, in particular a setting to determine what is full text (bibo:content or extracttext:extracted_text and some other) and another optional setting to let user select full text or not, by default or not. To use the event is possible, but complex.

So you can cherry-pick the first and say me what you think about the second.