### PR TITLE
Implemented module page template and module block template

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -746,6 +746,7 @@ return [
             ],
         ],
     ],
+    'page_templates' => [],
     'block_templates' => [],
     'block_layouts' => [
         'invokables' => [

--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -746,6 +746,7 @@ return [
             ],
         ],
     ],
+    'block_templates' => [],
     'block_layouts' => [
         'invokables' => [
             'pageTitle' => Site\BlockLayout\PageTitle::class,

--- a/application/src/Service/ThemeManagerFactory.php
+++ b/application/src/Service/ThemeManagerFactory.php
@@ -16,6 +16,7 @@ class ThemeManagerFactory implements FactoryInterface
     {
         // Prepare injection of module templates.
         $config = $serviceLocator->get('Config');
+        $modulePageTemplates = $config['page_templates'];
         $moduleBlockTemplates = $config['block_templates'];
 
         $manager = new ThemeManager;
@@ -68,6 +69,11 @@ class ThemeManagerFactory implements FactoryInterface
             $theme->setState(ThemeManager::STATE_ACTIVE);
 
             // Inject module templates.
+            if (count($modulePageTemplates)) {
+                $configSpec['page_templates'] = empty($configSpec['page_templates'])
+                    ? $modulePageTemplates
+                    : array_merge_recursive($configSpec['page_templates'], $modulePageTemplates);
+            }
             if (count($moduleBlockTemplates)) {
                 $configSpec['block_templates'] = empty($configSpec['block_templates'])
                     ? $moduleBlockTemplates

--- a/application/src/Service/ThemeManagerFactory.php
+++ b/application/src/Service/ThemeManagerFactory.php
@@ -14,6 +14,10 @@ class ThemeManagerFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, array $options = null)
     {
+        // Prepare injection of module templates.
+        $config = $serviceLocator->get('Config');
+        $moduleBlockTemplates = $config['block_templates'];
+
         $manager = new ThemeManager;
         $iniReader = new IniReader;
 
@@ -62,6 +66,14 @@ class ThemeManagerFactory implements FactoryInterface
             }
 
             $theme->setState(ThemeManager::STATE_ACTIVE);
+
+            // Inject module templates.
+            if (count($moduleBlockTemplates)) {
+                $configSpec['block_templates'] = empty($configSpec['block_templates'])
+                    ? $moduleBlockTemplates
+                    : array_merge_recursive($configSpec['block_templates'], $moduleBlockTemplates);
+            }
+            $theme->setConfigSpec($configSpec);
         }
 
         // Note that, unlike the ModuleManagerFactory, this does not register


### PR DESCRIPTION
The possibility to create multiple templates for blocks is very practical. There is just a last point: let modules create templates too. For example a module can implement a specific template for browse preview, whatever the theme is.

This feature is implemented in the new version of the module BlockPlus, but it should be usable by any module.

Technically, i prefered to inject the module templates (a list of key-value pairs for path/label) inside the theme data because it is the simplest way, but it can be done in a heavy way.