### PR TITLE
Make Item Set Browse Results Match Paginator

### DIFF
--- a/application/src/Controller/Site/ItemSetController.php
+++ b/application/src/Controller/Site/ItemSetController.php
@@ -16,6 +16,13 @@ class ItemSetController extends AbstractActionController
 
         $query = $this->params()->fromQuery();
         $query['site_id'] = $site->id();
+
+        //this is the same approach as admin, but it will change the sort order and other defaults
+//        $this->browse()->setDefaults('item_sets');
+
+        //this will only set the page
+        $query['page'] = $query['page'] ?? 1;
+
         $response = $this->api()->search('item_sets', $query);
         $this->paginator($response->getTotalResults());
         $itemSets = $response->getContent();


### PR DESCRIPTION
This pr proposes two different ways to address #2035 by setting the query parameter for page on the site item set browse page. 

The first method calls `browse()->setDefaults()` to se the default query parameters, as is done in the admin browse. The downside to this is that it will set all defaults and change the sort order for existing installations. 

The second method sets the `page` query parameter to 1 if it is not set already. 