### PR TITLE
Add filter to limit vocab members used by item sets in a site

### DIFF
--- a/application/src/Api/Adapter/PropertyAdapter.php
+++ b/application/src/Api/Adapter/PropertyAdapter.php
@@ -172,6 +172,26 @@ class PropertyAdapter extends AbstractEntityAdapter
                     $qb->createNamedParameter($query['site_id'])));
             $qb->andWhere($qb->expr()->in('omeka_root.id', $subquery->getDQL()));
         }
+
+        if (isset($query['site_id_item_sets']) && is_numeric($query['site_id_item_sets'])) {
+            $siteAlias = $qb->createAlias();
+            $itemSetAlias = $qb->createAlias();
+            $valuesAlias = $qb->createAlias();
+            $subquery = $this->createQueryBuilder()
+                ->select("IDENTITY($valuesAlias.property)")
+                ->from('Omeka\Entity\Value', $valuesAlias)
+                ->join('Omeka\Entity\Site', $siteAlias)
+                ->join(
+                    "$siteAlias.siteItemSets",
+                    $itemSetAlias,
+                    "WITH",
+                    "$itemSetAlias.itemSet = $valuesAlias.resource")
+                ->andWhere($qb->expr()->eq(
+                    "$siteAlias.id",
+                    $qb->createNamedParameter($query['site_id_item_sets'])
+                ));
+            $qb->andWhere($qb->expr()->in('omeka_root.id', $subquery->getDQL()));
+        }
     }
 
     public function validateEntity(EntityInterface $entity, ErrorStore $errorStore)

--- a/application/src/Api/Adapter/ResourceClassAdapter.php
+++ b/application/src/Api/Adapter/ResourceClassAdapter.php
@@ -164,6 +164,25 @@ class ResourceClassAdapter extends AbstractEntityAdapter
                     $qb->createNamedParameter($query['site_id'])));
             $qb->andWhere($qb->expr()->in('omeka_root.id', $subquery->getDQL()));
         }
+
+        if (isset($query['site_id_item_sets']) && is_numeric($query['site_id_item_sets'])) {
+            $siteAlias = $qb->createAlias();
+            $itemSetAlias = $qb->createAlias();
+            $resourcesAlias = $qb->createAlias();
+            $subquery = $this->createQueryBuilder()
+                ->select("IDENTITY($resourcesAlias.resourceClass)")
+                ->from('Omeka\Entity\Resource', $resourcesAlias)
+                ->join('Omeka\Entity\Site', $siteAlias)
+                ->join(
+                    "$siteAlias.siteItemSets",
+                    $itemSetAlias,
+                    'WITH',
+                    "$itemSetAlias.itemSet = $resourcesAlias.id"
+                )
+                ->andWhere($qb->expr()->eq("$siteAlias.id",
+                    $qb->createNamedParameter($query['site_id_item_sets'])));
+            $qb->andWhere($qb->expr()->in('omeka_root.id', $subquery->getDQL()));
+        }
     }
 
     public function validateEntity(EntityInterface $entity, ErrorStore $errorStore)

--- a/application/view/common/advanced-search/properties.phtml
+++ b/application/view/common/advanced-search/properties.phtml
@@ -36,7 +36,11 @@ $queryText = function(array $search, $index) use ($translate) {
 $optionsQuery = [];
 if ($this->status()->isSiteRequest()) {
     if ($this->siteSetting('vocabulary_scope') === 'sitewide') {
-        $optionsQuery['site_id'] = $this->layout()->site->id();
+        if ('itemSet' === $resourceType) {
+            $optionsQuery['site_id_item_sets'] = $this->layout()->site->id();
+        } else {
+            $optionsQuery['site_id'] = $this->layout()->site->id();
+        }
     } elseif ($this->siteSetting('vocabulary_scope') === 'cross-site') {
         $optionsQuery['used'] = true;
     }

--- a/application/view/common/advanced-search/resource-class.phtml
+++ b/application/view/common/advanced-search/resource-class.phtml
@@ -12,7 +12,11 @@ if (!$ids) {
 $optionsQuery = [];
 if ($this->status()->isSiteRequest()) {
     if ($this->siteSetting('vocabulary_scope') === 'sitewide') {
-        $optionsQuery['site_id'] = $this->layout()->site->id();
+        if ('itemSet' === $resourceType) {
+            $optionsQuery['site_id_item_sets'] = $this->layout()->site->id();
+        } else {
+            $optionsQuery['site_id'] = $this->layout()->site->id();
+        }
     } elseif ($this->siteSetting('vocabulary_scope') === 'cross-site') {
         $optionsQuery['used'] = true;
     }


### PR DESCRIPTION
See [this forum post](https://forum.omeka.org/t/advanced-item-set-search-bug/28025).

Adds the `site_id_item_sets` filter to property and resource class queries. This limits results to properties and resource classes used by item sets in a site. Before, results were limited to only those used by items in a site. The omission of a filter for item sets was an oversight. The existing `site_id` filter remains untouched, but, going forward, it may be clearer to name it `site_id_items` and accept `site_id` for backwards compatibility.

