### PR TITLE
Omeka query builder

### DIFF
--- a/application/Module.php
+++ b/application/Module.php
@@ -453,8 +453,9 @@ class Module extends AbstractModule
         }
 
         $adapter = $event->getTarget();
-        $itemAlias = $adapter->createAlias();
+
         $qb = $event->getParam('queryBuilder');
+        $itemAlias = $qb->createAlias();
         $qb->innerJoin('omeka_root.item', $itemAlias);
 
         // Users can view media they do not own that belong to public items.
@@ -496,7 +497,7 @@ class Module extends AbstractModule
         $identity = $this->getServiceLocator()
             ->get('Omeka\AuthenticationService')->getIdentity();
         if ($identity) {
-            $sitePermissionAlias = $adapter->createAlias();
+            $sitePermissionAlias = $qb->createAlias();
             $qb->leftJoin('omeka_root.sitePermissions', $sitePermissionAlias);
 
             $expression = $qb->expr()->orX(

--- a/application/Module.php
+++ b/application/Module.php
@@ -468,7 +468,7 @@ class Module extends AbstractModule
                 $expression,
                 $qb->expr()->eq(
                     "$itemAlias.owner",
-                    $adapter->createNamedParameter($qb, $identity)
+                    $qb->createNamedParameter($identity)
                 )
             );
         }
@@ -504,12 +504,12 @@ class Module extends AbstractModule
                 // Users can view all sites they own.
                 $qb->expr()->eq(
                     'omeka_root.owner',
-                    $adapter->createNamedParameter($qb, $identity)
+                    $qb->createNamedParameter($identity)
                 ),
                 // Users can view sites where they have a role (any role).
                 $qb->expr()->eq(
                     "$sitePermissionAlias.user",
-                    $adapter->createNamedParameter($qb, $identity)
+                    $qb->createNamedParameter($identity)
                 )
             );
         }
@@ -743,7 +743,7 @@ class Module extends AbstractModule
 
             $joinConditions = sprintf(
                 'omeka_fulltext_search.id = omeka_root.id AND omeka_fulltext_search.resource = %s',
-                $adapter->createNamedParameter($qb, $adapter->getResourceName())
+                $qb->createNamedParameter($adapter->getResourceName())
             );
             $qb->innerJoin('Omeka\Entity\FulltextSearch', 'omeka_fulltext_search', 'WITH', $joinConditions);
 

--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -180,8 +180,8 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
     public function sortByCount(QueryBuilder $qb, array $query,
         $inverseField, $instanceOf = null
     ) {
-        $inverseAlias = $this->createAlias();
-        $countAlias = $this->createAlias();
+        $inverseAlias = $qb->createAlias();
+        $countAlias = $qb->createAlias();
 
         $qb->addSelect("COUNT($inverseAlias.id) HIDDEN $countAlias");
         if ($instanceOf) {
@@ -749,7 +749,9 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
      * Create a unique named parameter for the query builder and bind a value to
      * it.
      *
-     * @deprecated No longer used by core code. Instead, use self::createQueryBuilder() and OmekaQueryBuilder::createNamedParameter().
+     * @deprecated No longer used by core code. Instead, use Omeka's query builder:
+     *      $qb = $this->createQueryBuilder();
+     *      $namedParam = $qb->createNamedParameter($value);
      * @param QueryBuilder $qb
      * @param mixed $value The value to bind
      * @param string $prefix The placeholder prefix
@@ -767,6 +769,9 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
     /**
      * Create a unique alias for the query builder.
      *
+     * @deprecated No longer used by core code. Instead, use Omeka's query builder:
+     *      $qb = $this->createQueryBuilder();
+     *      $alias = $qb->createAlias();
      * @param string $prefix The alias prefix
      * @return string The alias
      */

--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -21,6 +21,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
     /**
      * A unique token index for query builder aliases and placeholders.
      *
+     * @deprecated 4.2.0 No longer used by core code. Use \Omeka\Db\QueryBuilder instead.
      * @var int
      */
     protected $index = 0;
@@ -749,9 +750,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
      * Create a unique named parameter for the query builder and bind a value to
      * it.
      *
-     * @deprecated No longer used by core code. Instead, use Omeka's query builder:
-     *      $qb = $this->createQueryBuilder();
-     *      $namedParam = $qb->createNamedParameter($value);
+     * @deprecated 4.2.0 No longer used by core code. Use \Omeka\Db\QueryBuilder instead.
      * @param QueryBuilder $qb
      * @param mixed $value The value to bind
      * @param string $prefix The placeholder prefix
@@ -769,9 +768,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
     /**
      * Create a unique alias for the query builder.
      *
-     * @deprecated No longer used by core code. Instead, use Omeka's query builder:
-     *      $qb = $this->createQueryBuilder();
-     *      $alias = $qb->createAlias();
+     * @deprecated 4.2.0 No longer used by core code. Use \Omeka\Db\QueryBuilder instead.
      * @param string $prefix The alias prefix
      * @return string The alias
      */

--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -27,7 +27,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
         }
 
         if (isset($query['owner_id']) && is_numeric($query['owner_id'])) {
-            $userAlias = $this->createAlias();
+            $userAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.owner',
                 $userAlias
@@ -39,7 +39,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
         }
 
         if (isset($query['resource_class_label'])) {
-            $resourceClassAlias = $this->createAlias();
+            $resourceClassAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.resourceClass',
                 $resourceClassAlias
@@ -65,7 +65,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
         }
 
         if (isset($query['resource_template_label'])) {
-            $resourceTemplateAlias = $this->createAlias();
+            $resourceTemplateAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.resourceTemplate',
                 $resourceTemplateAlias
@@ -134,7 +134,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
         if (is_string($query['sort_by'])) {
             $property = $this->getPropertyByTerm($query['sort_by']);
             if ($property) {
-                $valuesAlias = $this->createAlias();
+                $valuesAlias = $qb->createAlias();
                 $qb->leftJoin(
                     "omeka_root.values", $valuesAlias,
                     'WITH', $qb->expr()->eq("$valuesAlias.property", $property->getId())
@@ -144,15 +144,15 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                     $query['sort_order']
                 );
             } elseif ('resource_class_label' == $query['sort_by']) {
-                $resourceClassAlias = $this->createAlias();
+                $resourceClassAlias = $qb->createAlias();
                 $qb->leftJoin("omeka_root.resourceClass", $resourceClassAlias)
                     ->addOrderBy("$resourceClassAlias.label", $query['sort_order']);
             } elseif ('resource_template_label' == $query['sort_by']) {
-                $resourceTemplateAlias = $this->createAlias();
+                $resourceTemplateAlias = $qb->createAlias();
                 $qb->leftJoin("omeka_root.resourceTemplate", $resourceTemplateAlias)
                     ->addOrderBy("$resourceTemplateAlias.label", $query['sort_order']);
             } elseif ('owner_name' == $query['sort_by']) {
-                $ownerAlias = $this->createAlias();
+                $ownerAlias = $qb->createAlias();
                 $qb->leftJoin("omeka_root.owner", $ownerAlias)
                     ->addOrderBy("$ownerAlias.name", $query['sort_order']);
             } else {
@@ -306,14 +306,14 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                 $valuesAlias = $previousAlias;
                 $usePrevious = true;
             } else {
-                $valuesAlias = $this->createAlias();
+                $valuesAlias = $qb->createAlias();
                 $usePrevious = false;
             }
 
             switch ($queryType) {
                 case 'eq':
                     $param = $qb->createNamedParameter($value);
-                    $subqueryAlias = $this->createAlias();
+                    $subqueryAlias = $qb->createAlias();
                     $subquery = $this->createQueryBuilder()
                         ->select("$subqueryAlias.id")
                         ->from('Omeka\Entity\Resource', $subqueryAlias)
@@ -327,7 +327,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
 
                 case 'in':
                     $param = $qb->createNamedParameter('%' . $escapeSqlLike($value) . '%');
-                    $subqueryAlias = $this->createAlias();
+                    $subqueryAlias = $qb->createAlias();
                     $subquery = $this->createQueryBuilder()
                         ->select("$subqueryAlias.id")
                         ->from('Omeka\Entity\Resource', $subqueryAlias)
@@ -341,7 +341,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
 
                 case 'sw':
                     $param = $qb->createNamedParameter($escapeSqlLike($value) . '%');
-                    $subqueryAlias = $this->createAlias();
+                    $subqueryAlias = $qb->createAlias();
                     $subquery = $this->createQueryBuilder()
                         ->select("$subqueryAlias.id")
                         ->from('Omeka\Entity\Resource', $subqueryAlias)
@@ -355,7 +355,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
 
                 case 'ew':
                     $param = $qb->createNamedParameter('%' . $escapeSqlLike($value));
-                    $subqueryAlias = $this->createAlias();
+                    $subqueryAlias = $qb->createAlias();
                     $subquery = $this->createQueryBuilder()
                         ->select("$subqueryAlias.id")
                         ->from('Omeka\Entity\Resource', $subqueryAlias)

--- a/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractResourceEntityAdapter.php
@@ -34,7 +34,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             );
             $qb->andWhere($qb->expr()->eq(
                 "$userAlias.id",
-                $this->createNamedParameter($qb, $query['owner_id']))
+                $qb->createNamedParameter($query['owner_id']))
             );
         }
 
@@ -46,7 +46,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             );
             $qb->andWhere($qb->expr()->eq(
                 "$resourceClassAlias.label",
-                $this->createNamedParameter($qb, $query['resource_class_label']))
+                $qb->createNamedParameter($query['resource_class_label']))
             );
         }
 
@@ -59,7 +59,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             if ($classes) {
                 $qb->andWhere($qb->expr()->in(
                     'omeka_root.resourceClass',
-                    $this->createNamedParameter($qb, $classes)
+                    $qb->createNamedParameter($classes)
                 ));
             }
         }
@@ -72,7 +72,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             );
             $qb->andWhere($qb->expr()->eq(
                 "$resourceTemplateAlias.label",
-                $this->createNamedParameter($qb, $query['resource_template_label']))
+                $qb->createNamedParameter($query['resource_template_label']))
             );
         }
 
@@ -85,7 +85,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
             if ($templates) {
                 $qb->andWhere($qb->expr()->in(
                     'omeka_root.resourceTemplate',
-                    $this->createNamedParameter($qb, $templates)
+                    $qb->createNamedParameter($templates)
                 ));
             }
         }
@@ -93,7 +93,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
         if (isset($query['is_public']) && (is_numeric($query['is_public']) || is_bool($query['is_public']))) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.isPublic',
-                $this->createNamedParameter($qb, (bool) $query['is_public'])
+                $qb->createNamedParameter((bool) $query['is_public'])
             ));
         }
 
@@ -123,7 +123,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                 $qb->andWhere($qb->expr()->{$dateSearch[0]}(
                     sprintf('omeka_root.%s', $dateSearch[1]),
                     // If the date is invalid, pass null to ensure no results.
-                    $this->createNamedParameter($qb, $date ?: null)
+                    $qb->createNamedParameter($date ?: null)
                 ));
             }
         }
@@ -312,10 +312,9 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
 
             switch ($queryType) {
                 case 'eq':
-                    $param = $this->createNamedParameter($qb, $value);
+                    $param = $qb->createNamedParameter($value);
                     $subqueryAlias = $this->createAlias();
-                    $subquery = $this->getEntityManager()
-                        ->createQueryBuilder()
+                    $subquery = $this->createQueryBuilder()
                         ->select("$subqueryAlias.id")
                         ->from('Omeka\Entity\Resource', $subqueryAlias)
                         ->where($qb->expr()->eq("$subqueryAlias.title", $param));
@@ -327,10 +326,9 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                     break;
 
                 case 'in':
-                    $param = $this->createNamedParameter($qb, '%' . $escapeSqlLike($value) . '%');
+                    $param = $qb->createNamedParameter('%' . $escapeSqlLike($value) . '%');
                     $subqueryAlias = $this->createAlias();
-                    $subquery = $this->getEntityManager()
-                        ->createQueryBuilder()
+                    $subquery = $this->createQueryBuilder()
                         ->select("$subqueryAlias.id")
                         ->from('Omeka\Entity\Resource', $subqueryAlias)
                         ->where($qb->expr()->like("$subqueryAlias.title", $param));
@@ -342,10 +340,9 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                     break;
 
                 case 'sw':
-                    $param = $this->createNamedParameter($qb, $escapeSqlLike($value) . '%');
+                    $param = $qb->createNamedParameter($escapeSqlLike($value) . '%');
                     $subqueryAlias = $this->createAlias();
-                    $subquery = $this->getEntityManager()
-                        ->createQueryBuilder()
+                    $subquery = $this->createQueryBuilder()
                         ->select("$subqueryAlias.id")
                         ->from('Omeka\Entity\Resource', $subqueryAlias)
                         ->where($qb->expr()->like("$subqueryAlias.title", $param));
@@ -357,10 +354,9 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                     break;
 
                 case 'ew':
-                    $param = $this->createNamedParameter($qb, '%' . $escapeSqlLike($value));
+                    $param = $qb->createNamedParameter('%' . $escapeSqlLike($value));
                     $subqueryAlias = $this->createAlias();
-                    $subquery = $this->getEntityManager()
-                        ->createQueryBuilder()
+                    $subquery = $this->createQueryBuilder()
                         ->select("$subqueryAlias.id")
                         ->from('Omeka\Entity\Resource', $subqueryAlias)
                         ->where($qb->expr()->like("$subqueryAlias.title", $param));
@@ -374,7 +370,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                 case 'res':
                     $predicateExpr = $qb->expr()->eq(
                         "$valuesAlias.valueResource",
-                        $this->createNamedParameter($qb, $value)
+                        $qb->createNamedParameter($value)
                     );
                     break;
 
@@ -385,7 +381,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                 case 'dt':
                     $predicateExpr = $qb->expr()->eq(
                         "$valuesAlias.type",
-                        $this->createNamedParameter($qb, $value)
+                        $qb->createNamedParameter($value)
                     );
                     break;
 
@@ -493,12 +489,12 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
      */
     public function getSubjectValuesQueryBuilder(Resource $resource, $propertyId = null, $resourceType = null, $siteId = null)
     {
-        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb = $this->createQueryBuilder();
         $qb->from('Omeka\Entity\Value', 'value')
             ->join('value.resource', 'resource')
             ->leftJoin('resource.resourceTemplate', 'resource_template')
             ->leftJoin('resource_template.resourceTemplateProperties', 'resource_template_property', 'WITH', 'value.property = resource_template_property.property')
-            ->where($qb->expr()->eq('value.valueResource', $this->createNamedParameter($qb, $resource)));
+            ->where($qb->expr()->eq('value.valueResource', $qb->createNamedParameter($resource)));
         // Filter according to resource type and site. Note that we can only
         // filter by site when a resource type is passed because each resource
         // type requires joins that are mutually incompatible.
@@ -545,13 +541,13 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
                     // where there is no corresponding resource template property.
                     $qb->andWhere($qb->expr()->orX(
                         $qb->expr()->isNull('resource_template_property'),
-                        $qb->expr()->in('resource_template_property', $this->createNamedParameter($qb, $resourceTemplatePropertyIds))
+                        $qb->expr()->in('resource_template_property', $qb->createNamedParameter($resourceTemplatePropertyIds))
                     ));
                 } else {
-                    $qb->andWhere($qb->expr()->in('resource_template_property', $this->createNamedParameter($qb, $resourceTemplatePropertyIds)));
+                    $qb->andWhere($qb->expr()->in('resource_template_property', $qb->createNamedParameter($resourceTemplatePropertyIds)));
                 }
             }
-            $qb->andWhere($qb->expr()->eq('value.property', $this->createNamedParameter($qb, $propertyId)));
+            $qb->andWhere($qb->expr()->eq('value.property', $qb->createNamedParameter($propertyId)));
         }
         // Need to check visibility manually here
         $services = $this->getServiceLocator();
@@ -560,7 +556,7 @@ abstract class AbstractResourceEntityAdapter extends AbstractEntityAdapter imple
         if (!$acl->userIsAllowed('Omeka\Entity\Resource', 'view-all')) {
             $qb->andWhere($qb->expr()->orX(
                 $qb->expr()->eq('resource.isPublic', '1'),
-                $qb->expr()->eq('resource.owner', $this->createNamedParameter($qb, $identity))
+                $qb->expr()->eq('resource.owner', $qb->createNamedParameter($identity))
             ));
         }
         return $qb;

--- a/application/src/Api/Adapter/AssetAdapter.php
+++ b/application/src/Api/Adapter/AssetAdapter.php
@@ -44,7 +44,7 @@ class AssetAdapter extends AbstractEntityAdapter
     public function buildQuery(QueryBuilder $qb, array $query)
     {
         if (isset($query['owner_id']) && is_numeric($query['owner_id'])) {
-            $userAlias = $this->createAlias();
+            $userAlias = $qb->createAlias();
             if (0 == $query['owner_id']) {
                 // Search assets without an owner.
                 $qb->andWhere($qb->expr()->isNull('omeka_root.owner'));

--- a/application/src/Api/Adapter/ItemAdapter.php
+++ b/application/src/Api/Adapter/ItemAdapter.php
@@ -61,7 +61,7 @@ class ItemAdapter extends AbstractResourceEntityAdapter
                 $qb->innerJoin(
                     'omeka_root.itemSets',
                     $itemSetAlias, 'WITH',
-                    $qb->expr()->in("$itemSetAlias.id", $this->createNamedParameter($qb, $itemSets))
+                    $qb->expr()->in("$itemSetAlias.id", $qb->createNamedParameter($itemSets))
                 );
             }
         }
@@ -76,13 +76,13 @@ class ItemAdapter extends AbstractResourceEntityAdapter
             if ($itemSets) {
                 $subItemAlias = $this->createAlias();
                 $subItemSetAlias = $this->createAlias();
-                $subQb = $this->getEntityManager()->createQueryBuilder();
+                $subQb = $this->createQueryBuilder();
                 $subQb->select("$subItemAlias.id")
                     ->from('Omeka\Entity\Item', $subItemAlias)
                     ->innerJoin(
                         "$subItemAlias.itemSets",
                         $subItemSetAlias, 'WITH',
-                        $qb->expr()->in("$subItemSetAlias.id", $this->createNamedParameter($qb, $itemSets))
+                        $qb->expr()->in("$subItemSetAlias.id", $qb->createNamedParameter($itemSets))
                     );
                 $qb->andWhere($qb->expr()->notIn("omeka_root.id", $subQb->getDQL()));
             }
@@ -93,7 +93,7 @@ class ItemAdapter extends AbstractResourceEntityAdapter
             $qb->innerJoin(
                 'omeka_root.sites', $siteAlias, 'WITH', $qb->expr()->eq(
                     "$siteAlias.id",
-                    $this->createNamedParameter($qb, $query['site_id'])
+                    $qb->createNamedParameter($query['site_id'])
                 )
             );
 
@@ -120,7 +120,7 @@ class ItemAdapter extends AbstractResourceEntityAdapter
                 );
                 $qb->andWhere($qb->expr()->eq(
                     "$siteAlias.id",
-                    $this->createNamedParameter($qb, $query['site_id']))
+                    $qb->createNamedParameter($query['site_id']))
                 );
             }
         } elseif (isset($query['in_sites']) && (is_numeric($query['in_sites']) || is_bool($query['in_sites']))) {

--- a/application/src/Api/Adapter/ItemAdapter.php
+++ b/application/src/Api/Adapter/ItemAdapter.php
@@ -57,7 +57,7 @@ class ItemAdapter extends AbstractResourceEntityAdapter
             $itemSets = array_filter($itemSets, 'is_numeric');
 
             if ($itemSets) {
-                $itemSetAlias = $this->createAlias();
+                $itemSetAlias = $qb->createAlias();
                 $qb->innerJoin(
                     'omeka_root.itemSets',
                     $itemSetAlias, 'WITH',
@@ -74,8 +74,8 @@ class ItemAdapter extends AbstractResourceEntityAdapter
             $itemSets = array_filter($itemSets, 'is_numeric');
 
             if ($itemSets) {
-                $subItemAlias = $this->createAlias();
-                $subItemSetAlias = $this->createAlias();
+                $subItemAlias = $qb->createAlias();
+                $subItemSetAlias = $qb->createAlias();
                 $subQb = $this->createQueryBuilder();
                 $subQb->select("$subItemAlias.id")
                     ->from('Omeka\Entity\Item', $subItemAlias)
@@ -89,7 +89,7 @@ class ItemAdapter extends AbstractResourceEntityAdapter
         }
 
         if (isset($query['site_id']) && is_numeric($query['site_id'])) {
-            $siteAlias = $this->createAlias();
+            $siteAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.sites', $siteAlias, 'WITH', $qb->expr()->eq(
                     "$siteAlias.id",
@@ -98,22 +98,22 @@ class ItemAdapter extends AbstractResourceEntityAdapter
             );
 
             if (isset($query['site_attachments_only']) && $query['site_attachments_only']) {
-                $siteBlockAttachmentsAlias = $this->createAlias();
+                $siteBlockAttachmentsAlias = $qb->createAlias();
                 $qb->innerJoin(
                     'omeka_root.siteBlockAttachments',
                     $siteBlockAttachmentsAlias
                 );
-                $sitePageBlockAlias = $this->createAlias();
+                $sitePageBlockAlias = $qb->createAlias();
                 $qb->innerJoin(
                     "$siteBlockAttachmentsAlias.block",
                     $sitePageBlockAlias
                 );
-                $sitePageAlias = $this->createAlias();
+                $sitePageAlias = $qb->createAlias();
                 $qb->innerJoin(
                     "$sitePageBlockAlias.page",
                     $sitePageAlias
                 );
-                $siteAlias = $this->createAlias();
+                $siteAlias = $qb->createAlias();
                 $qb->innerJoin(
                     "$sitePageAlias.site",
                     $siteAlias
@@ -124,7 +124,7 @@ class ItemAdapter extends AbstractResourceEntityAdapter
                 );
             }
         } elseif (isset($query['in_sites']) && (is_numeric($query['in_sites']) || is_bool($query['in_sites']))) {
-            $siteAlias = $this->createAlias();
+            $siteAlias = $qb->createAlias();
             if ($query['in_sites']) {
                 $qb->innerJoin('omeka_root.sites', $siteAlias);
             } else {
@@ -134,7 +134,7 @@ class ItemAdapter extends AbstractResourceEntityAdapter
         }
 
         if (isset($query['has_media']) && (is_numeric($query['has_media']) || is_bool($query['has_media']))) {
-            $mediaAlias = $this->createAlias();
+            $mediaAlias = $qb->createAlias();
             if ($query['has_media']) {
                 $qb->innerJoin('omeka_root.media', $mediaAlias);
             } else {

--- a/application/src/Api/Adapter/ItemSetAdapter.php
+++ b/application/src/Api/Adapter/ItemSetAdapter.php
@@ -87,7 +87,7 @@ class ItemSetAdapter extends AbstractResourceEntityAdapter
             } catch (Exception\NotFoundException $e) {
                 $site = null;
             }
-            $this->siteItemSetsAlias = $this->createAlias();
+            $this->siteItemSetsAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.siteItemSets',
                 $this->siteItemSetsAlias
@@ -97,7 +97,7 @@ class ItemSetAdapter extends AbstractResourceEntityAdapter
                 $qb->createNamedParameter($query['site_id']))
             );
         } elseif (isset($query['in_sites']) && (is_numeric($query['in_sites']) || is_bool($query['in_sites']))) {
-            $siteItemSetsAlias = $this->createAlias();
+            $siteItemSetsAlias = $qb->createAlias();
             if ($query['in_sites']) {
                 $qb->innerJoin('omeka_root.siteItemSets', $siteItemSetsAlias);
             } else {

--- a/application/src/Api/Adapter/ItemSetAdapter.php
+++ b/application/src/Api/Adapter/ItemSetAdapter.php
@@ -69,7 +69,7 @@ class ItemSetAdapter extends AbstractResourceEntityAdapter
                         $expr,
                         $qb->expr()->eq(
                             'omeka_root.owner',
-                            $this->createNamedParameter($qb, $identity->getId())
+                            $qb->createNamedParameter($identity->getId())
                         )
                     );
                 }
@@ -94,7 +94,7 @@ class ItemSetAdapter extends AbstractResourceEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$this->siteItemSetsAlias.site",
-                $this->createNamedParameter($qb, $query['site_id']))
+                $qb->createNamedParameter($query['site_id']))
             );
         } elseif (isset($query['in_sites']) && (is_numeric($query['in_sites']) || is_bool($query['in_sites']))) {
             $siteItemSetsAlias = $this->createAlias();

--- a/application/src/Api/Adapter/JobAdapter.php
+++ b/application/src/Api/Adapter/JobAdapter.php
@@ -64,13 +64,13 @@ class JobAdapter extends AbstractEntityAdapter
         if (isset($query['class'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.class',
-                $this->createNamedParameter($qb, $query['class']))
+                $qb->createNamedParameter($query['class']))
             );
         }
         if (isset($query['status'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.status',
-                $this->createNamedParameter($qb, $query['status']))
+                $qb->createNamedParameter($query['status']))
             );
         }
     }

--- a/application/src/Api/Adapter/JobAdapter.php
+++ b/application/src/Api/Adapter/JobAdapter.php
@@ -50,7 +50,7 @@ class JobAdapter extends AbstractEntityAdapter
     {
         if (is_string($query['sort_by'])) {
             if ('owner_email' == $query['sort_by']) {
-                $ownerAlias = $this->createAlias();
+                $ownerAlias = $qb->createAlias();
                 $qb->leftJoin('omeka_root.owner', $ownerAlias)
                     ->addOrderBy("$ownerAlias.email", $query['sort_order']);
             } else {

--- a/application/src/Api/Adapter/MediaAdapter.php
+++ b/application/src/Api/Adapter/MediaAdapter.php
@@ -65,28 +65,28 @@ class MediaAdapter extends AbstractResourceEntityAdapter
         if (isset($query['item_id']) && is_numeric($query['item_id'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.item',
-                $this->createNamedParameter($qb, $query['item_id'])
+                $qb->createNamedParameter($query['item_id'])
             ));
         }
 
         if (!empty($query['media_type'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.mediaType',
-                $this->createNamedParameter($qb, $query['media_type'])
+                $qb->createNamedParameter($query['media_type'])
             ));
         }
 
         if (!empty($query['ingester'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.ingester',
-                $this->createNamedParameter($qb, $query['ingester'])
+                $qb->createNamedParameter($query['ingester'])
             ));
         }
 
         if (!empty($query['renderer'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.renderer',
-                $this->createNamedParameter($qb, $query['renderer'])
+                $qb->createNamedParameter($query['renderer'])
             ));
         }
 
@@ -99,7 +99,7 @@ class MediaAdapter extends AbstractResourceEntityAdapter
             $qb->innerJoin(
                 "$itemAlias.sites", $siteAlias, 'WITH', $qb->expr()->eq(
                     "$siteAlias.id",
-                    $this->createNamedParameter($qb, $query['site_id'])
+                    $qb->createNamedParameter($query['site_id'])
                 )
             );
         }

--- a/application/src/Api/Adapter/MediaAdapter.php
+++ b/application/src/Api/Adapter/MediaAdapter.php
@@ -91,11 +91,11 @@ class MediaAdapter extends AbstractResourceEntityAdapter
         }
 
         if (isset($query['site_id']) && is_numeric($query['site_id'])) {
-            $itemAlias = $this->createAlias();
+            $itemAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.item', $itemAlias
             );
-            $siteAlias = $this->createAlias();
+            $siteAlias = $qb->createAlias();
             $qb->innerJoin(
                 "$itemAlias.sites", $siteAlias, 'WITH', $qb->expr()->eq(
                     "$siteAlias.id",

--- a/application/src/Api/Adapter/PropertyAdapter.php
+++ b/application/src/Api/Adapter/PropertyAdapter.php
@@ -45,9 +45,9 @@ class PropertyAdapter extends AbstractEntityAdapter
     {
         if (is_string($query['sort_by'])) {
             if ('item_count' == $query['sort_by']) {
-                $valuesAlias = $this->createAlias();
-                $resourceAlias = $this->createAlias();
-                $countAlias = $this->createAlias();
+                $valuesAlias = $qb->createAlias();
+                $resourceAlias = $qb->createAlias();
+                $countAlias = $qb->createAlias();
                 $qb->addSelect("COUNT($valuesAlias.id) HIDDEN $countAlias")
                     ->leftJoin("omeka_root.values", $valuesAlias)
                     ->leftJoin(
@@ -81,7 +81,7 @@ class PropertyAdapter extends AbstractEntityAdapter
     public function buildQuery(QueryBuilder $qb, array $query)
     {
         if (isset($query['owner_id']) && is_numeric($query['owner_id'])) {
-            $userAlias = $this->createAlias();
+            $userAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.owner',
                 $userAlias
@@ -92,7 +92,7 @@ class PropertyAdapter extends AbstractEntityAdapter
             );
         }
         if (isset($query['vocabulary_id']) && is_numeric($query['vocabulary_id'])) {
-            $vocabularyAlias = $this->createAlias();
+            $vocabularyAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.vocabulary',
                 $vocabularyAlias
@@ -103,7 +103,7 @@ class PropertyAdapter extends AbstractEntityAdapter
             );
         }
         if (isset($query['vocabulary_namespace_uri'])) {
-            $vocabularyAlias = $this->createAlias();
+            $vocabularyAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.vocabulary',
                 $vocabularyAlias
@@ -114,7 +114,7 @@ class PropertyAdapter extends AbstractEntityAdapter
             );
         }
         if (isset($query['vocabulary_prefix'])) {
-            $vocabularyAlias = $this->createAlias();
+            $vocabularyAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.vocabulary',
                 $vocabularyAlias
@@ -132,7 +132,7 @@ class PropertyAdapter extends AbstractEntityAdapter
         }
         if (isset($query['term']) && $this->isTerm($query['term'])) {
             [$prefix, $localName] = explode(':', $query['term']);
-            $vocabularyAlias = $this->createAlias();
+            $vocabularyAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.vocabulary',
                 $vocabularyAlias
@@ -148,7 +148,7 @@ class PropertyAdapter extends AbstractEntityAdapter
         }
         //limit results to properties used by resources
         if (!empty($query['used'])) {
-            $valuesAlias = $this->createAlias();
+            $valuesAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.values',
                 $valuesAlias
@@ -156,9 +156,9 @@ class PropertyAdapter extends AbstractEntityAdapter
         }
         //limit results to properties used by items in the site
         if (isset($query['site_id']) && is_numeric($query['site_id'])) {
-            $siteAlias = $this->createAlias();
-            $itemAlias = $this->createAlias();
-            $valuesAlias = $this->createAlias();
+            $siteAlias = $qb->createAlias();
+            $itemAlias = $qb->createAlias();
+            $valuesAlias = $qb->createAlias();
             $subquery = $this->createQueryBuilder()
                 ->select("IDENTITY($valuesAlias.property)")
                 ->from('Omeka\Entity\Value', $valuesAlias)

--- a/application/src/Api/Adapter/PropertyAdapter.php
+++ b/application/src/Api/Adapter/PropertyAdapter.php
@@ -88,7 +88,7 @@ class PropertyAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$userAlias.id",
-                $this->createNamedParameter($qb, $query['owner_id']))
+                $qb->createNamedParameter($query['owner_id']))
             );
         }
         if (isset($query['vocabulary_id']) && is_numeric($query['vocabulary_id'])) {
@@ -99,7 +99,7 @@ class PropertyAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$vocabularyAlias.id",
-                $this->createNamedParameter($qb, $query['vocabulary_id']))
+                $qb->createNamedParameter($query['vocabulary_id']))
             );
         }
         if (isset($query['vocabulary_namespace_uri'])) {
@@ -110,7 +110,7 @@ class PropertyAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$vocabularyAlias.namespaceUri",
-                $this->createNamedParameter($qb, $query['vocabulary_namespace_uri']))
+                $qb->createNamedParameter($query['vocabulary_namespace_uri']))
             );
         }
         if (isset($query['vocabulary_prefix'])) {
@@ -121,13 +121,13 @@ class PropertyAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$vocabularyAlias.prefix",
-                $this->createNamedParameter($qb, $query['vocabulary_prefix']))
+                $qb->createNamedParameter($query['vocabulary_prefix']))
             );
         }
         if (isset($query['local_name'])) {
             $qb->andWhere($qb->expr()->eq(
                 "omeka_root.localName",
-                $this->createNamedParameter($qb, $query['local_name']))
+                $qb->createNamedParameter($query['local_name']))
             );
         }
         if (isset($query['term']) && $this->isTerm($query['term'])) {
@@ -139,11 +139,11 @@ class PropertyAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$vocabularyAlias.prefix",
-                $this->createNamedParameter($qb, $prefix))
+                $qb->createNamedParameter($prefix))
             );
             $qb->andWhere($qb->expr()->eq(
                 "omeka_root.localName",
-                $this->createNamedParameter($qb, $localName))
+                $qb->createNamedParameter($localName))
             );
         }
         //limit results to properties used by resources
@@ -159,8 +159,7 @@ class PropertyAdapter extends AbstractEntityAdapter
             $siteAlias = $this->createAlias();
             $itemAlias = $this->createAlias();
             $valuesAlias = $this->createAlias();
-            $subquery = $this->getEntityManager()
-                ->createQueryBuilder()
+            $subquery = $this->createQueryBuilder()
                 ->select("IDENTITY($valuesAlias.property)")
                 ->from('Omeka\Entity\Value', $valuesAlias)
                 ->join('Omeka\Entity\Site', $siteAlias)
@@ -170,7 +169,7 @@ class PropertyAdapter extends AbstractEntityAdapter
                     'WITH',
                     "$itemAlias.id = $valuesAlias.resource")
                 ->andWhere($qb->expr()->eq("$siteAlias.id",
-                    $this->createNamedParameter($qb, $query['site_id'])));
+                    $qb->createNamedParameter($query['site_id'])));
             $qb->andWhere($qb->expr()->in('omeka_root.id', $subquery->getDQL()));
         }
     }

--- a/application/src/Api/Adapter/ResourceClassAdapter.php
+++ b/application/src/Api/Adapter/ResourceClassAdapter.php
@@ -79,7 +79,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$userAlias.id",
-                $this->createNamedParameter($qb, $query['owner_id']))
+                $qb->createNamedParameter($query['owner_id']))
             );
         }
         if (isset($query['vocabulary_id']) && is_numeric($query['vocabulary_id'])) {
@@ -90,7 +90,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$vocabularyAlias.id",
-                $this->createNamedParameter($qb, $query['vocabulary_id']))
+                $qb->createNamedParameter($query['vocabulary_id']))
             );
         }
         if (isset($query['vocabulary_namespace_uri'])) {
@@ -101,7 +101,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$vocabularyAlias.namespaceUri",
-                $this->createNamedParameter($qb, $query['vocabulary_namespace_uri']))
+                $qb->createNamedParameter($query['vocabulary_namespace_uri']))
             );
         }
         if (isset($query['vocabulary_prefix'])) {
@@ -112,13 +112,13 @@ class ResourceClassAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$vocabularyAlias.prefix",
-                $this->createNamedParameter($qb, $query['vocabulary_prefix']))
+                $qb->createNamedParameter($query['vocabulary_prefix']))
             );
         }
         if (isset($query['local_name'])) {
             $qb->andWhere($qb->expr()->eq(
                 "omeka_root.localName",
-                $this->createNamedParameter($qb, $query['local_name']))
+                $qb->createNamedParameter($query['local_name']))
             );
         }
         if (isset($query['term']) && $this->isTerm($query['term'])) {
@@ -130,11 +130,11 @@ class ResourceClassAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$vocabularyAlias.prefix",
-                $this->createNamedParameter($qb, $prefix))
+                $qb->createNamedParameter($prefix))
             );
             $qb->andWhere($qb->expr()->eq(
                 "omeka_root.localName",
-                $this->createNamedParameter($qb, $localName))
+                $qb->createNamedParameter($localName))
             );
         }
         //limit results to classes used by resources
@@ -150,8 +150,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
             $siteAlias = $this->createAlias();
             $itemAlias = $this->createAlias();
             $resourcesAlias = $this->createAlias();
-            $subquery = $this->getEntityManager()
-                ->createQueryBuilder()
+            $subquery = $this->createQueryBuilder()
                 ->select("IDENTITY($resourcesAlias.resourceClass)")
                 ->from('Omeka\Entity\Resource', $resourcesAlias)
                 ->join('Omeka\Entity\Site', $siteAlias)
@@ -162,7 +161,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
                     "$itemAlias.id = $resourcesAlias.id"
                 )
                 ->andWhere($qb->expr()->eq("$siteAlias.id",
-                    $this->createNamedParameter($qb, $query['site_id'])));
+                    $qb->createNamedParameter($query['site_id'])));
             $qb->andWhere($qb->expr()->in('omeka_root.id', $subquery->getDQL()));
         }
     }

--- a/application/src/Api/Adapter/ResourceClassAdapter.php
+++ b/application/src/Api/Adapter/ResourceClassAdapter.php
@@ -72,7 +72,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
     public function buildQuery(QueryBuilder $qb, array $query)
     {
         if (isset($query['owner_id']) && is_numeric($query['owner_id'])) {
-            $userAlias = $this->createAlias();
+            $userAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.owner',
                 $userAlias
@@ -83,7 +83,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
             );
         }
         if (isset($query['vocabulary_id']) && is_numeric($query['vocabulary_id'])) {
-            $vocabularyAlias = $this->createAlias();
+            $vocabularyAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.vocabulary',
                 $vocabularyAlias
@@ -94,7 +94,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
             );
         }
         if (isset($query['vocabulary_namespace_uri'])) {
-            $vocabularyAlias = $this->createAlias();
+            $vocabularyAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.vocabulary',
                 $vocabularyAlias
@@ -105,7 +105,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
             );
         }
         if (isset($query['vocabulary_prefix'])) {
-            $vocabularyAlias = $this->createAlias();
+            $vocabularyAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.vocabulary',
                 $vocabularyAlias
@@ -123,7 +123,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
         }
         if (isset($query['term']) && $this->isTerm($query['term'])) {
             [$prefix, $localName] = explode(':', $query['term']);
-            $vocabularyAlias = $this->createAlias();
+            $vocabularyAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.vocabulary',
                 $vocabularyAlias
@@ -139,7 +139,7 @@ class ResourceClassAdapter extends AbstractEntityAdapter
         }
         //limit results to classes used by resources
         if (!empty($query['used'])) {
-            $valuesAlias = $this->createAlias();
+            $valuesAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.resources',
                 $valuesAlias
@@ -147,9 +147,9 @@ class ResourceClassAdapter extends AbstractEntityAdapter
         }
         //limit results to classes used by items in the site
         if (isset($query['site_id']) && is_numeric($query['site_id'])) {
-            $siteAlias = $this->createAlias();
-            $itemAlias = $this->createAlias();
-            $resourcesAlias = $this->createAlias();
+            $siteAlias = $qb->createAlias();
+            $itemAlias = $qb->createAlias();
+            $resourcesAlias = $qb->createAlias();
             $subquery = $this->createQueryBuilder()
                 ->select("IDENTITY($resourcesAlias.resourceClass)")
                 ->from('Omeka\Entity\Resource', $resourcesAlias)

--- a/application/src/Api/Adapter/ResourceTemplateAdapter.php
+++ b/application/src/Api/Adapter/ResourceTemplateAdapter.php
@@ -42,7 +42,7 @@ class ResourceTemplateAdapter extends AbstractEntityAdapter
     {
         if (is_string($query['sort_by'])) {
             if ('resource_class_label' == $query['sort_by']) {
-                $resourceClassAlias = $this->createAlias();
+                $resourceClassAlias = $qb->createAlias();
                 $qb->leftJoin(
                     'omeka_root.resourceClass',
                     $resourceClassAlias

--- a/application/src/Api/Adapter/ResourceTemplateAdapter.php
+++ b/application/src/Api/Adapter/ResourceTemplateAdapter.php
@@ -60,7 +60,7 @@ class ResourceTemplateAdapter extends AbstractEntityAdapter
         if (isset($query['label'])) {
             $qb->andWhere($qb->expr()->eq(
                 "omeka_root.label",
-                $this->createNamedParameter($qb, $query['label']))
+                $qb->createNamedParameter($query['label']))
             );
         }
     }

--- a/application/src/Api/Adapter/SiteAdapter.php
+++ b/application/src/Api/Adapter/SiteAdapter.php
@@ -297,8 +297,8 @@ class SiteAdapter extends AbstractEntityAdapter
                 $sitePermissionsAlias,
                 'WITH',
                 $qb->expr()->orX(
-                    $qb->expr()->eq("$sitePermissionsAlias.user", $this->createNamedParameter($qb, $user->getId())),
-                    $qb->expr()->eq("omeka_root.owner", $this->createNamedParameter($qb, $user))
+                    $qb->expr()->eq("$sitePermissionsAlias.user", $qb->createNamedParameter($user->getId())),
+                    $qb->expr()->eq("omeka_root.owner", $qb->createNamedParameter($user))
                 )
             );
         }
@@ -307,7 +307,7 @@ class SiteAdapter extends AbstractEntityAdapter
             $itemAlias = $this->createAlias();
             $qb->leftJoin(
                 'omeka_root.items', $itemAlias, 'WITH',
-                $qb->expr()->eq("$itemAlias.id", $this->createNamedParameter($qb, $query['item_id']))
+                $qb->expr()->eq("$itemAlias.id", $qb->createNamedParameter($query['item_id']))
             );
         }
 
@@ -319,28 +319,28 @@ class SiteAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$userAlias.id",
-                $this->createNamedParameter($qb, $query['owner_id']))
+                $qb->createNamedParameter($query['owner_id']))
             );
         }
 
         if (isset($query['slug'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.slug',
-                $this->createNamedParameter($qb, $query['slug'])
+                $qb->createNamedParameter($query['slug'])
             ));
         }
 
         if (isset($query['exclude_id'])) {
             $qb->andWhere($qb->expr()->neq(
                 'omeka_root.id',
-                $this->createNamedParameter($qb, $query['exclude_id'])
+                $qb->createNamedParameter($query['exclude_id'])
             ));
         }
 
         if (isset($query['assign_new_items']) && (is_numeric($query['assign_new_items']) || is_bool($query['assign_new_items']))) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.assignNewItems',
-                $this->createNamedParameter($qb, (bool) $query['assign_new_items'])
+                $qb->createNamedParameter((bool) $query['assign_new_items'])
             ));
         }
     }

--- a/application/src/Api/Adapter/SiteAdapter.php
+++ b/application/src/Api/Adapter/SiteAdapter.php
@@ -291,7 +291,7 @@ class SiteAdapter extends AbstractEntityAdapter
         if (isset($query['user_has_role']) && $query['user_has_role']) {
             // Filter out sites where the logged in user has no role.
             $user = $this->getServiceLocator()->get('Omeka\AuthenticationService')->getIdentity();
-            $sitePermissionsAlias = $this->createAlias();
+            $sitePermissionsAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.sitePermissions',
                 $sitePermissionsAlias,
@@ -304,7 +304,7 @@ class SiteAdapter extends AbstractEntityAdapter
         }
 
         if (isset($query['item_id']) && is_numeric($query['item_id'])) {
-            $itemAlias = $this->createAlias();
+            $itemAlias = $qb->createAlias();
             $qb->leftJoin(
                 'omeka_root.items', $itemAlias, 'WITH',
                 $qb->expr()->eq("$itemAlias.id", $qb->createNamedParameter($query['item_id']))
@@ -312,7 +312,7 @@ class SiteAdapter extends AbstractEntityAdapter
         }
 
         if (isset($query['owner_id']) && is_numeric($query['owner_id'])) {
-            $userAlias = $this->createAlias();
+            $userAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.owner',
                 $userAlias
@@ -348,7 +348,7 @@ class SiteAdapter extends AbstractEntityAdapter
     public function sortQuery(QueryBuilder $qb, array $query)
     {
         if ('owner_name' == $query['sort_by']) {
-            $ownerAlias = $this->createAlias();
+            $ownerAlias = $qb->createAlias();
             $qb->leftJoin("omeka_root.owner", $ownerAlias)
                 ->addOrderBy("$ownerAlias.name", $query['sort_order']);
         } else {

--- a/application/src/Api/Adapter/SitePageAdapter.php
+++ b/application/src/Api/Adapter/SitePageAdapter.php
@@ -52,7 +52,7 @@ class SitePageAdapter extends AbstractEntityAdapter implements FulltextSearchabl
     public function buildQuery(QueryBuilder $qb, array $query)
     {
         if (isset($query['site_id']) && is_numeric($query['site_id'])) {
-            $siteAlias = $this->createAlias();
+            $siteAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.site',
                 $siteAlias
@@ -64,9 +64,9 @@ class SitePageAdapter extends AbstractEntityAdapter implements FulltextSearchabl
         }
 
         if (isset($query['item_id']) && is_numeric($query['item_id'])) {
-            $blocksAlias = $this->createAlias();
+            $blocksAlias = $qb->createAlias();
             $qb->innerJoin('omeka_root.blocks', $blocksAlias);
-            $attachmentsAlias = $this->createAlias();
+            $attachmentsAlias = $qb->createAlias();
             $qb->innerJoin("$blocksAlias.attachments", $attachmentsAlias);
             $qb->andWhere($qb->expr()->eq(
                 "$attachmentsAlias.item",
@@ -89,7 +89,7 @@ class SitePageAdapter extends AbstractEntityAdapter implements FulltextSearchabl
         }
 
         if (!empty($query['site_slug'])) {
-            $siteAlias = $this->createAlias();
+            $siteAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.site',
                 $siteAlias

--- a/application/src/Api/Adapter/SitePageAdapter.php
+++ b/application/src/Api/Adapter/SitePageAdapter.php
@@ -59,7 +59,7 @@ class SitePageAdapter extends AbstractEntityAdapter implements FulltextSearchabl
             );
             $qb->andWhere($qb->expr()->eq(
                 "$siteAlias.id",
-                $this->createNamedParameter($qb, $query['site_id']))
+                $qb->createNamedParameter($query['site_id']))
             );
         }
 
@@ -70,21 +70,21 @@ class SitePageAdapter extends AbstractEntityAdapter implements FulltextSearchabl
             $qb->innerJoin("$blocksAlias.attachments", $attachmentsAlias);
             $qb->andWhere($qb->expr()->eq(
                 "$attachmentsAlias.item",
-                $this->createNamedParameter($qb, $query['item_id']))
+                $qb->createNamedParameter($query['item_id']))
             );
         }
 
         if (isset($query['slug'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.slug',
-                $this->createNamedParameter($qb, $query['slug'])
+                $qb->createNamedParameter($query['slug'])
             ));
         }
 
         if (isset($query['is_public']) && (is_numeric($query['is_public']) || is_bool($query['is_public']))) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.isPublic',
-                $this->createNamedParameter($qb, (bool) $query['is_public'])
+                $qb->createNamedParameter((bool) $query['is_public'])
             ));
         }
 
@@ -96,7 +96,7 @@ class SitePageAdapter extends AbstractEntityAdapter implements FulltextSearchabl
             );
             $qb->andWhere($qb->expr()->eq(
                 "$siteAlias.slug",
-                $this->createNamedParameter($qb, $query['site_slug'])
+                $qb->createNamedParameter($query['site_slug'])
             ));
         }
     }

--- a/application/src/Api/Adapter/UserAdapter.php
+++ b/application/src/Api/Adapter/UserAdapter.php
@@ -110,7 +110,7 @@ class UserAdapter extends AbstractEntityAdapter
         }
 
         if (!empty($query['site_permission_site_id'])) {
-            $sitePermissionAlias = $this->createAlias();
+            $sitePermissionAlias = $qb->createAlias();
             $qb->innerJoin(
                 'Omeka\Entity\SitePermission',
                 $sitePermissionAlias,

--- a/application/src/Api/Adapter/UserAdapter.php
+++ b/application/src/Api/Adapter/UserAdapter.php
@@ -84,28 +84,28 @@ class UserAdapter extends AbstractEntityAdapter
         if (!empty($query['email'])) {
             $qb->andWhere($qb->expr()->eq(
                 "omeka_root.email",
-                $this->createNamedParameter($qb, $query['email']))
+                $qb->createNamedParameter($query['email']))
             );
         }
 
         if (!empty($query['name'])) {
             $qb->andWhere($qb->expr()->eq(
                 "omeka_root.name",
-                $this->createNamedParameter($qb, $query['name']))
+                $qb->createNamedParameter($query['name']))
             );
         }
 
         if (!empty($query['role'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.role',
-                $this->createNamedParameter($qb, $query['role']))
+                $qb->createNamedParameter($query['role']))
             );
         }
 
         if (isset($query['is_active']) && is_numeric($query['is_active'])) {
             $qb->andWhere($qb->expr()->eq(
                 'omeka_root.isActive',
-                $this->createNamedParameter($qb, (bool) $query['is_active']))
+                $qb->createNamedParameter((bool) $query['is_active']))
             );
         }
 
@@ -119,7 +119,7 @@ class UserAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$sitePermissionAlias.site",
-                $this->createNamedParameter($qb, $query['site_permission_site_id']))
+                $qb->createNamedParameter($query['site_permission_site_id']))
             );
         }
     }

--- a/application/src/Api/Adapter/VocabularyAdapter.php
+++ b/application/src/Api/Adapter/VocabularyAdapter.php
@@ -159,7 +159,7 @@ class VocabularyAdapter extends AbstractEntityAdapter
     public function buildQuery(QueryBuilder $qb, array $query)
     {
         if (isset($query['owner_id']) && is_numeric($query['owner_id'])) {
-            $userAlias = $this->createAlias();
+            $userAlias = $qb->createAlias();
             $qb->innerJoin(
                 'omeka_root.owner',
                 $userAlias

--- a/application/src/Api/Adapter/VocabularyAdapter.php
+++ b/application/src/Api/Adapter/VocabularyAdapter.php
@@ -166,19 +166,19 @@ class VocabularyAdapter extends AbstractEntityAdapter
             );
             $qb->andWhere($qb->expr()->eq(
                 "$userAlias.id",
-                $this->createNamedParameter($qb, $query['owner_id']))
+                $qb->createNamedParameter($query['owner_id']))
             );
         }
         if (isset($query['namespace_uri'])) {
             $qb->andWhere($qb->expr()->eq(
                 "omeka_root.namespaceUri",
-                $this->createNamedParameter($qb, $query['namespace_uri']))
+                $qb->createNamedParameter($query['namespace_uri']))
             );
         }
         if (isset($query['prefix'])) {
             $qb->andWhere($qb->expr()->eq(
                 "omeka_root.prefix",
-                $this->createNamedParameter($qb, $query['prefix']))
+                $qb->createNamedParameter($query['prefix']))
             );
         }
     }

--- a/application/src/Db/QueryBuilder.php
+++ b/application/src/Db/QueryBuilder.php
@@ -18,7 +18,7 @@ class QueryBuilder extends DoctrineQueryBuilder
      */
     public function createNamedParameter($value)
     {
-        $placeholder = sprintf('omeka_%s', $this->index++);
+        $placeholder = sprintf('omeka_qb_%s', $this->index++);
         $this->setParameter($placeholder, $value);
         return sprintf(':%s', $placeholder);
     }
@@ -30,6 +30,6 @@ class QueryBuilder extends DoctrineQueryBuilder
      */
     public function createAlias()
     {
-        return sprintf('omeka_%s', $this->index++);
+        return sprintf('omeka_qb_%s', $this->index++);
     }
 }

--- a/application/src/Db/QueryBuilder.php
+++ b/application/src/Db/QueryBuilder.php
@@ -1,0 +1,22 @@
+<?php
+namespace Omeka\Db;
+
+use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
+
+class QueryBuilder extends DoctrineQueryBuilder
+{
+    protected $index = 0;
+
+    /**
+     * Create a unique named parameter, exclusive to this query builder.
+     *
+     * @param mixed $value The value to bind
+     * @return string The placeholder
+     */
+    public function createNamedParameter($value)
+    {
+        $placeholder = sprintf('omeka_%s', $this->index++);
+        $this->setParameter($placeholder, $value);
+        return sprintf(':%s', $placeholder);
+    }
+}

--- a/application/src/Db/QueryBuilder.php
+++ b/application/src/Db/QueryBuilder.php
@@ -5,6 +5,9 @@ use Doctrine\ORM\QueryBuilder as DoctrineQueryBuilder;
 
 class QueryBuilder extends DoctrineQueryBuilder
 {
+    /**
+     * @var int A unique index for query builder placeholders and aliases.
+     */
     protected $index = 0;
 
     /**

--- a/application/src/Db/QueryBuilder.php
+++ b/application/src/Db/QueryBuilder.php
@@ -19,4 +19,14 @@ class QueryBuilder extends DoctrineQueryBuilder
         $this->setParameter($placeholder, $value);
         return sprintf(':%s', $placeholder);
     }
+
+    /**
+     * Create a unique alias, exclusive to this query builder.
+     *
+     * @return string The alias
+     */
+    public function createAlias()
+    {
+        return sprintf('omeka_%s', $this->index++);
+    }
 }


### PR DESCRIPTION
Adds new, preferred methods to create named parameters and aliases used by the query builder, and deprecates the old methods. This change eliminates the need to reset the param/alias index within the adapter. New query builders "reset" the index automatically for free. See https://github.com/omeka/omeka-s/pull/2244#issuecomment-3050638880 for some background on why the indexes are important.

| Deprecated method | New method |
| ---- | ---- |
| `\Omeka\Api\Adapter\AbstractEntityAdapter::createNamedParameter()` | `\Omeka\Db\QueryBuilder::createNamedParameter()` |
| `\Omeka\Api\Adapter\AbstractEntityAdapter::createAlias()` | `\Omeka\Db\QueryBuilder::createAlias()` |

Modules using the deprecated methods should switch when able. For example, in module adapters, change these:

```php
$namedParam = $this->createNamedParameter($qb, $value);
$alias = $this->createAlias();
```

To these:

```php
$namedParam = $qb->createNamedParameter($value);
$alias = $qb->createAlias();
```

