### PR TITLE
Set correct total results for returnScalar requests

### DIFF
--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -316,7 +316,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
             }
             $content = array_column($qb->getQuery()->getScalarResult(), $scalarField, 'id');
             $response = new Response($content);
-            $response->setTotalResults(count($content));
+            $response->setTotalResults($countPaginator->count());
             return $response;
         }
 


### PR DESCRIPTION
I'm not sure why I initially set the total results to the count of the current response content, but getting the total results from the count paginator seems like the correct approach.