### PR TITLE
Checked value of resource template select before setting default user param.

### DIFF
--- a/application/view/common/resource-fields.phtml
+++ b/application/view/common/resource-fields.phtml
@@ -18,7 +18,7 @@ if (isset($resource)) {
     if ($owner = $resource->owner()) {
         $ownerSelect->setValue($owner->id());
     }
-} else {
+} elseif (!$resourceTemplateSelect->getValue()) {
     // Set the logged in user's default template when adding a resource.
     $resourceTemplateSelect->setValue($this->userSetting('default_resource_template'));
 }


### PR DESCRIPTION
In some cases (modules that modify the form), the template may be already set, so the user setting should be set only if not set.
Anyway, all this functional part should be somewhere else than a view.