### PR TITLE
Fixed check of matched route in cli.

### DIFF
--- a/application/src/Mvc/Status.php
+++ b/application/src/Mvc/Status.php
@@ -74,8 +74,9 @@ class Status
     public function getRouteMatch()
     {
         // Attempt to get the route match from the MVC event.
+        // There is no route in cli (background jobs) because no http request.
         $routeMatch = $this->serviceLocator->get('Application')->getMvcEvent()->getRouteMatch();
-        if (!$routeMatch) {
+        if (!$routeMatch && PHP_SAPI !== 'cli') {
             // If the match hasn't already been set, calculate it here.
             $router = $this->serviceLocator->get('Router');
             $request = $this->serviceLocator->get('Request');


### PR DESCRIPTION
There were some issues on the forum on [CleanUrl that break csv import](https://forum.omeka.org/t/csv-import-error-call-to-a-member-function-getparam/28675/4). So this patch avoids to prepare the route in cli context.