### PR TITLE
Remove unnecessary is_file check.

### DIFF
--- a/application/src/Service/LoggerFactory.php
+++ b/application/src/Service/LoggerFactory.php
@@ -24,7 +24,6 @@ class LoggerFactory implements FactoryInterface
         if (isset($config['logger']['log'])
             && $config['logger']['log']
             && isset($config['logger']['path'])
-            && is_file($config['logger']['path'])
             && is_writable($config['logger']['path'])
         ) {
             $writer = new Stream($config['logger']['path']);


### PR DESCRIPTION
Ref: #2285 

The standard output is not a file but should be a legitimate path that can be set since the path is writable.

This update removes the `is_file` check and allows for a logger to be created as long as the configured path is `writable`.