### PR TITLE
Add events on setting insert, update, and delete

### DIFF
--- a/application/src/Settings/AbstractSettings.php
+++ b/application/src/Settings/AbstractSettings.php
@@ -6,8 +6,6 @@ use Laminas\EventManager\EventManagerAwareInterface;
 use Laminas\EventManager\EventManagerAwareTrait;
 use Omeka\Mvc\Status;
 
-
-
 abstract class AbstractSettings implements SettingsInterface, EventManagerAwareInterface
 {
     use EventManagerAwareTrait;

--- a/application/src/Settings/AbstractSettings.php
+++ b/application/src/Settings/AbstractSettings.php
@@ -2,10 +2,13 @@
 namespace Omeka\Settings;
 
 use Doctrine\DBAL\Connection;
+use Laminas\EventManager\EventManagerAwareInterface;
 use Laminas\EventManager\EventManagerAwareTrait;
 use Omeka\Mvc\Status;
 
-abstract class AbstractSettings implements SettingsInterface
+
+
+abstract class AbstractSettings implements SettingsInterface, EventManagerAwareInterface
 {
     use EventManagerAwareTrait;
 

--- a/application/src/Settings/AbstractSettings.php
+++ b/application/src/Settings/AbstractSettings.php
@@ -2,10 +2,13 @@
 namespace Omeka\Settings;
 
 use Doctrine\DBAL\Connection;
+use Laminas\EventManager\EventManagerAwareTrait;
 use Omeka\Mvc\Status;
 
 abstract class AbstractSettings implements SettingsInterface
 {
+    use EventManagerAwareTrait;
+
     /**
      * @var Connection
      */
@@ -173,17 +176,26 @@ abstract class AbstractSettings implements SettingsInterface
                 ['id' => $id],
                 ['json_array']
             );
+            $this->getEventManager()->trigger('setting.update', $this, [
+                'id' => $id,
+                'value' => $value,
+            ]);
         } else {
             $this->connection->insert(
                 $this->getTableName(),
                 ['value' => $value, 'id' => $id],
                 ['json_array']
             );
+            $this->getEventManager()->trigger('setting.insert', $this, [
+                'id' => $id,
+                'value' => $value,
+            ]);
         }
     }
 
     protected function deleteSetting($id)
     {
         $this->connection->delete($this->getTableName(), ['id' => $id]);
+        $this->getEventManager()->trigger('setting.delete', $this, ['id' => $id]);
     }
 }

--- a/application/src/Settings/AbstractTargetSettings.php
+++ b/application/src/Settings/AbstractTargetSettings.php
@@ -118,12 +118,22 @@ abstract class AbstractTargetSettings extends AbstractSettings
                 ['id' => $id, $this->getTargetIdColumnName() => $this->targetId],
                 ['json_array']
             );
+            $this->getEventManager()->trigger('setting.update', $this, [
+                'target_id' => $this->targetId,
+                'id' => $id,
+                'value' => $value,
+            ]);
         } else {
             $this->connection->insert(
                 $this->getTableName(),
                 ['value' => $value, $this->getTargetIdColumnName() => $this->targetId, 'id' => $id],
                 ['json_array', \PDO::PARAM_INT]
             );
+            $this->getEventManager()->trigger('setting.insert', $this, [
+                'target_id' => $this->targetId,
+                'id' => $id,
+                'value' => $value,
+            ]);
         }
     }
 

--- a/application/src/Settings/SettingsInterface.php
+++ b/application/src/Settings/SettingsInterface.php
@@ -1,9 +1,7 @@
 <?php
 namespace Omeka\Settings;
 
-use Laminas\EventManager\EventManagerAwareInterface;
-
-interface SettingsInterface extends EventManagerAwareInterface
+interface SettingsInterface
 {
     /**
      * Set a setting.

--- a/application/src/Settings/SettingsInterface.php
+++ b/application/src/Settings/SettingsInterface.php
@@ -1,7 +1,9 @@
 <?php
 namespace Omeka\Settings;
 
-interface SettingsInterface
+use Laminas\EventManager\EventManagerAwareInterface;
+
+interface SettingsInterface extends EventManagerAwareInterface
 {
     /**
      * Set a setting.


### PR DESCRIPTION
Settings bypass the API and ORM during insert, update, and delete, so there is no way to detect changes. This PR adds events during these operations so handlers can detect them.