### PR TITLE
Cast __toString() return value to string

### DIFF
--- a/application/src/Api/Representation/ValueRepresentation.php
+++ b/application/src/Api/Representation/ValueRepresentation.php
@@ -43,7 +43,7 @@ class ValueRepresentation extends AbstractRepresentation
             'string' => $this->dataType->toString($this),
         ]);
         $eventManager->trigger('rep.value.string', $this, $args);
-        return $args['string'];
+        return (string) $args['string'];
     }
 
     /**


### PR DESCRIPTION
Prevents fatal uncaught type error "Return value must be of type string" when casting ValueRepresentation to string.