### PR TITLE
Load linked resource interface asynchronously

### DIFF
--- a/application/asset/js/linked-resources.js
+++ b/application/asset/js/linked-resources.js
@@ -2,16 +2,19 @@ $(document).ready(function () {
 
     // Render linked resources.
     const renderLinkedResources = function(page, resourceProperty) {
-        let url = container.data('url');
-        searchParams = new URLSearchParams;
+        const url = container.data('url');
+        const siteId = container.data('siteId');
+        const query = {};
+        if (siteId) {
+            query.site_id = siteId;
+        }
         if (page) {
-            searchParams.append('page', page);
+            query.page = page;
         }
         if (resourceProperty) {
-            searchParams.append('resource_property', resourceProperty);
+            query.resource_property = resourceProperty
         }
-        url += '?' + searchParams.toString();
-        $.get(url, function(data) {
+        $.get(url, query, function(data) {
             container.html(data);
         });
     };

--- a/application/asset/js/linked-resources.js
+++ b/application/asset/js/linked-resources.js
@@ -1,0 +1,7 @@
+$(document).ready(function () {
+    const container = $('#linked-resources-container');
+    const url = container.data('url');
+    $.get(url, function(data) {
+        container.html(data);
+    });
+});

--- a/application/asset/js/linked-resources.js
+++ b/application/asset/js/linked-resources.js
@@ -1,7 +1,51 @@
 $(document).ready(function () {
+
+    // Render linked resources.
+    const renderLinkedResources = function(page, resourceProperty) {
+        let url = container.data('url');
+        searchParams = new URLSearchParams;
+        if (page) {
+            searchParams.append('page', page);
+        }
+        if (resourceProperty) {
+            searchParams.append('resource_property', resourceProperty);
+        }
+        url += '?' + searchParams.toString();
+        $.get(url, function(data) {
+            container.html(data);
+        });
+    };
+
+    // Render linked resources on initial load.
     const container = $('#linked-resources-container');
-    const url = container.data('url');
-    $.get(url, function(data) {
-        container.html(data);
+    renderLinkedResources();
+
+    // Handle next and previous clicks.
+    $(container).on('click', 'a.next, a.previous', function(e) {
+        e.preventDefault();
+        const thisButton = $(this);
+        // Note that we can use any base URL for this purpose.
+        const url = new URL(thisButton.attr('href'), 'http://foo');
+        renderLinkedResources(
+            url.searchParams.get('page'),
+            url.searchParams.get('resource_property')
+        );
+    });
+
+    // Handle page form submission.
+    $(container).on('submit', 'form', function(e) {
+        e.preventDefault();
+        const thisForm = $(this);
+        const searchParams = new URLSearchParams(thisForm.serialize());
+        renderLinkedResources(
+            searchParams.get('page'),
+            searchParams.get('resource_property')
+        );
+    });
+
+    // Handle resource property select.
+    $(container).on('change', '#resource-property-select', function(e) {
+        const thisSelect = $(this);
+        renderLinkedResources('1', thisSelect.val());
     });
 });

--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -363,6 +363,7 @@ return [
             'Omeka\Controller\Admin\Item' => Service\Controller\Admin\ItemControllerFactory::class,
             'Omeka\Controller\SiteAdmin\Index' => Service\Controller\SiteAdmin\IndexControllerFactory::class,
             'Omeka\Controller\Site\Page' => Service\Controller\Site\PageControllerFactory::class,
+            'Omeka\Controller\LinkedResources' => Service\Controller\LinkedResourcesControllerFactory::class,
         ],
     ],
     'controller_plugins' => [
@@ -489,6 +490,7 @@ return [
             'passwordRequirements' => Service\ViewHelper\PasswordRequirementsFactory::class,
             'resourcePageBlocks' => Service\ViewHelper\ResourcePageBlocksFactory::class,
             'browse' => Service\ViewHelper\BrowseFactory::class,
+            'linkedResources' => Service\ViewHelper\LinkedResourcesFactory::class,
         ],
         'shared' => [
             'resourcePageBlocks' => false,

--- a/application/config/routes.config.php
+++ b/application/config/routes.config.php
@@ -377,6 +377,19 @@ return [
                     ],
                 ],
             ],
+            'linked-resources' => [
+                'type' => \Laminas\Router\Http\Segment::class,
+                'options' => [
+                    'route' => '/linked-resources/:resource-id',
+                    'defaults' => [
+                        'controller' => 'Omeka\Controller\LinkedResources',
+                        'action' => 'index',
+                    ],
+                    'constraints' => [
+                        'resource-id' => '\d+',
+                    ],
+                ],
+            ],
         ],
     ],
 ];

--- a/application/src/Controller/LinkedResourcesController.php
+++ b/application/src/Controller/LinkedResourcesController.php
@@ -4,11 +4,11 @@ namespace Omeka\Controller;
 use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\ViewModel;
 
-
 class LinkedResourcesController extends AbstractActionController
 {
     public function __construct()
-    {}
+    {
+    }
 
     public function indexAction()
     {

--- a/application/src/Controller/LinkedResourcesController.php
+++ b/application/src/Controller/LinkedResourcesController.php
@@ -1,0 +1,22 @@
+<?php
+namespace Omeka\Controller;
+
+use Laminas\Mvc\Controller\AbstractActionController;
+use Laminas\View\Model\ViewModel;
+
+
+class LinkedResourcesController extends AbstractActionController
+{
+    public function __construct()
+    {}
+
+    public function indexAction()
+    {
+        $resource = $this->api()->read('resources', $this->params('resource-id'))->getContent();
+
+        $view = new ViewModel;
+        $view->setTerminal(true);
+        $view->setVariable('resource', $resource);
+        return $view;
+    }
+}

--- a/application/src/Service/Controller/LinkedResourcesControllerFactory.php
+++ b/application/src/Service/Controller/LinkedResourcesControllerFactory.php
@@ -1,0 +1,14 @@
+<?php
+namespace Omeka\Service\Controller;
+
+use Interop\Container\ContainerInterface;
+use Omeka\Controller\LinkedResourcesController;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class LinkedResourcesControllerFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        return new LinkedResourcesController;
+    }
+}

--- a/application/src/Service/ViewHelper/LinkedResourcesFactory.php
+++ b/application/src/Service/ViewHelper/LinkedResourcesFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Omeka\Service\ViewHelper;
+
+use Omeka\View\Helper\LinkedResources;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Interop\Container\ContainerInterface;
+
+class LinkedResourcesFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $services, $requestedName, array $options = null)
+    {
+        return new LinkedResources;
+    }
+}

--- a/application/src/View/Helper/LinkedResources.php
+++ b/application/src/View/Helper/LinkedResources.php
@@ -7,7 +7,8 @@ use Omeka\Api\Representation\AbstractResourceEntityRepresentation;
 class LinkedResources extends AbstractHelper
 {
     public function __construct()
-    {}
+    {
+    }
 
     public function __invoke(AbstractResourceEntityRepresentation $resource, int $siteId = null)
     {

--- a/application/src/View/Helper/LinkedResources.php
+++ b/application/src/View/Helper/LinkedResources.php
@@ -1,0 +1,21 @@
+<?php
+namespace Omeka\View\Helper;
+
+use Laminas\View\Helper\AbstractHelper;
+use Omeka\Api\Representation\AbstractResourceEntityRepresentation;
+
+class LinkedResources extends AbstractHelper
+{
+    public function __construct()
+    {}
+
+    public function __invoke(AbstractResourceEntityRepresentation $resource)
+    {
+        $view = $this->getView();
+        $view->headScript()->appendFile($view->assetUrl('js/linked-resources.js', 'Omeka'));
+        return sprintf(
+            '<div id="linked-resources-container" data-url="%s"></div>',
+            $view->url('linked-resources', ['resource-id' => $resource->id()])
+        );
+    }
+}

--- a/application/src/View/Helper/LinkedResources.php
+++ b/application/src/View/Helper/LinkedResources.php
@@ -9,13 +9,14 @@ class LinkedResources extends AbstractHelper
     public function __construct()
     {}
 
-    public function __invoke(AbstractResourceEntityRepresentation $resource)
+    public function __invoke(AbstractResourceEntityRepresentation $resource, int $siteId = null)
     {
         $view = $this->getView();
         $view->headScript()->appendFile($view->assetUrl('js/linked-resources.js', 'Omeka'));
         return sprintf(
-            '<div id="linked-resources-container" data-url="%s"></div>',
-            $view->url('linked-resources', ['resource-id' => $resource->id()])
+            '<div id="linked-resources-container" data-url="%s" data-site-id="%s"></div>',
+            $view->url('linked-resources', ['resource-id' => $resource->id()]),
+            $view->escapeHtml($siteId)
         );
     }
 }

--- a/application/view/common/linked-resources.phtml
+++ b/application/view/common/linked-resources.phtml
@@ -93,14 +93,3 @@ $caption = sprintf(
 <?php echo ($totalCount > $perPage) ? '<div class="linked-footer">' . $pagination . '</div>' : ''; ?>
 
 </div>
-
-<script>
-const propertySelect = $('#resource-property-select');
-const url = propertySelect.data('url');
-const fragment = propertySelect.data('fragment');
-propertySelect.on('change', function(e) {
-    const selectedOption = propertySelect.find(':selected');
-    const resourceProperty = selectedOption.val();
-    window.location = url + '?' + $.param({resource_property: resourceProperty}) + '#' + fragment;
-});
-</script>

--- a/application/view/common/resource-page-block-layout/linked-resources.phtml
+++ b/application/view/common/resource-page-block-layout/linked-resources.phtml
@@ -1,17 +1,9 @@
 <?php
-$options = [
-    'page' => $this->params()->fromQuery('page', 1),
-    'perPage' => 25,
-    'resourceProperty' => $this->params()->fromQuery('resource_property'),
-];
+$siteId = null;
 if ($this->siteSetting('exclude_resources_not_in_site')) {
-    $options['siteId'] = $this->currentSite()->id();
+    $siteId = $this->currentSite()->id();
 }
-$subjectValues = $resource->displaySubjectValues($options);
 ?>
-<?php if ($subjectValues): ?>
-<div id="resources-linked">
-    <h3><?php echo $this->translate('Linked resources'); ?></h3>
-    <?php echo $subjectValues; ?>
-</div>
+<?php if ($resource->subjectValueTotalCount(null, null, $siteId)): ?>
+<?php echo $this->linkedResources($resource, $siteId); ?>
 <?php endif; ?>

--- a/application/view/omeka/admin/item-set/show.phtml
+++ b/application/view/omeka/admin/item-set/show.phtml
@@ -49,18 +49,12 @@ $sectionNavs = [
 
 <div id="resources-linked" class="section">
     <?php if ($itemSet->subjectValueTotalCount()): ?>
-        <p><?php echo $translate('The following resources link to this item set:'); ?></p>
-        <?php echo $itemSet->displaySubjectValues([
-            'page' => $this->params()->fromQuery('page', 1),
-            'perPage' => 25,
-            'resourceProperty' => $this->params()->fromQuery('resource_property'),
-        ]); ?>
+    <?php echo $this->linkedResources($itemSet); ?>
     <?php else: ?>
-        <div class="no-resources">
-            <p><?php echo $translate('No resources link to this item set.'); ?></p>
-        </div>
-    <?php endif; ?>
-</div>
+    <div class="no-resources">
+        <p><?php echo $translate('No resources link to this item set.'); ?></p>
+    </div>
+<?php endif; ?>
 
 <div class="active sidebar">
     <div class="meta-group">

--- a/application/view/omeka/admin/item/show.phtml
+++ b/application/view/omeka/admin/item/show.phtml
@@ -38,17 +38,7 @@ $itemMedia = $item->media();
 </div>
 
 <div id="resources-linked" class="section">
-    <?php if ($item->subjectValueTotalCount()): ?>
-        <?php echo $item->displaySubjectValues([
-            'page' => $this->params()->fromQuery('page', 1),
-            'perPage' => 25,
-            'resourceProperty' => $this->params()->fromQuery('resource_property'),
-        ]); ?>
-    <?php else: ?>
-        <div class="no-resources">
-            <p><?php echo $translate('No resources link to this item.'); ?></p>
-        </div>
-    <?php endif; ?>
+    <?php echo $this->linkedResources($item); ?>
 </div>
 
 <div class="sidebar active">

--- a/application/view/omeka/admin/item/show.phtml
+++ b/application/view/omeka/admin/item/show.phtml
@@ -38,7 +38,14 @@ $itemMedia = $item->media();
 </div>
 
 <div id="resources-linked" class="section">
+    <?php if ($item->subjectValueTotalCount()): ?>
     <?php echo $this->linkedResources($item); ?>
+    <?php else: ?>
+    <div class="no-resources">
+        <p><?php echo $translate('No resources link to this item.'); ?></p>
+    </div>
+<?php endif; ?>
+
 </div>
 
 <div class="sidebar active">

--- a/application/view/omeka/linked-resources/index.phtml
+++ b/application/view/omeka/linked-resources/index.phtml
@@ -1,0 +1,11 @@
+<?php if ($resource->subjectValueTotalCount()): ?>
+    <?php echo $resource->displaySubjectValues([
+        'page' => $this->params()->fromQuery('page', 1),
+        'perPage' => 25,
+        'resourceProperty' => $this->params()->fromQuery('resource_property'),
+    ]); ?>
+<?php else: ?>
+    <div class="no-resources">
+        <p><?php echo $translate('No resources link to this resource.'); ?></p>
+    </div>
+<?php endif; ?>

--- a/application/view/omeka/linked-resources/index.phtml
+++ b/application/view/omeka/linked-resources/index.phtml
@@ -1,11 +1,5 @@
-<?php if ($resource->subjectValueTotalCount()): ?>
-    <?php echo $resource->displaySubjectValues([
-        'page' => $this->params()->fromQuery('page', 1),
-        'perPage' => 25,
-        'resourceProperty' => $this->params()->fromQuery('resource_property'),
-    ]); ?>
-<?php else: ?>
-    <div class="no-resources">
-        <p><?php echo $translate('No resources link to this resource.'); ?></p>
-    </div>
-<?php endif; ?>
+<?php echo $resource->displaySubjectValues([
+    'page' => $this->params()->fromQuery('page', 1),
+    'perPage' => 25,
+    'resourceProperty' => $this->params()->fromQuery('resource_property'),
+]); ?>


### PR DESCRIPTION
This PR converts the linked resources interface into one that loads asynchronously. This isolates the interface from the surrounding one, which avoids unintended interactions such as pagination queries clobbering each other.