### PR TITLE
Light gallery media credits

### DIFF
--- a/application/src/View/Helper/LightGalleryOutput.php
+++ b/application/src/View/Helper/LightGalleryOutput.php
@@ -26,9 +26,7 @@ class LightGalleryOutput extends AbstractHelper
 
         foreach ($files as $file) {
             $media = $file['media'];
-            //echo(json_encode($media->value('dcterms:rightsHolder')->asHtml(), TRUE));
             $source = ($media->originalUrl()) ? $media->originalUrl() : $media->source();
-            $mediaTitle = $media->displayTitle();
             $mediaCredits = $media->value('dcterms:rightsHolder', ['all'=>true]);
             $renderCredits = [];
             foreach ($mediaCredits as $mediaCredit){
@@ -42,11 +40,11 @@ class LightGalleryOutput extends AbstractHelper
                 };
             }
             if (empty($renderCredits)){$renderCredits[] = 'unknown';};
-            $dataSub = "<p>" . $mediaTitle . "</p><p> © ". implode(', © ', $renderCredits) . "</p>";
+            $titleCredit = "<p>" . $media->displayTitle() . "</p><p> © ". implode(', © ', $renderCredits) . "</p>";
             $mediaCaptionOptions = [
                 'none' => '',
-                'title' => 'data-sub-html="' . $dataSub . '"'  ,
-                // 'title' => 'data-sub-html="' . $media->displayTitle() . '"',
+                'titlecredit' => 'data-sub-html="' . $titleCredit . '"'  ,
+                'title' => 'data-sub-html="' . $media->displayTitle() . '"',
                 'description' => 'data-sub-html="' . $media->displayDescription() . '"',
             ];
             $mediaCaptionAttribute = ($mediaCaption) ? $mediaCaptionOptions[$mediaCaption] : '';

--- a/application/src/View/Helper/LightGalleryOutput.php
+++ b/application/src/View/Helper/LightGalleryOutput.php
@@ -26,10 +26,27 @@ class LightGalleryOutput extends AbstractHelper
 
         foreach ($files as $file) {
             $media = $file['media'];
+            //echo(json_encode($media->value('dcterms:rightsHolder')->asHtml(), TRUE));
             $source = ($media->originalUrl()) ? $media->originalUrl() : $media->source();
+            $mediaTitle = $media->displayTitle();
+            $mediaCredits = $media->value('dcterms:rightsHolder', ['all'=>true]);
+            $renderCredits = [];
+            foreach ($mediaCredits as $mediaCredit){
+                $creditValueType =$mediaCredit->type();
+                if ('resource' == $creditValueType) {
+                    $renderCredits[] = "<a href=" . $mediaCredit . ">" . $mediaCredit->valueResource()->title() . "</a>";
+                } elseif ('uri' == $creditValueType) {
+                    $renderCredits[] =  "<a href=" . $mediaCredit->uri() . ">" . $mediaCredit . "</a>";
+                } elseif ('literal' == $creditValueType) {
+                    $renderCredits[] =  $mediaCredit;
+                };
+            }
+            if (empty($renderCredits)){$renderCredits[] = 'unknown';};
+            $dataSub = "<p>" . $mediaTitle . "</p><p> © ". implode(', © ', $renderCredits) . "</p>";
             $mediaCaptionOptions = [
                 'none' => '',
-                'title' => 'data-sub-html="' . $media->displayTitle() . '"',
+                'title' => 'data-sub-html="' . $dataSub . '"'  ,
+                // 'title' => 'data-sub-html="' . $media->displayTitle() . '"',
                 'description' => 'data-sub-html="' . $media->displayDescription() . '"',
             ];
             $mediaCaptionAttribute = ($mediaCaption) ? $mediaCaptionOptions[$mediaCaption] : '';


### PR DESCRIPTION
add an option to show the credits of the media (copyrights for example). 
The credit is catched from the dcterms:rightsHolder property value of the media. 
Hyperlinking when possible. 
option has to be implemented as a themeSetting in 'media-caption' by the themes. 

PS: its a PR to you and not a Theme Helper because (I don't know why) the theme helper is not used, and directly the application helper is used. 