### PR TITLE
Sort value options after they are translated

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -453,6 +453,7 @@ return [
             'lightGalleryOutput' => View\Helper\LightGalleryOutput::class,
             'iiifViewer' => View\Helper\IiifViewer::class,
             'currentSite' => View\Helper\CurrentSite::class,
+            'formSelect' => Form\View\Helper\FormSelect::class,
         ],
         'factories' => [
             'api' => Service\ViewHelper\ApiFactory::class,

--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -503,6 +503,9 @@ return [
             'Laminas\Form\View\Helper\FormSelect' => [
                 Service\Delegator\FormSelectDelegatorFactory::class,
             ],
+            'Omeka\Form\View\Helper\FormSelect' => [
+                Service\Delegator\FormSelectDelegatorFactory::class,
+            ],
             'Laminas\Form\View\Helper\FormRow' => [
                 Service\Delegator\FormRowDelegatorFactory::class,
             ],

--- a/application/src/Form/Element/AbstractGroupByOwnerSelect.php
+++ b/application/src/Form/Element/AbstractGroupByOwnerSelect.php
@@ -5,8 +5,10 @@ use Omeka\Api\Manager as ApiManager;
 use Omeka\Api\Representation\UserRepresentation;
 use Laminas\Form\Element\Select;
 
-abstract class AbstractGroupByOwnerSelect extends Select
+abstract class AbstractGroupByOwnerSelect extends Select implements SelectSortTranslatedInterface
 {
+    use SelectSortTranslatedTrait;
+
     /**
      * @var ApiManager
      */

--- a/application/src/Form/Element/AbstractVocabularyMemberSelect.php
+++ b/application/src/Form/Element/AbstractVocabularyMemberSelect.php
@@ -7,7 +7,7 @@ use Laminas\EventManager\EventManagerAwareTrait;
 use Laminas\Form\Element\Select;
 use Laminas\I18n\Translator\TranslatorAwareTrait;
 
-abstract class AbstractVocabularyMemberSelect extends Select implements EventManagerAwareInterface, SortTranslatedValueOptionsInterface
+abstract class AbstractVocabularyMemberSelect extends Select implements EventManagerAwareInterface, SelectSortTranslatedInterface
 {
     use EventManagerAwareTrait;
     use TranslatorAwareTrait;
@@ -94,7 +94,7 @@ abstract class AbstractVocabularyMemberSelect extends Select implements EventMan
         return $valueOptions;
     }
 
-    public function getFinalizedValueOptions(array $options): array
+    public function finalizeValueOptions(array $options): array
     {
         // Move Dublin Core vocabularies (dcterms & dctype) to the beginning.
         if (isset($options['dcterms'])) {
@@ -103,13 +103,11 @@ abstract class AbstractVocabularyMemberSelect extends Select implements EventMan
         if (isset($options['dctype'])) {
             $options = ['dctype' => $options['dctype']] + $options;
         }
-
         // Prepend configured value options.
         $prependOptions = $this->getOption('prepend_value_options');
         if (is_array($prependOptions)) {
             $options = $prependOptions + $options;
         }
-
         return $options;
     }
 }

--- a/application/src/Form/Element/AbstractVocabularyMemberSelect.php
+++ b/application/src/Form/Element/AbstractVocabularyMemberSelect.php
@@ -7,7 +7,7 @@ use Laminas\EventManager\EventManagerAwareTrait;
 use Laminas\Form\Element\Select;
 use Laminas\I18n\Translator\TranslatorAwareTrait;
 
-abstract class AbstractVocabularyMemberSelect extends Select implements EventManagerAwareInterface
+abstract class AbstractVocabularyMemberSelect extends Select implements EventManagerAwareInterface, SortTranslatedValueOptionsInterface
 {
     use EventManagerAwareTrait;
     use TranslatorAwareTrait;
@@ -85,19 +85,6 @@ abstract class AbstractVocabularyMemberSelect extends Select implements EventMan
             }
             $valueOptions[$vocabulary->prefix()]['options'][] = $option;
         }
-        // Move Dublin Core vocabularies (dcterms & dctype) to the beginning.
-        if (isset($valueOptions['dcterms'])) {
-            $valueOptions = ['dcterms' => $valueOptions['dcterms']] + $valueOptions;
-        }
-        if (isset($valueOptions['dctype'])) {
-            $valueOptions = ['dctype' => $valueOptions['dctype']] + $valueOptions;
-        }
-
-        // Prepend configured value options.
-        $prependValueOptions = $this->getOption('prepend_value_options');
-        if (is_array($prependValueOptions)) {
-            $valueOptions = $prependValueOptions + $valueOptions;
-        }
 
         // Allow handlers to filter the value options.
         $args = $events->prepareArgs(['valueOptions' => $valueOptions]);
@@ -105,5 +92,24 @@ abstract class AbstractVocabularyMemberSelect extends Select implements EventMan
         $valueOptions = $args['valueOptions'];
 
         return $valueOptions;
+    }
+
+    public function getFinalizedValueOptions(array $options): array
+    {
+        // Move Dublin Core vocabularies (dcterms & dctype) to the beginning.
+        if (isset($options['dcterms'])) {
+            $options = ['dcterms' => $options['dcterms']] + $options;
+        }
+        if (isset($options['dctype'])) {
+            $options = ['dctype' => $options['dctype']] + $options;
+        }
+
+        // Prepend configured value options.
+        $prependOptions = $this->getOption('prepend_value_options');
+        if (is_array($prependOptions)) {
+            $options = $prependOptions + $options;
+        }
+
+        return $options;
     }
 }

--- a/application/src/Form/Element/SelectSortTranslatedInterface.php
+++ b/application/src/Form/Element/SelectSortTranslatedInterface.php
@@ -2,19 +2,19 @@
 namespace Omeka\Form\Element;
 
 /**
- * The SortTranslatedValueOptionsInterface interface.
+ * The SelectSortTranslatedInterface interface.
  *
  * The FormSelect view helper translates labels immediately before rendering
  * them, which makes it impossible to sort on the translated labels. Implement
  * this interface to translate before sorting.
  */
-interface SortTranslatedValueOptionsInterface
+interface SelectSortTranslatedInterface
 {
     /**
      * Get the finalized value options.
      *
-     * Implementing classes should use this method to finalize the structure and
+     * Implementing classes may use this method to finalize the structure and
      * content of the value options (e.g. custom sorting).
      */
-    public function getFinalizedValueOptions(array $options): array;
+    public function finalizeValueOptions(array $options): array;
 }

--- a/application/src/Form/Element/SelectSortTranslatedTrait.php
+++ b/application/src/Form/Element/SelectSortTranslatedTrait.php
@@ -1,0 +1,10 @@
+<?php
+namespace Omeka\Form\Element;
+
+trait SelectSortTranslatedTrait
+{
+    public function finalizeValueOptions(array $options): array
+    {
+        return $options;
+    }
+}

--- a/application/src/Form/Element/SortTranslatedValueOptionsInterface.php
+++ b/application/src/Form/Element/SortTranslatedValueOptionsInterface.php
@@ -1,0 +1,20 @@
+<?php
+namespace Omeka\Form\Element;
+
+/**
+ * The SortTranslatedValueOptionsInterface interface.
+ *
+ * The FormSelect view helper translates labels immediately before rendering
+ * them, which makes it impossible to sort on the translated labels. Implement
+ * this interface to translate before sorting.
+ */
+interface SortTranslatedValueOptionsInterface
+{
+    /**
+     * Get the finalized value options.
+     *
+     * Implementing classes should use this method to finalize the structure and
+     * content of the value options (e.g. custom sorting).
+     */
+    public function getFinalizedValueOptions(array $options): array;
+}

--- a/application/src/Form/View/Helper/FormSelect.php
+++ b/application/src/Form/View/Helper/FormSelect.php
@@ -38,6 +38,9 @@ class FormSelect extends LaminasFormSelect
         }
 
         if (($emptyOption = $element->getEmptyOption()) !== null) {
+            if ($element instanceof SelectSortTranslatedInterface) {
+                $emptyOption = $this->getView()->translate($emptyOption);
+            }
             $options = ['' => $emptyOption] + $options;
         }
 
@@ -61,8 +64,10 @@ class FormSelect extends LaminasFormSelect
             $rendered = $this->renderHiddenElement($element) . $rendered;
         }
 
-        // Enable the translator (default is true)
-        $this->setTranslatorEnabled(true);
+        if ($element instanceof SelectSortTranslatedInterface) {
+            // Re-enable the translator (default is true)
+            $this->setTranslatorEnabled(true);
+        }
 
         return $rendered;
     }

--- a/application/src/Form/View/Helper/FormSelect.php
+++ b/application/src/Form/View/Helper/FormSelect.php
@@ -5,15 +5,10 @@ use Laminas\Form\Exception;
 use Laminas\Form\ElementInterface;
 use Laminas\Form\Element\Select as SelectElement;
 use Laminas\Form\View\Helper\FormSelect as LaminasFormSelect;
-use Omeka\Form\Element\SortTranslatedValueOptionsInterface;
+use Omeka\Form\Element\SelectSortTranslatedInterface;
 
 class FormSelect extends LaminasFormSelect
 {
-    /**
-     * Override parent::render(), copying over the original code, adding a few
-     * lines that disable/enable automatic translation and translate/sort the
-     * value options.
-     */
     public function render(ElementInterface $element): string
     {
         if (! $element instanceof SelectElement) {
@@ -31,15 +26,16 @@ class FormSelect extends LaminasFormSelect
             ));
         }
 
-        /* begin code injection */
-        if ($element instanceof SortTranslatedValueOptionsInterface) {
-            // Temporarily disable the translator.
+        if ($element instanceof SelectSortTranslatedInterface) {
+            // Implementations of SelectSortTranslatedInterface override default
+            // behavior by sorting value options *after* they are translated.
+            // Normally they are sorted before they are translated.
             $this->setTranslatorEnabled(false);
             $options = $this->getValueOptions($element);
         } else {
+            // Default behavior.
             $options = $element->getValueOptions();
         }
-        /* end code injection */
 
         if (($emptyOption = $element->getEmptyOption()) !== null) {
             $options = ['' => $emptyOption] + $options;
@@ -65,10 +61,8 @@ class FormSelect extends LaminasFormSelect
             $rendered = $this->renderHiddenElement($element) . $rendered;
         }
 
-        /* begin code injection */
         // Enable the translator (default is true)
         $this->setTranslatorEnabled(true);
-        /* end code injection */
 
         return $rendered;
     }
@@ -119,8 +113,8 @@ class FormSelect extends LaminasFormSelect
             }
         }
 
-        // Elements can finalize the value options.
-        $options = $element->getFinalizedValueOptions($options);
+        // Elements may finalize the value options.
+        $options = $element->finalizeValueOptions($options);
 
         return $options;
     }

--- a/application/src/Form/View/Helper/FormSelect.php
+++ b/application/src/Form/View/Helper/FormSelect.php
@@ -1,0 +1,127 @@
+<?php
+namespace Omeka\Form\View\Helper;
+
+use Laminas\Form\Exception;
+use Laminas\Form\ElementInterface;
+use Laminas\Form\Element\Select as SelectElement;
+use Laminas\Form\View\Helper\FormSelect as LaminasFormSelect;
+use Omeka\Form\Element\SortTranslatedValueOptionsInterface;
+
+class FormSelect extends LaminasFormSelect
+{
+    /**
+     * Override parent::render(), copying over the original code, adding a few
+     * lines that disable/enable automatic translation and translate/sort the
+     * value options.
+     */
+    public function render(ElementInterface $element): string
+    {
+        if (! $element instanceof SelectElement) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s requires that the element is of type Laminas\Form\Element\Select',
+                __METHOD__
+            ));
+        }
+
+        $name = $element->getName();
+        if ($name === null || $name === '') {
+            throw new Exception\DomainException(sprintf(
+                '%s requires that the element has an assigned name; none discovered',
+                __METHOD__
+            ));
+        }
+
+        /* begin code injection */
+        if ($element instanceof SortTranslatedValueOptionsInterface) {
+            // Temporarily disable the translator.
+            $this->setTranslatorEnabled(false);
+            $options = $this->getValueOptions($element);
+        } else {
+            $options = $element->getValueOptions();
+        }
+        /* end code injection */
+
+        if (($emptyOption = $element->getEmptyOption()) !== null) {
+            $options = ['' => $emptyOption] + $options;
+        }
+
+        $attributes = $element->getAttributes();
+        $value      = $this->validateMultiValue($element->getValue(), $attributes);
+
+        $attributes['name'] = $name;
+        if (array_key_exists('multiple', $attributes) && $attributes['multiple']) {
+            $attributes['name'] .= '[]';
+        }
+        $this->validTagAttributes = $this->validSelectAttributes;
+
+        $rendered = sprintf(
+            '<select %s>%s</select>',
+            $this->createAttributesString($attributes),
+            $this->renderOptions($options, $value)
+        );
+
+        // Render hidden element
+        if ($element->useHiddenElement()) {
+            $rendered = $this->renderHiddenElement($element) . $rendered;
+        }
+
+        /* begin code injection */
+        // Enable the translator (default is true)
+        $this->setTranslatorEnabled(true);
+        /* end code injection */
+
+        return $rendered;
+    }
+
+    /**
+     * Get the translated/sorted value options.
+     */
+    public function getValueOptions(ElementInterface $element)
+    {
+        $options = $element->getValueOptions();
+        $view = $this->getView();
+
+        // Translate the options labels.
+        foreach ($options as &$option) {
+            if (is_string($option)) {
+                $option = $view->translate($option);
+            } elseif (is_array($option)) {
+                $option['label'] = $view->translate($option['label']);
+                if (isset($option['options'])) {
+                    foreach ($option['options'] as &$groupOption) {
+                        if (is_string($groupOption)) {
+                            $groupOption = $view->translate($groupOption);
+                        } elseif (is_array($groupOption)) {
+                            $groupOption['label'] = $view->translate($groupOption['label']);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Function to get option labels.
+        $getLabel = function ($option) {
+            if (is_string($option)) {
+                return $option;
+            } elseif (is_array($option)) {
+                return $option['label'];
+            }
+        };
+        // Sort the options alphabetically.
+        uasort($options, function ($a, $b) use ($getLabel) {
+            return strcasecmp($getLabel($a), $getLabel($b));
+        });
+        foreach ($options as &$option) {
+            if (isset($option['options'])) {
+                uasort($option['options'], function ($a, $b) use ($getLabel) {
+                    return strcasecmp($getLabel($a), $getLabel($b));
+                });
+            }
+        }
+
+        // Elements can finalize the value options.
+        $options = $element->getFinalizedValueOptions($options);
+
+        return $options;
+    }
+}


### PR DESCRIPTION
See #2350. Laminas's `FormSelect` view helper automatically translates labels immediately before rendering them, which makes it impossible to sort on the translated labels. With this PR, select elements that implement the new `SelectSortTranslatedInterface` interface declare that their value options should be translated before being sorted.