### PR TITLE
Add option to skip Paginator count

### DIFF
--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -272,26 +272,21 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
 
         // Add the LIMIT clause.
         $this->limitQuery($qb, $query);
-
-        // Set whether to skip the Paginator count. Setting to true, or setting
-        // none of the queries used for pagination, will skip getting the total
-        // count from the Paginaor.
-        $skipPaginatorCount = $request->getOption('skipPaginatorCount');
-        if (null === $skipPaginatorCount
-            && !isset($query['page'])
-            && !isset($query['per_page'])
-            && !isset($query['limit'])
-            && !isset($query['offset'])
-        ) {
-            $skipPaginatorCount = true;
-        }
+        $maxResults = $qb->getMaxResults();
+        $firstResult = $qb->getFirstResult();
 
         // Before adding the ORDER BY clause, set a paginator responsible for
-        // getting the total count. This optimization excludes the ORDER BY
-        // clause from the count query, greatly speeding up response time.
-        $countQb = clone $qb;
-        $countQb->select('1')->resetDQLPart('orderBy');
-        $countPaginator = new Paginator($countQb, false);
+        // getting the total count (unless configured not to or when no search
+        // params needed for pagination are set).
+        $countQueryDefault = $maxResults || $firstResult > 0;
+        $countQuery = $request->getOption('countQuery') ?? $countQueryDefault;
+        if ($countQuery) {
+            $countQb = clone $qb;
+            // This optimization excludes the ORDER BY clause from the count
+            // query, greatly speeding up response time.
+            $countQb->select('1')->resetDQLPart('orderBy');
+            $countPaginator = new Paginator($countQb, false);
+        }
 
         // Add the ORDER BY clause. Always sort by entity ID in addition to any
         // sorting the adapters add.
@@ -328,7 +323,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
             }
             $content = array_column($qb->getQuery()->getScalarResult(), $scalarField, 'id');
             $response = new Response($content);
-            $response->setTotalResults($skipPaginatorCount ? count($content) : $countPaginator->count());
+            $response->setTotalResults($countQuery ? $countPaginator->count() : count($content));
             return $response;
         }
 
@@ -343,7 +338,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
         $entities = [];
         // Don't make the request if the LIMIT is set to zero. Useful if the
         // only information needed is total results.
-        if ($qb->getMaxResults() || null === $qb->getMaxResults()) {
+        if ($maxResults !== 0) {
             foreach ($paginator as $entity) {
                 if (is_array($entity)) {
                     // Remove non-entity columns added to the SELECT. You can use
@@ -355,7 +350,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
         }
 
         $response = new Response($entities);
-        $response->setTotalResults($skipPaginatorCount ? count($entities) : $countPaginator->count());
+        $response->setTotalResults($countQuery ? $countPaginator->count() : count($entities));
         return $response;
     }
 

--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -276,9 +276,9 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
         $firstResult = $qb->getFirstResult();
 
         // Before adding the ORDER BY clause, set a paginator responsible for
-        // getting the total count (unless configured not to or when no search
-        // params needed for pagination are set).
-        $countQueryDefault = $maxResults || $firstResult > 0;
+        // getting the total count (unless configured not to or when no pagination
+        // is set.
+        $countQueryDefault = $maxResults !== null || $firstResult > 0;
         $countQuery = $request->getOption('countQuery') ?? $countQueryDefault;
         if ($countQuery) {
             $countQb = clone $qb;

--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -279,7 +279,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
         // getting the total count (unless configured not to or when no pagination
         // is set.
         $countQueryDefault = $maxResults !== null || $firstResult > 0;
-        $countQuery = $request->getOption('countQuery') ?? $countQueryDefault;
+        $countQuery = $request->getOption('countQuery', $countQueryDefault);
         if ($countQuery) {
             $countQb = clone $qb;
             // This optimization excludes the ORDER BY clause from the count

--- a/application/src/Api/Request.php
+++ b/application/src/Api/Request.php
@@ -200,7 +200,10 @@ class Request
      *     - representation: an API resource representation (implements Omeka\Api\Representation\RepresentationInterface)
      *     - reference: an API resource reference (instance of Omeka\Api\Representation\ResourceReference)
      *     - resource: an API resource (implements Omeka\Api\ResourceInterface)
-     *
+     * - skipPaginatorCount: (bool) Set whether to skip the Paginator count. Setting
+     *     to true will skip getting the total count from the Paginaor, a potentially
+     *     expensive query that's not needed when expecting all results to return
+     *     from one search.
      * @param string|int|array $spec
      * @param mixed $value
      */

--- a/application/src/Api/Request.php
+++ b/application/src/Api/Request.php
@@ -200,10 +200,12 @@ class Request
      *     - representation: an API resource representation (implements Omeka\Api\Representation\RepresentationInterface)
      *     - reference: an API resource reference (instance of Omeka\Api\Representation\ResourceReference)
      *     - resource: an API resource (implements Omeka\Api\ResourceInterface)
-     * - skipPaginatorCount: (bool) Set whether to skip the Paginator count. Setting
-     *     to true will skip getting the total count from the Paginaor, a potentially
-     *     expensive query that's not needed when expecting all results to return
-     *     from one search.
+     * - countQuery: (bool) Set whether to run the total count query during a SEARCH
+     *     request. Setting to false will skip getting the total count from the
+     *     Paginaor, a potentially expensive query that's not needed when expecting
+     *     all results to return from one search. Note that setting none of the
+     *     search params needed for pagination is equivalent to countQuery=false.
+     *     Default is true.
      * @param string|int|array $spec
      * @param mixed $value
      */

--- a/application/src/Mvc/Controller/Plugin/Api.php
+++ b/application/src/Mvc/Controller/Plugin/Api.php
@@ -77,6 +77,7 @@ class Api extends AbstractPlugin
     public function searchOne($resource, $data = [], array $options = [])
     {
         $data['limit'] = 1;
+        $options['countQuery'] = false;
         $response = $this->search($resource, $data, $options);
         $content = $response->getContent();
         $content = is_array($content) && count($content) ? reset($content) : null;

--- a/application/src/View/Helper/Api.php
+++ b/application/src/View/Helper/Api.php
@@ -49,7 +49,7 @@ class Api extends AbstractHelper
     public function searchOne($resource, $data = [])
     {
         $data['limit'] = 1;
-        $response = $this->apiManager->search($resource, $data);
+        $response = $this->apiManager->search($resource, $data, ['countQuery' => false]);
         $content = $response->getContent();
         $content = is_array($content) && count($content) ? reset($content) : null;
         $response->setContent($content);


### PR DESCRIPTION
See #2265

This adds an API request option to skip the Paginator count, but instead of passing `skipPaginatorCount=true` to every `search()` that needs it, I've set a heuristic that automatically sets the option to true when none of the queries used for pagination are set. I can't think of a situation where there's no pagination, but there's still a need for a total count calculated by the Paginator.