### PR TITLE
Fix missing check if original folder exits.

### DIFF
--- a/application/src/Controller/Admin/SystemInfoController.php
+++ b/application/src/Controller/Admin/SystemInfoController.php
@@ -134,9 +134,12 @@ class SystemInfoController extends AbstractActionController
                 $info['Free space']['Local files'] = $this->formatSpace($freeSpaceFiles);
             }
             // Manage the case where directory "original" is mounted separately.
-            $freeSpaceOriginal = disk_free_space($freeSpaceFilesDir . '/original');
-            if ($freeSpaceFiles !== $freeSpaceOriginal) {
-                $info['Free space']['Local files (original)'] = $this->formatSpace($freeSpaceOriginal);
+            $freeSpaceOriginalDir = $freeSpaceFilesDir . '/original';
+            if (file_exists($freeSpaceOriginalDir)) {
+                $freeSpaceOriginal = disk_free_space($freeSpaceOriginalDir);
+                if ($freeSpaceFiles !== $freeSpaceOriginal) {
+                    $info['Free space']['Local files (original)'] = $this->formatSpace($freeSpaceOriginal);
+                }
             }
         }
         $freeSpaceTemp = disk_free_space($this->getDirTemp());


### PR DESCRIPTION
This pull request fix missing check if original folder exits. 

In early stages when no files are handled, the ```original``` folder does not exist yet, with the result of an error when calling ```disk_free_space ``` with a non existing folder path.

