### PR TITLE
Improve Japanese translation quality

### DIFF
--- a/application/language/ja.po
+++ b/application/language/ja.po
@@ -39,7 +39,7 @@ msgstr "%1$s アダプタは作成操作を実装していません。"
 #: application/src/Api/Adapter/AbstractAdapter.php:60
 #, php-format
 msgid "The %1$s adapter does not implement the batch create operation."
-msgstr "%1$s  アダプタは一括作成操作を実装していません。"
+msgstr "%1$s アダプタは一括作成操作を実装していません。"
 
 #: application/src/Api/Adapter/AbstractAdapter.php:70
 #, php-format
@@ -69,23 +69,23 @@ msgstr "%1$s アダプタは一括削除操作を実装しません。"
 #: application/src/Api/Adapter/AbstractEntityAdapter.php:293
 #, php-format
 msgid "The \"%1$s\" field is not available in the %2$s adapter class."
-msgstr ""
+msgstr "「%1$s」フィールドは %2$s アダプタクラスで使用できません。"
 
 #: application/src/Api/Adapter/AbstractEntityAdapter.php:309
 #, php-format
 msgid "The \"%1$s\" field is not available in the %2$s entity class."
-msgstr "「%1$s」フィールドは エンティティクラス  %2$s で使用できません。。"
+msgstr "「%1$s」フィールドはエンティティクラス %2$s で使用できません。"
 
 #: application/src/Api/Adapter/AbstractEntityAdapter.php:681
 #: application/src/Api/Manager.php:209
 #, php-format
 msgid "Permission denied for the current user to %1$s the %2$s resource."
-msgstr "現在のユーザーが %2$sリソースに対し%1$sする権限 が拒否されました。"
+msgstr "現在のユーザーが %2$s リソースに対し %1$s する権限が拒否されました。"
 
 #: application/src/Api/Adapter/AbstractEntityAdapter.php:723
 #, php-format
 msgid "%1$s entity with criteria %2$s not found"
-msgstr "%1$s エンティティ（ %2$s 基準）が見つかりません"
+msgstr "%1$s エンティティ（%2$s 基準）が見つかりません"
 
 #: application/src/Api/Adapter/SiteAdapter.php:154
 msgid "Welcome"
@@ -196,12 +196,12 @@ msgstr "別のリソーステンプレートを追加しますか？"
 #: application/src/Controller/Admin/SystemInfoController.php:90
 #: application/src/Controller/Admin/SystemInfoController.php:95
 msgid "[invalid]"
-msgstr ""
+msgstr "[無効]"
 
 #: application/src/Controller/Admin/SystemInfoController.php:154
 #: application/src/Controller/Admin/SystemInfoController.php:165
 msgid "[Unable to execute command]"
-msgstr ""
+msgstr "[コマンドを実行できません]"
 
 #: application/src/Controller/Admin/UserController.php:125
 msgid "Add another user?"
@@ -239,7 +239,7 @@ msgstr "アイテム"
 
 #: application/src/DataType/Resource/ItemSet.php:27
 msgid "Item Sets"
-msgstr ""
+msgstr "アイテムセット"
 
 #: application/src/DataType/Resource/Media.php:27
 #: application/view/common/block-layout/item-with-metadata.phtml:29
@@ -276,21 +276,21 @@ msgstr "少なくとも %s 個の小文字を含みます。 "
 #: application/src/Form/Element/PasswordConfirm.php:35
 #, php-format
 msgid "contain at least %s uppercase characters."
-msgstr "少なくとも   %s 個の大文字を含みます。"
+msgstr "少なくとも %s 個の大文字を含みます。"
 
 #: application/src/Form/Element/PasswordConfirm.php:39
 #, php-format
 msgid "contain at least %s numbers."
-msgstr "少なくとも  %s 個の数字を含みます。"
+msgstr "少なくとも %s 個の数字を含みます。"
 
 #: application/src/Form/Element/PasswordConfirm.php:46
 #, php-format
 msgid "contain at least %1$s symbols: %2$s"
-msgstr "少なくとも  %1$s 個の記号を含みます: %2$s"
+msgstr "少なくとも %1$s 個の記号を含みます: %2$s"
 
 #: application/src/Form/Element/PasswordConfirm.php:50
 msgid "Password must:"
-msgstr ""
+msgstr "パスワードの条件:"
 
 #: application/src/Form/View/Helper/FormCollectionElementGroupsCollapsible.php:33
 #: application/src/Media/Ingester/Upload.php:75
@@ -331,47 +331,47 @@ msgstr "ファイルをアップロード"
 #: application/src/Module/Manager.php:156
 #, php-format
 msgid "Module \"%1$s\" is marked as \"%2$s\" and cannot be activated"
-msgstr "モジュール \"%1$s\" は \"%2$s\"  としてマークされており、有効化できません"
+msgstr "モジュール \"%1$s\" は \"%2$s\" としてマークされており、有効化できません"
 
 #: application/src/Module/Manager.php:167
 #, php-format
 msgid "Module \"%s\" not in database during activation"
-msgstr "モジュール  \"%s\" はデータベースにないため有効化できません"
+msgstr "モジュール \"%s\" はデータベースにないため有効化できません"
 
 #: application/src/Module/Manager.php:188
 #, php-format
 msgid "Module \"%1$s\" is marked as \"%2$s\" and cannot be deactivated"
-msgstr "モジュール \"%1$s\" は \"%2$s\"  としてマークされており、無効化できません"
+msgstr "モジュール \"%1$s\" は \"%2$s\" としてマークされており、無効化できません"
 
 #: application/src/Module/Manager.php:199
 #, php-format
 msgid "Module \"%s\" not in database during deactivation"
-msgstr "モジュール  \"%s\" はデータベースにないため無効化できません"
+msgstr "モジュール \"%s\" はデータベースにないため無効化できません"
 
 #: application/src/Module/Manager.php:219
 #, php-format
 msgid "Module \"%1$s\" is marked as \"%2$s\" and cannot be installed"
-msgstr "モジュール \"%1$s\" は \"%2$s\"  としてマークされており、インストールできません"
+msgstr "モジュール \"%1$s\" は \"%2$s\" としてマークされており、インストールできません"
 
 #: application/src/Module/Manager.php:257
 #, php-format
 msgid "Module \"%1$s\" is marked as \"%2$s\" and cannot be uninstalled"
-msgstr "モジュール \"%1$s\" は \"%2$s\"  としてマークされており、アンインストールできません"
+msgstr "モジュール \"%1$s\" は \"%2$s\" としてマークされており、アンインストールできません"
 
 #: application/src/Module/Manager.php:274
 #, php-format
 msgid "Module \"%s\" not found in database during uninstallation"
-msgstr "モジュール  \"%s\" はデータベースにないためアンインストールできません"
+msgstr "モジュール \"%s\" はデータベースにないためアンインストールできません"
 
 #: application/src/Module/Manager.php:295
 #, php-format
 msgid "Module \"%1$s\" is marked as \"%2$s\" and cannot be upgraded"
-msgstr "モジュール \"%1$s\" は \"%2$s\"  としてマークされており、更新できません"
+msgstr "モジュール \"%1$s\" は \"%2$s\" としてマークされており、更新できません"
 
 #: application/src/Module/Manager.php:317
 #, php-format
 msgid "Module \"%s\" not found in database during upgrade"
-msgstr "モジュール  \"%s\" はデータベースにないため更新できません"
+msgstr "モジュール \"%s\" はデータベースにないため更新できません"
 
 #: application/src/Module/Manager.php:396
 #, php-format
@@ -383,19 +383,19 @@ msgstr "現在のユーザーは %2$s モジュールを %1$s する権限があ
 msgid ""
 "Permission denied for the current user to access the %1$s action of the %2$s"
 " controller."
-msgstr "現在のユーザが %2$s コントローラの %1$sアクションへのアクセスが拒否されました。 "
+msgstr "現在のユーザが %2$s コントローラの %1$s アクションへのアクセスが拒否されました。"
 
 #: application/src/Site/BlockLayout/BlockGroup.php:27
 msgid "Drag blocks here to group."
-msgstr ""
+msgstr "ここにブロックをドラッグしてグループ化します。"
 
 #: application/src/Site/BlockLayout/Fallback.php:41
 msgid "This layout is invalid."
-msgstr "このレイアウトは無効です"
+msgstr "このレイアウトは無効です。"
 
 #: application/src/Site/BlockLayout/LineBreak.php:41
 msgid "Break type"
-msgstr "Break type"
+msgstr "改行タイプ"
 
 #: application/src/Site/BlockLayout/ListOfPages.php:58
 msgid "Add pages"
@@ -489,27 +489,27 @@ msgstr "%s のユーザー認証"
 #: application/src/Stdlib/Oembed.php:44
 #, php-format
 msgid "oEmbed: URL is not allowed %s"
-msgstr ""
+msgstr "oEmbed: URLが許可されていません %s"
 
 #: application/src/Stdlib/Oembed.php:57
 #, php-format
 msgid "oEmbed: links cannot be found at %s"
-msgstr ""
+msgstr "oEmbed: %s でリンクが見つかりません"
 
 #: application/src/Stdlib/Oembed.php:69
 #, php-format
 msgid "oEmbed: response cannot be decoded to JSON %s"
-msgstr ""
+msgstr "oEmbed: レスポンスをJSONにデコードできません %s"
 
 #: application/src/Stdlib/Oembed.php:114
 #, php-format
 msgid "oEmbed: URL is invalid: %s"
-msgstr ""
+msgstr "oEmbed: URLが無効です: %s"
 
 #: application/src/Stdlib/Oembed.php:123
 #, php-format
 msgid "oEmbed: URL is unreadable at %s: %s (%s)"
-msgstr ""
+msgstr "oEmbed: %s でURLが読み取れません: %s (%s)"
 
 #: application/src/View/Helper/BlockShowTitleSelect.php:33
 msgid "Show attachment title"
@@ -569,22 +569,22 @@ msgstr "含まれていない"
 #: application/src/View/Helper/SearchFilters.php:36
 #: application/view/common/advanced-search/properties.phtml:80
 msgid "starts with"
-msgstr ""
+msgstr "で始まる"
 
 #: application/src/View/Helper/SearchFilters.php:37
 #: application/view/common/advanced-search/properties.phtml:81
 msgid "does not start with"
-msgstr ""
+msgstr "で始まらない"
 
 #: application/src/View/Helper/SearchFilters.php:38
 #: application/view/common/advanced-search/properties.phtml:82
 msgid "ends with"
-msgstr ""
+msgstr "で終わる"
 
 #: application/src/View/Helper/SearchFilters.php:39
 #: application/view/common/advanced-search/properties.phtml:83
 msgid "does not end with"
-msgstr ""
+msgstr "で終わらない"
 
 #: application/src/View/Helper/SearchFilters.php:40
 #: application/view/common/advanced-search/properties.phtml:84
@@ -677,7 +677,7 @@ msgstr "不明なテンプレート"
 
 #: application/src/View/Helper/SearchFilters.php:160
 msgid "In item set"
-msgstr ""
+msgstr "アイテムセット内"
 
 #: application/src/View/Helper/SearchFilters.php:164
 #: application/src/View/Helper/SearchFilters.php:182
@@ -686,7 +686,7 @@ msgstr "不明なアイテムセット"
 
 #: application/src/View/Helper/SearchFilters.php:178
 msgid "Not in item set"
-msgstr ""
+msgstr "アイテムセット外"
 
 #: application/src/View/Helper/SearchFilters.php:190
 #: application/view/omeka/site-admin/index/users.phtml:54
@@ -740,15 +740,15 @@ msgstr "非公開"
 
 #: application/src/View/Helper/SearchFilters.php:215
 msgid "Media presence"
-msgstr ""
+msgstr "メディアの有無"
 
 #: application/src/View/Helper/SearchFilters.php:216
 msgid "Has media"
-msgstr ""
+msgstr "メディアあり"
 
 #: application/src/View/Helper/SearchFilters.php:216
 msgid "Has no media"
-msgstr ""
+msgstr "メディアなし"
 
 #: application/src/View/Helper/SearchFilters.php:220
 #: application/view/omeka/admin/item-set/show-details.phtml:13
@@ -842,7 +842,7 @@ msgstr "表示"
 
 #: application/view/common/advanced-search/ids.phtml:12
 msgid "Search by ID"
-msgstr ""
+msgstr "IDで検索"
 
 #: application/view/common/advanced-search/ids.phtml:15
 msgid ""
@@ -866,15 +866,15 @@ msgstr "新規アイテムセットを追加"
 
 #: application/view/common/advanced-search/item-sets.phtml:53
 msgid "Condition"
-msgstr ""
+msgstr "条件"
 
 #: application/view/common/advanced-search/item-sets.phtml:54
 msgid "In"
-msgstr ""
+msgstr "含む"
 
 #: application/view/common/advanced-search/item-sets.phtml:55
 msgid "Not in"
-msgstr ""
+msgstr "含まない"
 
 #: application/view/common/advanced-search/item-sets.phtml:66
 #: application/view/common/advanced-search/properties.phtml:90
@@ -913,7 +913,7 @@ msgstr "新規の値を追加"
 
 #: application/view/common/advanced-search/properties.phtml:58
 msgid "Joiner"
-msgstr ""
+msgstr "結合子"
 
 #: application/view/common/advanced-search/properties.phtml:75
 msgid "Query type"
@@ -925,7 +925,7 @@ msgstr "クラスを検索"
 
 #: application/view/common/advanced-search/resource-class.phtml:27
 msgid "Searches for resources that are any of these classes."
-msgstr ""
+msgstr "これらのクラスのいずれかのリソースを検索します。"
 
 #: application/view/common/advanced-search/resource-class.phtml:29
 msgid "Add new class"
@@ -937,7 +937,7 @@ msgstr "テンプレートを検索"
 
 #: application/view/common/advanced-search/resource-template.phtml:19
 msgid "Searches for resources that use any of these templates."
-msgstr ""
+msgstr "これらのテンプレートのいずれかを使用するリソースを検索します。"
 
 #: application/view/common/advanced-search/resource-template.phtml:21
 msgid "Add new template"
@@ -949,7 +949,7 @@ msgstr "サイト毎に検索"
 
 #: application/view/common/advanced-search/site.phtml:6
 msgid "Searches for items that are assigned to this site."
-msgstr ""
+msgstr "このサイトに割り当てられたアイテムを検索します。"
 
 #: application/view/common/advanced-search/sort.phtml:35
 #: application/view/common/sort-selector.phtml:16
@@ -975,12 +975,12 @@ msgstr "活動を検索"
 #: application/view/common/asset-block-form.phtml:7
 #: application/view/common/asset-block-form.phtml:40
 msgid "No asset selected"
-msgstr ""
+msgstr "アセットが選択されていません"
 
 #: application/view/common/asset-block-form.phtml:9
 #: application/view/common/asset-block-form.phtml:43
 msgid "Open asset options"
-msgstr ""
+msgstr "アセットオプションを開く"
 
 #: application/view/common/asset-block-form.phtml:10
 #: application/view/common/asset-block-form.phtml:44
@@ -1011,11 +1011,11 @@ msgstr "折りたたむ"
 #: application/view/omeka/admin/asset/browse.phtml:8
 #: application/view/omeka/admin/asset/edit.phtml:10
 msgid "Assets"
-msgstr ""
+msgstr "アセット"
 
 #: application/view/common/asset-block-form.phtml:54
 msgid "Add asset"
-msgstr ""
+msgstr "アセットを追加"
 
 #: application/view/common/asset-form.phtml:35
 #: application/view/common/asset-options.phtml:15
@@ -1036,16 +1036,16 @@ msgstr "クリア"
 
 #: application/view/common/asset-options.phtml:10
 msgid "No Asset"
-msgstr ""
+msgstr "アセットなし"
 
 #: application/view/common/asset-options.phtml:19
 #: application/view/omeka/admin/query/sidebar-edit.phtml:12
 msgid "Preview"
-msgstr ""
+msgstr "プレビュー"
 
 #: application/view/common/asset-options.phtml:20
 msgid "[No page selected]"
-msgstr ""
+msgstr "[ページが未選択]"
 
 #: application/view/common/asset-options.phtml:25
 #: application/view/common/delete-confirm.phtml:8
@@ -1097,7 +1097,7 @@ msgstr "閉じる"
 
 #: application/view/common/asset-options.phtml:32
 msgid "Page link"
-msgstr ""
+msgstr "ページリンク"
 
 #: application/view/common/asset-options.phtml:40
 msgid "Alternative link title"
@@ -1134,17 +1134,17 @@ msgstr "添付ファイルを追加"
 
 #: application/view/common/block-layout.phtml:5
 msgid "Auto"
-msgstr ""
+msgstr "自動"
 
 #: application/view/common/block-layout.phtml:7
 #, php-format
 msgid "Position %s"
-msgstr ""
+msgstr "位置 %s"
 
 #: application/view/common/block-layout.phtml:11
 #, php-format
 msgid "Span %s"
-msgstr ""
+msgstr "範囲 %s"
 
 #: application/view/common/block-layout.phtml:17
 msgid "Block to be removed"
@@ -1152,43 +1152,43 @@ msgstr "削除をブロック"
 
 #: application/view/common/block-layout.phtml:20
 msgid "Block and contents to be removed"
-msgstr ""
+msgstr "削除されるブロックとコンテンツ"
 
 #: application/view/common/block-layout.phtml:31
 msgid "Position"
-msgstr ""
+msgstr "位置"
 
 #: application/view/common/block-layout.phtml:38
 msgid "Span"
-msgstr ""
+msgstr "範囲"
 
 #: application/view/common/block-layout.phtml:49
 #: application/view/omeka/site-admin/page/edit.phtml:70
 msgid "Preview layout"
-msgstr ""
+msgstr "レイアウトプレビュー"
 
 #: application/view/common/block-layout.phtml:51
 #: application/view/omeka/site-admin/page/edit.phtml:71
 msgid "Configure layout"
-msgstr ""
+msgstr "レイアウト設定"
 
 #: application/view/common/block-layout.phtml:52
 #: application/view/omeka/site-admin/index/theme-resource-pages.phtml:6
 msgid "Remove block"
-msgstr ""
+msgstr "ブロックを削除"
 
 #: application/view/common/block-layout.phtml:53
 #: application/view/omeka/site-admin/index/theme-resource-pages.phtml:7
 msgid "Restore block"
-msgstr ""
+msgstr "ブロックを復元"
 
 #: application/view/common/block-layout.phtml:55
 msgid "Expand group"
-msgstr ""
+msgstr "グループを展開"
 
 #: application/view/common/block-layout.phtml:56
 msgid "Collapse group"
-msgstr ""
+msgstr "グループを折りたたみ"
 
 #: application/view/common/block-layout/item-with-metadata.phtml:19
 #: application/view/common/cross-site-search/results.phtml:70
@@ -1222,15 +1222,15 @@ msgstr "登録日"
 #: application/view/common/block-layout/page-date-time.phtml:19
 #: application/view/omeka/site-admin/page/index.phtml:26
 msgid "Modified"
-msgstr ""
+msgstr "更新日"
 
 #: application/view/common/browse-defaults-form.phtml:12
 msgid "[Custom sort by]"
-msgstr ""
+msgstr "[カスタム並び順]"
 
 #: application/view/common/browse-defaults-form.phtml:17
 msgid "Enter a custom sort by"
-msgstr ""
+msgstr "カスタム並び順を入力"
 
 #: application/view/common/browse-defaults-form.phtml:19
 #: application/view/common/sort-selector.phtml:14
@@ -1269,17 +1269,17 @@ msgstr "高度なアイテム検索"
 #: application/view/common/cross-site-search/item-results.phtml:8
 #, php-format
 msgid "Item results for \"%s\""
-msgstr ""
+msgstr "\"%s\"のアイテム結果"
 
 #: application/view/common/cross-site-search/item-set-results.phtml:3
 #: application/view/omeka/search/item-sets-advanced.phtml:2
 msgid "Advanced item set search"
-msgstr ""
+msgstr "高度なアイテムセット検索"
 
 #: application/view/common/cross-site-search/item-set-results.phtml:8
 #, php-format
 msgid "Item set results for \"%s\""
-msgstr ""
+msgstr "\"%s\"のアイテムセット結果"
 
 #: application/view/common/cross-site-search/results.phtml:6
 #: application/view/omeka/site/index/search.phtml:12
@@ -1290,7 +1290,7 @@ msgstr "\"%s\" の検索結果"
 #: application/view/common/cross-site-search/results.phtml:13
 #: application/view/common/resource-page-block-layout/site-pages.phtml:8
 msgid "Site pages"
-msgstr ""
+msgstr "サイトページ"
 
 #: application/view/common/cross-site-search/results.phtml:24
 #: application/view/common/cross-site-search/results.phtml:55
@@ -1329,7 +1329,7 @@ msgstr "値の復元"
 
 #: application/view/common/data-type-wrapper.phtml:21
 msgid "More actions"
-msgstr ""
+msgstr "その他の操作"
 
 #: application/view/common/data-type-wrapper.phtml:24
 #: application/view/common/media-field-wrapper.phtml:10
@@ -1347,7 +1347,7 @@ msgstr "非公開にする"
 #: application/view/common/data-type-wrapper.phtml:27
 #: application/view/common/value-annotation-sidebar.phtml:6
 msgid "Annotate value"
-msgstr ""
+msgstr "値に注釈を付ける"
 
 #: application/view/common/data-type/literal.phtml:5
 #: application/view/common/data-type/uri.phtml:5
@@ -1442,7 +1442,7 @@ msgstr "詳細情報"
 
 #: application/view/common/linked-resources.phtml:54
 msgid "Filter by resource type and property:"
-msgstr ""
+msgstr "リソースタイプとプロパティで絞り込み:"
 
 #: application/view/common/linked-resources.phtml:64
 #, php-format
@@ -1464,7 +1464,7 @@ msgstr "タイトル"
 
 #: application/view/common/navigation-link-form/browse.phtml:8
 msgid "Search query"
-msgstr ""
+msgstr "検索クエリ"
 
 #: application/view/common/navigation-link-form/browse.phtml:15
 #: application/view/common/navigation-link-form/page.phtml:13
@@ -1488,27 +1488,27 @@ msgstr "URL"
 
 #: application/view/common/navigation-link-form/url.phtml:12
 msgid "Open in new tab"
-msgstr ""
+msgstr "新しいタブで開く"
 
 #: application/view/common/padding-form.phtml:1
 msgid "Top"
-msgstr ""
+msgstr "上"
 
 #: application/view/common/padding-form.phtml:2
 msgid "Right"
-msgstr ""
+msgstr "右"
 
 #: application/view/common/padding-form.phtml:3
 msgid "Bottom"
-msgstr ""
+msgstr "下"
 
 #: application/view/common/padding-form.phtml:4
 msgid "Left"
-msgstr ""
+msgstr "左"
 
 #: application/view/common/page-select-sidebar.phtml:8
 msgid "Select Pages"
-msgstr ""
+msgstr "ページを選択"
 
 #: application/view/common/pagination.phtml:16
 #: application/view/common/sidebar-pagination.phtml:7
@@ -1583,16 +1583,16 @@ msgstr "プロパティをフィルター"
 #: application/view/common/query-form.phtml:8
 #: application/view/omeka/admin/query/search-filters.phtml:4
 msgid "[Edit below]"
-msgstr ""
+msgstr "[下で編集]"
 
 #: application/view/common/query-form.phtml:24
 msgid "Advanced edit"
-msgstr ""
+msgstr "詳細編集"
 
 #: application/view/common/query-form.phtml:25
 #: application/view/omeka/admin/query/sidebar-edit.phtml:14
 msgid "Apply"
-msgstr ""
+msgstr "適用"
 
 #: application/view/common/query-form.phtml:27
 #: application/view/omeka/site-admin/index/users.phtml:8
@@ -1626,7 +1626,7 @@ msgstr "テキスト"
 
 #: application/view/common/resource-page-block-layout/lightbox-gallery-item.phtml:11
 msgid "Other Media"
-msgstr ""
+msgstr "その他のメディア"
 
 #: application/view/common/resource-page-block-layout/linked-resources.phtml:14
 #: application/view/omeka/admin/item-set/show.phtml:22
@@ -1636,7 +1636,7 @@ msgstr "リンクしたリソース"
 
 #: application/view/common/resource-page-block-layout/resource-class.phtml:7
 msgid "Resource class"
-msgstr ""
+msgstr "リソースクラス"
 
 #: application/view/common/resource-select-sidebar.phtml:20
 msgid "Select resource"
@@ -1662,11 +1662,11 @@ msgstr "非公開"
 
 #: application/view/common/resource-values.phtml:67
 msgid "Has annotation"
-msgstr ""
+msgstr "注釈あり"
 
 #: application/view/common/sidebar-pagelist.phtml:10
 msgid "Add to List of pages"
-msgstr ""
+msgstr "ページリストに追加"
 
 #: application/view/common/sidebar-pagelist.phtml:12
 #: application/view/omeka/site-admin/index/navigation.phtml:50
@@ -1690,11 +1690,11 @@ msgstr "無効"
 
 #: application/view/common/sidebar-select-quick-add.phtml:8
 msgid "Quick add checkboxes are now available."
-msgstr ""
+msgstr "クイック追加チェックボックスが利用可能になりました。"
 
 #: application/view/common/sidebar-select-quick-add.phtml:9
 msgid "Quick add checkboxes are now hidden."
-msgstr ""
+msgstr "クイック追加チェックボックスが非表示になりました。"
 
 #: application/view/common/sidebar-select-quick-add.phtml:12
 #: application/view/omeka/admin/item-set/browse.phtml:53
@@ -1705,7 +1705,7 @@ msgstr "全て選択"
 
 #: application/view/common/sidebar-select-quick-add.phtml:17
 msgid "All results are now selected."
-msgstr ""
+msgstr "すべての結果が選択されました。"
 
 #: application/view/common/sidebar-select-quick-add.phtml:18
 msgid "All results are now deselected."
@@ -2548,7 +2548,7 @@ msgstr "メディアを削除"
 
 #: application/view/omeka/admin/media/browse.phtml:118
 msgid "Are you sure you would like to delete the selected media?"
-msgstr ""
+msgstr "選択したメディアを削除してもよろしいですか？"
 
 #: application/view/omeka/admin/media/browse.phtml:120
 #: application/view/omeka/admin/media/browse.phtml:138
@@ -5114,15 +5114,15 @@ msgstr ""
 
 #: application/src/View/Helper/Browse.php:164
 msgid "Add a column…"
-msgstr ""
+msgstr "列を追加…"
 
 #: application/src/View/Helper/Browse.php:183
 msgid "Column type"
-msgstr ""
+msgstr "列タイプ"
 
 #: application/src/View/Helper/Browse.php:194
 msgid "Header"
-msgstr ""
+msgstr "ヘッダー"
 
 #: application/src/View/Helper/ResourceTemplateSelect.php:39
 msgid "Select template…"
@@ -5138,7 +5138,7 @@ msgstr "ユーザーを選択..."
 
 #: application/src/View/Helper/BlockThumbnailTypeSelect.php:42
 msgid "Image type"
-msgstr ""
+msgstr "画像タイプ"
 
 #: application/src/View/Helper/ItemSetSelect.php:39
 msgid "Select item set…"
@@ -5166,11 +5166,11 @@ msgstr "ページを作成しました"
 
 #: application/src/Controller/SiteAdmin/IndexController.php:197
 msgid "Homepage"
-msgstr ""
+msgstr "ホームページ"
 
 #: application/src/Controller/SiteAdmin/IndexController.php:203
 msgid "First page in navigation"
-msgstr ""
+msgstr "ナビゲーションの最初のページ"
 
 #: application/src/Controller/SiteAdmin/IndexController.php:219
 msgid "Navigation successfully updated"
@@ -5199,7 +5199,7 @@ msgstr "テーマ設定を更新しました"
 
 #: application/src/Controller/SiteAdmin/IndexController.php:457
 msgid "Theme resource pages successfully updated"
-msgstr ""
+msgstr "テーマリソースページが正常に更新されました"
 
 #: application/src/Controller/SiteAdmin/IndexController.php:480
 msgid "Site successfully deleted"
@@ -5251,7 +5251,7 @@ msgstr "パスワード作成が失敗しました"
 
 #: application/src/Controller/LoginController.php:174
 msgid "Unable to send password reset email."
-msgstr ""
+msgstr "パスワードリセットメールを送信できません。"
 
 #: application/src/Controller/LoginController.php:177
 msgid "Check your email for instructions on how to reset your password"
@@ -5319,7 +5319,7 @@ msgstr "アイテムを編集しています。しばらくお待ちください
 
 #: application/src/Controller/Admin/UserController.php:118
 msgid "Unable to send user activation email."
-msgstr ""
+msgstr "ユーザー有効化メールを送信できません。"
 
 #: application/src/Controller/Admin/UserController.php:121
 #, php-format
@@ -5458,7 +5458,7 @@ msgstr "一括削除するメディアを少なくとも1つ選択する必要�
 
 #: application/src/Controller/Admin/MediaController.php:202
 msgid "Deleting media. This may take a while."
-msgstr ""
+msgstr "メディアを削除しています。しばらくお待ちください。"
 
 #: application/src/Controller/Admin/MediaController.php:221
 msgid "You must select at least one media to batch edit."
@@ -5466,23 +5466,23 @@ msgstr "一括編集するメディアを少なくとも1つ選択する必要�
 
 #: application/src/Controller/Admin/MediaController.php:245
 msgid "Media successfully edited"
-msgstr ""
+msgstr "メディアが正常に編集されました"
 
 #: application/src/Controller/Admin/MediaController.php:301
 msgid "Editing media. This may take a while."
-msgstr ""
+msgstr "メディアを編集しています。しばらくお待ちください。"
 
 #: application/src/Controller/Admin/AssetController.php:93
 msgid "Asset successfully updated"
-msgstr ""
+msgstr "アセットが正常に更新されました"
 
 #: application/src/Controller/Admin/AssetController.php:124
 msgid "asset"
-msgstr ""
+msgstr "アセット"
 
 #: application/src/Controller/Admin/AssetController.php:137
 msgid "Asset successfully deleted"
-msgstr ""
+msgstr "アセットが正常に削除されました"
 
 #: application/src/Controller/Admin/ItemSetController.php:32
 #, php-format
@@ -5574,21 +5574,21 @@ msgstr "リソーステンプレートを作成しました。 %s"
 
 #: application/config/module.config.php:704
 msgid "Owner email"
-msgstr ""
+msgstr "所有者のメールアドレス"
 
 #: application/config/module.config.php:710
 #: application/config/module.config.php:726
 #: application/config/module.config.php:731
 msgid "Item count"
-msgstr ""
+msgstr "アイテム数"
 
 #: application/config/module.config.php:720
 msgid "Resource class count"
-msgstr ""
+msgstr "リソースクラス数"
 
 #: application/config/module.config.php:721
 msgid "Property count"
-msgstr ""
+msgstr "プロパティ数"
 
 #: application/config/module.config.php:894
 msgid "Something went wrong"
@@ -5628,23 +5628,23 @@ msgstr "内容記述／Description"
 
 #: application/config/module.config.php:910
 msgid "Unknown block layout"
-msgstr ""
+msgstr "不明なブロックレイアウト"
 
 #: application/config/module.config.php:911
 msgid "Required field must be completed"
-msgstr ""
+msgstr "必須フィールドを入力してください"
 
 #: application/config/navigation.config.php:201
 msgid "Site admin"
-msgstr ""
+msgstr "サイト管理者"
 
 #: application/view/common/advanced-search/visibility.phtml:3
 msgid "Search by visibility"
-msgstr ""
+msgstr "可視性で検索"
 
 #: application/view/common/advanced-search/visibility.phtml:8
 msgid "Select visibility…"
-msgstr ""
+msgstr "可視性を選択…"
 
 #: application/view/common/advanced-search/sort.phtml:20
 msgid "Select sort by…"
@@ -5656,11 +5656,11 @@ msgstr "ソート順を選択"
 
 #: application/view/common/advanced-search/has-media.phtml:4
 msgid "Search by media presence"
-msgstr ""
+msgstr "メディアの有無で検索"
 
 #: application/view/common/advanced-search/has-media.phtml:9
 msgid "Select media presence…"
-msgstr ""
+msgstr "メディアの有無を選択…"
 
 #: application/view/common/advanced-search/properties.phtml:70
 msgid "[Any Property]"
@@ -5685,7 +5685,7 @@ msgstr "Dublin Core"
 
 #. Vocabulary comment for Dublin Core
 msgid "Basic resource metadata (DCMI Metadata Terms)"
-msgstr ""
+msgstr "基本リソースメタデータ (DCMI メタデータターム)"
 "基本的なリソースメタデータ（DCMIメタデータ語彙。日本語訳はhttp://ndl.go.jp/jp/dlib/standards/translation/dcmi-"
 "terms.htmから引用）"
 
@@ -5720,7 +5720,7 @@ msgstr "ファイル記録形式"
 
 #. Class comment for Dublin Core:FileFormat
 msgid "A digital resource format."
-msgstr ""
+msgstr "デジタルリソースの形式。"
 "デジタル情報資源の記録形式。例えば、インターネットメディアタイプ（Internet Media Types）のリストによって定義された記録形式を含む。"
 
 #. Class label for Dublin Core:Frequency
@@ -5871,7 +5871,7 @@ msgstr "寸法又は再生時間／Size or Duration"
 
 #. Class comment for Dublin Core:SizeOrDuration
 msgid "A dimension or extent, or a time taken to play or execute."
-msgstr ""
+msgstr "寸法、範囲、または再生・実行にかかる時間。"
 "次元（dimension）又はサイズ、若しくは実行にかかる時間。注釈： 例えば、ページ数、長さ、幅及び深さの仕様、又は時、分及び秒の区間がある。"
 
 #. Class label for Dublin Core:Standard
@@ -5891,7 +5891,7 @@ msgstr "リソースに与えられた名前。"
 
 #. Property comment for Dublin Core:creator
 msgid "An entity primarily responsible for making the resource."
-msgstr ""
+msgstr "リソースの作成に主要な責任を持つ実体。"
 "情報資源の内容の作成に主たる責任をもつ実体。\n"
 "注釈： creatorの例としては、人、組織、サービスなどがある。"
 
@@ -5901,13 +5901,13 @@ msgstr "キーワード／Subject"
 
 #. Property comment for Dublin Core:subject
 msgid "The topic of the resource."
-msgstr ""
+msgstr "リソースの主題。"
 "情報資源のトピック。\n"
 "注釈： 一般的に、subjectは、キーワード、キーフレーズ、又は分類コードによって表わすことになる。統制語彙を用いることを強く推奨する。"
 
 #. Property comment for Dublin Core:description
 msgid "An account of the resource."
-msgstr ""
+msgstr "リソースの説明。"
 "情報資源の内容の説明・記述。\n"
 "注釈： descriptionには、抄録、目次、内容の中の図に対する説明、自由テキストによる説明・記述などを含んでもよいが、これらに限定はされない。"
 
@@ -5917,7 +5917,7 @@ msgstr "公開者／Publisher"
 
 #. Property comment for Dublin Core:publisher
 msgid "An entity responsible for making the resource available."
-msgstr ""
+msgstr "リソースを利用可能にする責任を持つ実体。"
 "情報資源を公開することに対して責任をもつ実体。\n"
 "注釈： publisherの例としては、人、組織、サービスがある。"
 
@@ -5927,7 +5927,7 @@ msgstr "寄与者／Contributor"
 
 #. Property comment for Dublin Core:contributor
 msgid "An entity responsible for making contributions to the resource."
-msgstr ""
+msgstr "リソースへの貢献に責任を持つ実体。"
 "情報資源の内容になんらかの寄与、貢献をした実体。\n"
 "注釈： contributorの例としては、人、機関、サービスなどがある。一般的に、contributorの名前は、その実体を指示するために使用するのが望ましい。"
 
@@ -5953,7 +5953,7 @@ msgstr "記録形式／Format"
 
 #. Property comment for Dublin Core:format
 msgid "The file format, physical medium, or dimensions of the resource."
-msgstr ""
+msgstr "リソースのファイル形式、物理媒体、または寸法。"
 "情報資源のファイルの記録形式、物理媒体又は次元（dimension）。\n"
 "注釈： 次元の例には、寸法や再生時間などがある。インターネットメディアタイプ（Internet Media Types）[MIME]のような統制語彙を用いることを強く推奨する。"
 
@@ -5963,7 +5963,7 @@ msgstr "資源識別子／Identifier"
 
 #. Property comment for Dublin Core:identifier
 msgid "An unambiguous reference to the resource within a given context."
-msgstr ""
+msgstr "特定のコンテキスト内でのリソースへの明確な参照。"
 "所与の文脈における情報資源への明確な参照。\n"
 "注釈： 形式的な体系に基づいて文字列として表現された識別子によって情報資源を同定識別することを強く推奨する。"
 
@@ -5973,7 +5973,7 @@ msgstr "記述リソースが由来する関連リソース。"
 
 #. Property comment for Dublin Core:language
 msgid "A language of the resource."
-msgstr ""
+msgstr "リソースの言語。"
 "情報資源の言語。\n"
 "注釈： RFC 4646のような統制語彙を用いることを強く推奨する[RFC4646]。"
 
@@ -5983,7 +5983,7 @@ msgstr "関係／Relation"
 
 #. Property comment for Dublin Core:relation
 msgid "A related resource."
-msgstr ""
+msgstr "関連リソース。"
 "関係する情報資源。\n"
 "注釈： 形式的な体系に基づいて文字列として表現された識別子によって情報資源を同定識別することを強く推奨する。"
 
@@ -6005,7 +6005,7 @@ msgstr "権利管理／Rights"
 
 #. Property comment for Dublin Core:rights
 msgid "Information about rights held in and over the resource."
-msgstr ""
+msgstr "リソースに関する権利情報。"
 "情報資源に含まれる、又はかかわる権利管理に関する情報。\n"
 "注釈： 一般的に、権利管理の情報は、知的所有権(IPR)を含む情報資源に関する各種の所有権に関する記述を含む。"
 
@@ -6023,7 +6023,7 @@ msgstr "別タイトル／Alternative Title"
 
 #. Property comment for Dublin Core:alternative
 msgid "An alternative name for the resource."
-msgstr ""
+msgstr "リソースの代替名。"
 "情報資源の別の名前\n"
 "注釈： タイトルと別タイトルの間の区別はアプリケーションの特性に拠る。"
 
@@ -6277,7 +6277,7 @@ msgstr "提出日／Date Submitted"
 
 #. Property comment for Dublin Core:dateSubmitted
 msgid "Date of submission of the resource."
-msgstr ""
+msgstr "リソースの提出日。"
 "情報資源が提出された日付。\n"
 "注釈： dateSubmittedが関係するかもしれない情報資源の例としては、（大学学部へ提出された）学位論文、（雑誌へ提出された）論文記事などがある。"
 
@@ -6309,7 +6309,7 @@ msgstr "書誌的引用"
 
 #. Property comment for Dublin Core:bibliographicCitation
 msgid "A bibliographic reference for the resource."
-msgstr ""
+msgstr "リソースの書誌参照。"
 "情報資源のための書誌参照（bibliographic reference）。\n"
 "注釈： 可能な限り明確に情報資源を同定識別するため、書誌詳細事項を十分に含めることを推奨する。"
 
@@ -6403,7 +6403,7 @@ msgstr "データセット"
 
 #. Class comment for Dublin Core Type:Dataset
 msgid "Data encoded in a defined structure."
-msgstr ""
+msgstr "定義された構造でエンコードされたデータ。"
 "ある既定構造に符号化されたデータ。\n"
 "注釈： 例として、リスト、表、データベースなどがある。データセットは、直接的な機械処理に役立つかもしれない。"
 
@@ -6414,13 +6414,13 @@ msgstr "事象／Event"
 
 #. Class comment for Dublin Core Type:Event
 msgid "A non-persistent, time-based occurrence."
-msgstr ""
+msgstr "非永続的で時間ベースの出来事。"
 "永続的でない、時間に基づいた出来事。\n"
 "注釈： ある事象のメタデータは、その事象に関わる目的、場所、再生時間、責任エージェントを発見する際に土台となる記述的な情報を提供する。例として、展示、ウェブキャスト、会議、ワークショップ、オープンデイ、興行、戦闘、裁判、結婚式、お茶会、大火災などがある。"
 
 #. Class comment for Dublin Core Type:Image
 msgid "A visual representation other than text."
-msgstr ""
+msgstr "テキスト以外の視覚的表現。"
 "テキストではない視覚的表現。\n"
 "注釈： 例として、物理的対象の画像及び写真、絵画、版画、線画、その他の画像及び図形、アニメーション及び動画、映画、図表、地図、楽譜がある。なお、Imageには、電子的表現も物理的表現も含んでもよい。"
 
@@ -6442,7 +6442,7 @@ msgstr "サービス"
 
 #. Class comment for Dublin Core Type:Service
 msgid "A system that provides one or more functions."
-msgstr ""
+msgstr "1つ以上の機能を提供するシステム。"
 "一つ又は複数の機能を提供するシステム。\n"
 "注釈： 例として、複写サービス、銀行サービス、認証サービス、図書館間貸出、Z39.50、ウェブサーバなどがある。"
 
@@ -6452,7 +6452,7 @@ msgstr " ソフトウェア"
 
 #. Class comment for Dublin Core Type:Software
 msgid "A computer program in source or compiled form."
-msgstr ""
+msgstr "ソースまたはコンパイルされた形式のコンピュータプログラム。"
 "ソースコード又はコンパイルされた形のコンピュータプログラム。\n"
 "注釈： 例として、C言語のソースファイル、MS-Windowsの実行ファイル.exe、Perlのスクリプトなどがある。"
 
@@ -6462,7 +6462,7 @@ msgstr "録音／Sound"
 
 #. Class comment for Dublin Core Type:Sound
 msgid "A resource primarily intended to be heard."
-msgstr ""
+msgstr "主に聴くことを意図したリソース。"
 "聞かれることを主たる目的とする情報資源。\n"
 "注釈： 例として、音楽再生のファイル記録形式、音楽用コンパクトディスク、録音された発話又は録音などがある。"
 
@@ -6476,7 +6476,7 @@ msgstr "物理的対象"
 
 #. Class comment for Dublin Core Type:PhysicalObject
 msgid "An inanimate, three-dimensional object or substance."
-msgstr ""
+msgstr "無生物の3次元オブジェクトまたは物質。"
 "無生物で三次元の対象又は物質。\n"
 "注釈： これらの対象のデジタル表現又は代替物の記述には、Imageタイプ、Textタイプ、その他のタイプを用いるのがよい。"
 
@@ -6486,7 +6486,7 @@ msgstr "静止画像／Still Image"
 
 #. Class comment for Dublin Core Type:StillImage
 msgid "A static visual representation."
-msgstr ""
+msgstr "静的な視覚表現。"
 "静的な視覚表現。\n"
 "注釈： 例として、絵画、線画、グラフィックデザイン、設計図、地図などがある。文字資料の画像には、Textタイプを割り当てることを強く推奨する。StillImageのインスタンスは、上位のImageタイプのインスタンスとして記述することも可能である。"
 
@@ -7255,7 +7255,7 @@ msgstr "文書を一部の元のテキストに関連付けます。"
 
 #. Property label for Bibliographic Ontology:translationOf
 msgid "translation of"
-msgstr "の翻訳／translation of"
+msgstr "の翻訳"
 
 #. Property comment for Bibliographic Ontology:translationOf
 msgid "Relates a translated document to the original document."


### PR DESCRIPTION
## Summary
- Fix spacing issues and inconsistencies in Japanese translations
- Add missing translations for UI elements
- Correct grammar and formatting issues

## Important Note
This PR is submitted as a demonstration. The Omeka S project typically manages translations through [Transifex](https://www.transifex.com/omeka/omeka-s/), not direct pull requests. 

For sustainable contribution to Japanese translations, please consider joining the translation team on Transifex.

## Changes Made
- Fixed unnecessary spaces in translation strings
- Added translations for previously untranslated strings (e.g., "[invalid]" → "[無効]")
- Corrected inconsistent formatting and punctuation

## Test Plan
- [ ] Verify Japanese translations display correctly in the UI
- [ ] Check that no translation keys are broken
- [ ] Confirm proper spacing and formatting in rendered text

🤖 Generated with [Claude Code](https://claude.ai/code)