### PR TITLE
Add displayValues option to respect property order

### DIFF
--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -481,6 +481,7 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
         $options['viewName'] ??= 'common/resource-values';
         $options['siteId'] ??= null;
         $options['properties'] ??= [];
+        $options['propertiesRespectOrder'] ??= false;
         $options['excludeProperties'] ??= [];
 
         $services = $this->getServiceLocator();
@@ -488,7 +489,11 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
 
         // Filter values by the "properties" and "excludeProperties" options.
         if ($options['properties']) {
-            $values = array_intersect_key($values, array_flip($options['properties']));
+            $termsAsKeys = array_flip($options['properties']);
+            $values = $options['propertiesRespectOrder']
+                ? array_replace($termsAsKeys, $values)
+                : $values;
+            $values = array_intersect_key($values, $termsAsKeys);
         }
         if ($options['excludeProperties']) {
             $values = array_diff_key($values, array_flip($options['excludeProperties']));

--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -471,6 +471,9 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
      * - viewName: Name of view script, or a view model. Default "common/resource-values"
      * - siteId: A site ID
      * - properties: an array of property terms to include in the markup (excludes all others)
+     * - propertiesRespectOrder:
+     *      - false (default): Maintain the original property order, irrespective of the passed order
+     *      - true: Respect the order of properties passed in the "properties" option
      * - excludeProperties: an array of property terms to exclude from the markup (includes all others)
      *
      * @param array $options
@@ -489,11 +492,17 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
 
         // Filter values by the "properties" and "excludeProperties" options.
         if ($options['properties']) {
-            $termsAsKeys = array_flip($options['properties']);
-            $values = $options['propertiesRespectOrder']
-                ? array_replace($termsAsKeys, $values)
-                : $values;
-            $values = array_intersect_key($values, $termsAsKeys);
+            if ($options['propertiesRespectOrder']) {
+                $orderedValues = [];
+                foreach ($options['properties'] as $term) {
+                    if (isset($values[$term])) {
+                        $orderedValues[$term] = $values[$term];
+                    }
+                }
+                $values = $orderedValues;
+            } else {
+                $values = array_intersect_key($values, array_flip($options['properties']));
+            }
         }
         if ($options['excludeProperties']) {
             $values = array_diff_key($values, array_flip($options['excludeProperties']));


### PR DESCRIPTION
See #2391. Adds "propertiesRespectOrder" option to `AbstractResourceEntityRepresentation::displayValues()`. Setting it to `true` changes default behavior to respect the order of properties passed in the "properties" option. The default behavior is to maintain the original property order, irrespective of the passed order. For example, this:

```php
$item->displayValues(['properties' => ['dcterms:subject', 'dcterms:description', 'dcterms:title']]);
```

will, in most cases, output "Title, Description, Subject" because that's the order defined on the resource itself. Whereas, this:

```php
$item->displayValues(['properties' => ['dcterms:subject', 'dcterms:description', 'dcterms:title'], 'propertiesRespectOrder' => true])
```

will output "Subject, Description, Title" because "propertiesRespectOrder" is `true`, and that's the order passed in the "properties" option.