### PR TITLE
Make YouTube iframes accessibility compliant

### DIFF
--- a/application/src/Media/Renderer/Youtube.php
+++ b/application/src/Media/Renderer/Youtube.php
@@ -37,7 +37,7 @@ class Youtube implements RendererInterface
         }
         $url->setQuery($query);
         $embed = sprintf(
-            '<iframe width="%s" height="%s" src="%s" title="%s" frameborder="0" %s></iframe>',
+            '<iframe width="%s" height="%s" src="%s" title="%s" frameborder="0"%s></iframe>',
             $view->escapeHtml($options['width']),
             $view->escapeHtml($options['height']),
             $view->escapeHtml($url),

--- a/application/src/Media/Renderer/Youtube.php
+++ b/application/src/Media/Renderer/Youtube.php
@@ -26,6 +26,7 @@ class Youtube implements RendererInterface
 
         // Compose the YouTube embed URL and build the markup.
         $data = $media->mediaData();
+        $title = $media->displayTitle();
         $url = new HttpUri(sprintf('https://www.youtube.com/embed/%s', $data['id']));
         $query = [];
         if (isset($data['start'])) {
@@ -36,10 +37,11 @@ class Youtube implements RendererInterface
         }
         $url->setQuery($query);
         $embed = sprintf(
-            '<iframe width="%s" height="%s" src="%s" frameborder="0"%s></iframe>',
+            '<iframe width="%s" height="%s" src="%s" title="%s" frameborder="0" %s></iframe>',
             $view->escapeHtml($options['width']),
             $view->escapeHtml($options['height']),
             $view->escapeHtml($url),
+            $view->escapeHtml($title ?? $url),
             $options['allowfullscreen'] ? ' allowfullscreen' : ''
         );
         return $embed;


### PR DESCRIPTION
The iframes for embedding YouTube videos should have an accessible name even before the video loads. This sets the title for the iframe element. It's entirely possible, likely, and acceptable that the YouTube embed JavaScript will overwrite it after the video loads.