### PR TITLE
Filter default sites for items user setting

### DIFF
--- a/application/asset/js/global.js
+++ b/application/asset/js/global.js
@@ -227,7 +227,7 @@ var Omeka = {
                 tableRowCell.text(tableRowValue);
             });
             selectorRow.addClass('added');
-            table.append(tableRow).removeClass('empty').trigger('appendRow');
+            table.children('.resource-rows').append(tableRow).removeClass('empty').trigger('appendRow');
             updateResourceCount(id);
         }
 

--- a/application/asset/js/global.js
+++ b/application/asset/js/global.js
@@ -235,6 +235,10 @@ var Omeka = {
             var resource = selector.find('[data-resource-id="' + id + '"]');
             var resourceParent = resource.parents('.selector-parent');
             var childCount = resourceParent.find('.selector-child-count').first();
+            // Update the count only when the resource exists in the selector.
+            if (!selector.find(`.selector-child[data-resource-id="${id}"]`).length) {
+                return;
+            }
             if (resource.hasClass('added')) {
                 var newTotalCount = parseInt(selectorCount.text()) - 1;
                 var newChildCount = parseInt(childCount.text()) - 1;

--- a/application/src/Api/Adapter/ItemAdapter.php
+++ b/application/src/Api/Adapter/ItemAdapter.php
@@ -258,13 +258,11 @@ class ItemAdapter extends AbstractResourceEntityAdapter
                 if (!$site) {
                     // Assign site that was not already assigned.
                     $site = $siteAdapter->findEntity($siteId);
-                    if ($acl->userIsAllowed($site, 'can-assign-items')) {
+                    if ($acl->userIsAllowed($site, 'can-assign-items') || ($isCreate && $assignNewItemsSites->contains($site))) {
                         // A user with the "can-assign-items" privilege can assign
-                        // a site at any time.
-                        $sites->set($site->getId(), $site);
-                    } elseif ($isCreate && $assignNewItemsSites->contains($site)) {
-                        // A user without the "can-assign-items" privilege can assign
-                        // a site only on CREATE when the site has assignNewItems=true.
+                        // a site at any time. A user without the "can-assign-items"
+                        // privilege can assign a site only on CREATE when the site
+                        // has assignNewItems=true.
                         $sites->set($site->getId(), $site);
                     }
                 }

--- a/application/src/Api/Adapter/ItemAdapter.php
+++ b/application/src/Api/Adapter/ItemAdapter.php
@@ -254,7 +254,11 @@ class ItemAdapter extends AbstractResourceEntityAdapter
                 if (!$site) {
                     // Assign site that was not already assigned.
                     $site = $siteAdapter->findEntity($siteId);
-                    if ($acl->userIsAllowed($site, 'can-assign-items')) {
+                    if ($isCreate) {
+                        // Only on create can users assign to sites if they don't
+                        // otherwise have permission to do so.
+                        $sites->set($site->getId(), $site);
+                    } elseif ($acl->userIsAllowed($site, 'can-assign-items')) {
                         $sites->set($site->getId(), $site);
                     }
                 }

--- a/application/src/Api/Adapter/ItemAdapter.php
+++ b/application/src/Api/Adapter/ItemAdapter.php
@@ -1,6 +1,7 @@
 <?php
 namespace Omeka\Api\Adapter;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\QueryBuilder;
 use Omeka\Api\Exception;
 use Omeka\Api\Request;
@@ -217,16 +218,19 @@ class ItemAdapter extends AbstractResourceEntityAdapter
                 }
             }
         }
-        if ($isCreate && !is_array($request->getValue('o:site'))) {
-            // On CREATE and when no "o:site" array is passed, assign this item
-            // to all sites where assignNewItems=true.
-            $dql = '
-                SELECT site
+        if ($isCreate) {
+            // On CREATE we will need sites where assignNewItems=true.
+            $dql = 'SELECT site
                 FROM Omeka\Entity\Site site
                 WHERE site.assignNewItems = true';
             $query = $this->getEntityManager()->createQuery($dql);
+            $assignNewItemsSites = new ArrayCollection($query->getResult());
+        }
+        if ($isCreate && !is_array($request->getValue('o:site'))) {
+            // On CREATE and when no "o:site" array is passed, assign this item
+            // to all sites where assignNewItems=true.
             $sites = $entity->getSites();
-            foreach ($query->getResult() as $site) {
+            foreach ($assignNewItemsSites as $site) {
                 $sites->set($site->getId(), $site);
             }
         } elseif ($this->shouldHydrate($request, 'o:site')) {
@@ -254,11 +258,13 @@ class ItemAdapter extends AbstractResourceEntityAdapter
                 if (!$site) {
                     // Assign site that was not already assigned.
                     $site = $siteAdapter->findEntity($siteId);
-                    if ($isCreate) {
-                        // Only on create can users assign to sites if they don't
-                        // otherwise have permission to do so.
+                    if ($acl->userIsAllowed($site, 'can-assign-items')) {
+                        // A user with the "can-assign-items" privilege can assign
+                        // a site at any time.
                         $sites->set($site->getId(), $site);
-                    } elseif ($acl->userIsAllowed($site, 'can-assign-items')) {
+                    } elseif ($isCreate && $assignNewItemsSites->contains($site)) {
+                        // A user without the "can-assign-items" privilege can assign
+                        // a site only on CREATE when the site has assignNewItems=true.
                         $sites->set($site->getId(), $site);
                     }
                 }

--- a/application/src/Form/Element/AbstractGroupByOwnerSelect.php
+++ b/application/src/Form/Element/AbstractGroupByOwnerSelect.php
@@ -50,12 +50,19 @@ abstract class AbstractGroupByOwnerSelect extends Select
             $query = [];
         }
 
-        $response = $this->getApiManager()->search($this->getResourceName(), $query);
+        $resourceReps = $this->getApiManager()->search($this->getResourceName(), $query)->getContent();
+
+        // Provide a way to filter the resource representations prior to
+        // building the value options.
+        $callback = $this->getOption('filter_resource_representations');
+        if (is_callable($callback)) {
+            $resourceReps = $callback($resourceReps);
+        }
 
         if ($this->getOption('disable_group_by_owner')) {
             // Group alphabetically by resource label without grouping by owner.
             $resources = [];
-            foreach ($response->getContent() as $resource) {
+            foreach ($resourceReps as $resource) {
                 $resources[$this->getValueLabel($resource)][] = $resource->id();
             }
             ksort($resources);
@@ -68,7 +75,7 @@ abstract class AbstractGroupByOwnerSelect extends Select
         } else {
             // Group alphabetically by owner email.
             $resourceOwners = [];
-            foreach ($response->getContent() as $resource) {
+            foreach ($resourceReps as $resource) {
                 $owner = $resource->owner();
                 $index = $owner ? $owner->email() : null;
                 $resourceOwners[$index]['owner'] = $owner;

--- a/application/src/Form/UserForm.php
+++ b/application/src/Form/UserForm.php
@@ -199,6 +199,15 @@ class UserForm extends Form
             'options' => [
                 'label' => 'Default sites for items', // @translate
                 'empty_option' => '',
+                'filter_resource_representations' => function ($sites) {
+                    // The user must have permission to assign items to the site.
+                    foreach ($sites as $index => $site) {
+                        if (!$site->userIsAllowed('can-assign-items')) {
+                            unset($sites[$index]);
+                        }
+                    }
+                    return $sites;
+                },
             ],
         ]);
         $settingsFieldset->add([

--- a/application/view/omeka/admin/item/manage-sites.phtml
+++ b/application/view/omeka/admin/item/manage-sites.phtml
@@ -1,25 +1,43 @@
 <?php
+$canAssignItemsSites = [];
+$cannotAssignItemsSites = [];
+
 if ($item) {
-    $siteRepresentations = $item->sites();
+    // This is an existing item.
+
+    $sites = $item->sites();
+    foreach ($sites as $site) {
+        if ($site->userIsAllowed('can-assign-items')) {
+            $canAssignItemsSites[] = ['id' => $site->id()];
+        } else {
+            $cannotAssignItemsSites[$site->id()] = $site;
+        }
+    }
 } else {
-    $siteRepresentations = $this->api()->search('sites', ['assign_new_items' => true])->getContent();
+    // This is a new item.
 
-    $userDefaultSites = $this->userSetting('default_item_sites');
-    if (is_array($userDefaultSites)) {
-        $userDefaultSiteRepresentations = $this->api()->search('sites', ['id' => $userDefaultSites])->getContent();
-        $siteRepresentations = array_merge($siteRepresentations, $userDefaultSiteRepresentations);
+    // Get all sites that allow item assignment in site settings.
+    $sites = $this->api()->search('sites', ['assign_new_items' => true])->getContent();
+    foreach ($sites as $site) {
+        if ($site->userIsAllowed('can-assign-items')) {
+            $canAssignItemsSites[] = ['id' => $site->id()];
+        } else {
+            $cannotAssignItemsSites[$site->id()] = $site;
+        }
     }
-}
 
-$sites = [];
-foreach ($siteRepresentations as $siteRepresentation) {
-    // The user must have permission to assign items to the site.
-    if (!$siteRepresentation->userIsAllowed('can-assign-items')) {
-        continue;
+    // Get all sites that the user set as default in user settings.
+    $defaultItemSites = $this->userSetting('default_item_sites');
+    $sites = is_array($defaultItemSites)
+        ? $this->api()->search('sites', ['id' => $defaultItemSites])->getContent()
+        : [];
+    foreach ($sites as $site) {
+        if ($site->userIsAllowed('can-assign-items')) {
+            $canAssignItemsSites[] = ['id' => $site->id()];
+        } else {
+            $cannotAssignItemsSites[$site->id()] = $site;
+        }
     }
-    $sites[] = [
-        'id' => $siteRepresentation->id(),
-    ];
 }
 
 $siteTemplate = '
@@ -34,7 +52,7 @@ $siteTemplate = '
     </td>
 </tr>';
 ?>
-<table id="item-sites" data-existing-rows="<?php echo $this->escapeHtml(json_encode(array_values($sites))); ?>" data-row-template="<?php echo $this->escapeHtml($siteTemplate); ?>" data-tablesaw-mode="stack" class="selector-table tablesaw tablesaw-stack <?php echo ($item && (count($sites) > 0)) ? '' : 'empty'; ?>">
+<table id="item-sites" data-existing-rows="<?php echo $this->escapeHtml(json_encode($canAssignItemsSites)); ?>" data-row-template="<?php echo $this->escapeHtml($siteTemplate); ?>" data-tablesaw-mode="stack" class="selector-table tablesaw tablesaw-stack <?php echo ($item && (count($sites) > 0)) ? '' : ''; ?>">
     <thead>
     <tr>
         <th><?php echo $this->translate('Title'); ?></th>
@@ -42,7 +60,20 @@ $siteTemplate = '
         <th></th>
     </tr>
     </thead>
-    <tbody class="resource-rows"></tbody>
+    <tbody class="resource-rows">
+        <?php foreach ($cannotAssignItemsSites as $site): ?>
+        <tr class="resource-row">
+            <td class="data-value" data-row-key="child-search"><?php echo $this->escapeHtml($site->title()); ?></td>
+            <td class="data-value" data-row-key="resource-email"><?php echo $this->escapeHtml($site->owner()->email()); ?></td>
+            <td>
+                <ul class="actions">
+                    <li><?php echo $this->hyperlink('', '#', ['class' => 'o-icon-delete', 'title' => $this->translate('Unassign from site')]); ?></li>
+                </ul>
+                <input type="hidden" name="o:site[]" class="resource-id">
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
 </table>
 
 <div class="no-resources">

--- a/application/view/omeka/admin/item/manage-sites.phtml
+++ b/application/view/omeka/admin/item/manage-sites.phtml
@@ -13,6 +13,10 @@ if ($item) {
 
 $sites = [];
 foreach ($siteRepresentations as $siteRepresentation) {
+    // The user must have permission to assign items to the site.
+    if (!$siteRepresentation->userIsAllowed('can-assign-items')) {
+        continue;
+    }
     $sites[] = [
         'id' => $siteRepresentation->id(),
     ];

--- a/application/view/omeka/admin/item/manage-sites.phtml
+++ b/application/view/omeka/admin/item/manage-sites.phtml
@@ -69,7 +69,7 @@ $siteTemplate = '
                 <ul class="actions">
                     <li><?php echo $this->hyperlink('', '#', ['class' => 'o-icon-delete', 'title' => $this->translate('Unassign from site')]); ?></li>
                 </ul>
-                <input type="hidden" name="o:site[]" class="resource-id">
+                <input type="hidden" name="o:site[]" class="resource-id" value="<?php echo $this->escapeHtml($site->id()); ?>">
             </td>
         </tr>
         <?php endforeach; ?>


### PR DESCRIPTION
This is an attempt to resolve a conflict between the "assign_new_items" site setting and the "can-assign-items" user permission. Put simply, a site can be set to automatically assign itself to new items, but the user can lack the permission to assign items to the site. This conflict could lead to a broken "Site" tab on the item add page (see #2166).

This PR fixes the conflict by a) limiting the sites on the site selector sidebar to those that the current user has "can-assign-items" permission; and b) adding the sites that are "assign_new_items" but restricted by "can-assign-items" to the "Site" tab, giving users the opportunity to assign these restricted sites, but _only_ on the item add page. A few other changes to the site selector element, the item adapter, and JS were necessary to accomplish this.