### PR TITLE
Prevent exception when controller name not set

### DIFF
--- a/application/src/Api/Representation/AbstractResourceRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceRepresentation.php
@@ -190,6 +190,9 @@ abstract class AbstractResourceRepresentation extends AbstractRepresentation
      */
     public function adminUrl($action = null, $canonical = false)
     {
+        if (null === $this->getControllerName()) {
+            return null;
+        }
         $url = $this->getViewHelper('Url');
         return $url(
             'admin/id',


### PR DESCRIPTION
Otherwise `adminUrl()` will throw an exception whenever `getControllerName()` returns null. 

The need for this change arose from this [forum post](https://forum.omeka.org/t/importing-from-omeka-classic-into-s/28024/3), which was addressed in https://github.com/omeka-s-modules/ActivityLog/commit/695461203aca08de2338d6dcd32cadf549db5192