### PR TITLE
unset prop value in api

### DIFF
--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -388,6 +388,16 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
     }
 
     /**
+     * Unset a term in the representations.
+     *
+     * @param string $term The prefix:local_part
+     * @return null
+     */
+    public function unsetTerm($term){
+        unset($this->{'values'}[$term]);
+    }
+
+    /**
      * Get value representations where this resource is the RDF object.
      *
      * @param int $page


### PR DESCRIPTION
This light and simple api method allows to unset a value (property) in an item representation.
- Because it's better than filter it xx times in loops
- Because values of item representation are protected
- Because the view file can't do such filtering (with parameters)
- Because it does not affect the item itself, so it is safe

thx