### PR TITLE
Add options to pagination helper

### DIFF
--- a/application/src/View/Helper/Pagination.php
+++ b/application/src/View/Helper/Pagination.php
@@ -31,6 +31,8 @@ class Pagination extends AbstractHelper
      */
     protected $fragment;
 
+    protected $options;
+
     /**
      * Construct the helper.
      *
@@ -44,14 +46,18 @@ class Pagination extends AbstractHelper
     /**
      * Configure the pagination.
      *
+     * Options:
+     *   - page_key: The page # key passed in the URL query (defualt: "page")
+     *
      * @param string|null $partialName Name of view script
      * @param int|null $totalCount The total record count
      * @param int|null $currentPage The current page number
      * @param int|null $perPage The number of records per page
+     * @param array $options
      * @return self
      */
     public function __invoke($partialName = null, $totalCount = null, $currentPage = null,
-        $perPage = null
+        $perPage = null, array $options = []
     ) {
         if (null !== $totalCount) {
             $this->getPaginator()->setTotalCount($totalCount);
@@ -63,6 +69,7 @@ class Pagination extends AbstractHelper
             $this->getPaginator()->setPerPage($perPage);
         }
         $this->partialName = $partialName ?: self::PARTIAL_NAME;
+        $this->options = $options;
         return $this;
     }
 
@@ -99,6 +106,7 @@ class Pagination extends AbstractHelper
                 'lastPageUrl' => $this->getUrl($pageCount),
                 'pagelessUrl' => $this->getPagelessUrl(),
                 'offset' => $paginator->getOffset(),
+                'options' => $this->options,
             ]
         );
     }
@@ -127,7 +135,7 @@ class Pagination extends AbstractHelper
     protected function getUrl($page)
     {
         $query = $this->getView()->params()->fromQuery();
-        $query['page'] = (int) $page;
+        $query[$this->options['page_key'] ?? 'page'] = (int) $page;
         if (isset($query['sort_by_default'])) {
             // Do not emit sort_by if the sort_by_default flag is set.
             unset($query['sort_by']);

--- a/application/test/OmekaTest/View/Helper/PaginationTest.php
+++ b/application/test/OmekaTest/View/Helper/PaginationTest.php
@@ -82,6 +82,7 @@ class PaginationTest extends TestCase
                     'lastPageUrl' => null,
                     'pagelessUrl' => null,
                     'offset' => null,
+                    'options' => [],
                 ])
             )
             ->will($this->returnValue(''));

--- a/application/view/common/linked-resources.phtml
+++ b/application/view/common/linked-resources.phtml
@@ -2,7 +2,7 @@
 use Laminas\Form\Element\Select;
 
 // Set up pagination.
-$pagination = $this->pagination(null, $totalCount, $page, $perPage);
+$pagination = $this->pagination(null, $totalCount, $page, $perPage, ['page_key' => 'linked_resources_page']);
 $fragment = 'resources-linked';
 $pagination->setFragment($fragment);
 

--- a/application/view/common/pagination.phtml
+++ b/application/view/common/pagination.phtml
@@ -12,7 +12,7 @@ if (isset($query['sort_by_default'])) {
 <?php if ($totalCount): ?>
     <form method="GET" action="">
         <?php echo $this->queryToHiddenInputs($removeQueries); ?>
-        <input type="text" name="page" class="page-input-top" value="<?php echo $currentPage; ?>" size="4" <?php echo ($pageCount == 1) ? 'readonly' : ''; ?> aria-label="<?php echo $translate('Page'); ?>">
+        <input type="text" name="<?php echo $this->escapeHtml($options['page_key'] ?? 'page'); ?>" class="page-input-top" value="<?php echo $currentPage; ?>" size="4" <?php echo ($pageCount == 1) ? 'readonly' : ''; ?> aria-label="<?php echo $translate('Page'); ?>">
         <span class="page-count"><?php echo sprintf($translate('of %s'), $pageCount); ?></span>
     </form>
 

--- a/application/view/omeka/admin/item/show.phtml
+++ b/application/view/omeka/admin/item/show.phtml
@@ -40,7 +40,7 @@ $itemMedia = $item->media();
 <div id="resources-linked" class="section">
     <?php if ($item->subjectValueTotalCount()): ?>
         <?php echo $item->displaySubjectValues([
-            'page' => $this->params()->fromQuery('page', 1),
+            'page' => $this->params()->fromQuery('linked_resources_page', 1),
             'perPage' => 25,
             'resourceProperty' => $this->params()->fromQuery('resource_property'),
         ]); ?>


### PR DESCRIPTION
This adds the ability for views to set options to the pagination view helper. The option included in this PR is "page_key" which is the page # key passed in the URL query (default is "page"). This makes it possible to have more than one type of pagination on one page.