### PR TITLE
Max block attachments option

### DIFF
--- a/application/asset/js/site-page-edit.js
+++ b/application/asset/js/site-page-edit.js
@@ -197,6 +197,22 @@
         });
     }
 
+    /**
+     * Enable max attachments.
+     *
+     * Hides the "Add attachment" button when the number of attachments equals
+     * or exceeds the maxAttachments setting.
+     *
+     * @param object attachmentsContainer
+     */
+    function enableMaxAttachments(attachmentsContainer) {
+        var attachments = attachmentsContainer.children('.attachment');
+        var maxAttachments = parseInt(attachmentsContainer.data('maxAttachments'), 10);
+        if (maxAttachments && attachments.length >= maxAttachments) {
+            attachmentsContainer.children('button.attachment-add').hide();
+        }
+    }
+
     $(document).ready(function () {
         var blockIndex = 0;
 
@@ -237,15 +253,9 @@
             });
         });
 
-        // Hide "Add attachment" buttons when the number of attachments equal or
-        // exceed the maxAttachments setting.
+        // Enable max attachmnets.
         $('.attachments').each(function() {
-            var attachmentsContainer = $(this);
-            var attachments = attachmentsContainer.children('.attachment');
-            var maxAttachments = parseInt(attachmentsContainer.data('maxAttachments'), 10);
-            if (maxAttachments && attachments.length >= maxAttachments) {
-                attachmentsContainer.children('button.attachment-add').hide();
-            }
+            enableMaxAttachments($(this));
         });
 
         // Hide the bulk select controls when there is a maxAttachment setting.
@@ -462,14 +472,8 @@
                 attachment.find('.item-title').empty().append(thumbnail).append(title);
             }
 
-            // Hide the "Add attachment" button when the number of attachments
-            // equal or exceed the maxAttachments setting.
-            var attachmentsContainer = $('.selecting-attachment').closest('.attachments');
-            var attachments = attachmentsContainer.children('.attachment');
-            var maxAttachments = parseInt(attachmentsContainer.data('maxAttachments'), 10);
-            if (maxAttachments && attachments.length >= maxAttachments) {
-                attachmentsContainer.children('button.attachment-add').hide();
-            }
+            // Enable max attachmnets.
+            enableMaxAttachments($('.selecting-attachment').closest('.attachments'));
         });
 
         $('#blocks').on('click', '.asset-options-configure', function(e) {

--- a/application/asset/js/site-page-edit.js
+++ b/application/asset/js/site-page-edit.js
@@ -237,6 +237,26 @@
             });
         });
 
+        // Hide "Add attachment" buttons when the number of attachments equal or
+        // exceed the maxAttachments setting.
+        $('.attachments').each(function() {
+            var attachmentsContainer = $(this);
+            var attachments = attachmentsContainer.children('.attachment');
+            var maxAttachments = parseInt(attachmentsContainer.data('maxAttachments'), 10);
+            if (maxAttachments && attachments.length >= maxAttachments) {
+                attachmentsContainer.children('button.attachment-add').hide();
+            }
+        });
+
+        // Hide the bulk select controls when there is a maxAttachment setting.
+        $('#select-resource').on('o:sidebar-content-loaded', function() {
+            var thisSidebar = $(this);
+            var attachmentsContainer = $('.selecting-attachment').closest('.attachments');
+            var maxAttachments = parseInt(attachmentsContainer.data('maxAttachments'), 10);
+            var bulkSelectControls = thisSidebar.find('.quick-select-toggle, .select-all');
+            maxAttachments ? bulkSelectControls.hide() : bulkSelectControls.show();
+        });
+
         $('#new-block button').on('click', function() {
             $.post(
                 $(this).parents('#new-block').data('url'),
@@ -440,6 +460,15 @@
                     thumbnail = $('<img>', {src: thumbnailUrl});
                 }
                 attachment.find('.item-title').empty().append(thumbnail).append(title);
+            }
+
+            // Hide the "Add attachment" button when the number of attachments
+            // equal or exceed the maxAttachments setting.
+            var attachmentsContainer = $('.selecting-attachment').closest('.attachments');
+            var attachments = attachmentsContainer.children('.attachment');
+            var maxAttachments = parseInt(attachmentsContainer.data('maxAttachments'), 10);
+            if (maxAttachments && attachments.length >= maxAttachments) {
+                attachmentsContainer.children('button.attachment-add').hide();
             }
         });
 

--- a/application/src/View/Helper/BlockAttachmentsForm.php
+++ b/application/src/View/Helper/BlockAttachmentsForm.php
@@ -22,7 +22,7 @@ class BlockAttachmentsForm extends AbstractHelper
      * @return string
      */
     public function __invoke(SitePageBlockRepresentation $block = null, $itemOnly = false,
-        array $itemQuery = [], ?int $maxAttachments = 1)
+        array $itemQuery = [], ?int $maxAttachments = null)
     {
         return $this->getView()->partial('common/attachments-form', [
             'block' => $block,

--- a/application/src/View/Helper/BlockAttachmentsForm.php
+++ b/application/src/View/Helper/BlockAttachmentsForm.php
@@ -22,12 +22,13 @@ class BlockAttachmentsForm extends AbstractHelper
      * @return string
      */
     public function __invoke(SitePageBlockRepresentation $block = null, $itemOnly = false,
-        array $itemQuery = [])
+        array $itemQuery = [], ?int $maxAttachments = 1)
     {
         return $this->getView()->partial('common/attachments-form', [
             'block' => $block,
             'itemOnly' => (bool) $itemOnly,
             'itemQuery' => $itemQuery,
+            'maxAttachments' => $maxAttachments,
         ]);
     }
 }

--- a/application/view/common/attachments-form.phtml
+++ b/application/view/common/attachments-form.phtml
@@ -18,7 +18,7 @@ $attachmentRowTemplate = '
 ?>
 <div class="attachments-form<?php echo $this->itemOnly ? ' attachments-item-only' : ''; ?>" data-item-query="<?php echo $escape(json_encode($this->itemQuery)); ?>">
     <a href="#" class="collapse"><h4><?php echo $translate('Attachments'); ?></h4></a>
-    <div class="attachments collapsible" data-template="<?php echo $escape($attachmentRowTemplate); ?>">
+    <div class="attachments collapsible" data-template="<?php echo $escape($attachmentRowTemplate); ?>" data-max-attachments="<?php echo $this->escapeHtml($maxAttachments); ?>">
         <?php foreach ($attachments as $attachment): ?>
         <?php
         $itemId = null;


### PR DESCRIPTION
This PR adds an option to set a maximum number of attachments allowed in a block. A developer would set `$maxAttahments` when calling the `blockAttachmentsForm()` view helper. It's more of a superficial maximum, rather than an enforced one, because it simply hides the "Add attachment" button when the number of attachments reaches the maximum. It also hides the bulk add controls in the sidebar if a maximum is set.

The use case I'm working on that needs this feature is the ImageAnnotate module. I would like there to be a way to prevent more than one attachment on the block: one block, one image to annotate.