### PR TITLE
Simplify stat/mkdir in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,13 +38,7 @@ var cliOptions = minimist(process.argv.slice(2), {
 });
 
 function ensureBuildDir() {
-    return fs.statAsync(buildDir).catch(function (e) {
-        return fs.mkdirAsync(buildDir);
-    }).then(function () {
-        return fs.statAsync(buildDir + '/cache');
-    }).catch(function (e) {
-        fs.mkdirAsync(buildDir + '/cache');
-    });
+    return fs.promises.mkdir(buildDir + '/cache', {recursive: true});
 }
 
 function download(url, path) {


### PR DESCRIPTION
Node.js introduced a recursive option to mkdir in 10.x. Using it simplifies some of the code in gulpfile.js. There is no longer a need to stat the directory before calling mkdir or calling mkdir more than once.