### PR TITLE
Pass user entity to user.logout event

### DIFF
--- a/application/src/Controller/LoginController.php
+++ b/application/src/Controller/LoginController.php
@@ -80,12 +80,13 @@ class LoginController extends AbstractActionController
 
     public function logoutAction()
     {
+        $user = $this->auth->getIdentity();
         $this->auth->clearIdentity();
 
         $sessionManager = Container::getDefaultManager();
 
         $eventManager = $this->getEventManager();
-        $eventManager->trigger('user.logout');
+        $eventManager->trigger('user.logout', $user);
 
         $sessionManager->destroy();
 


### PR DESCRIPTION
Before, there was no way for handlers to know which user logged out.