### PR TITLE
Add Canal-u oembed provider to module.config.php whitelist

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -932,6 +932,8 @@ return [
             ['#^https?://([a-z]{2}|www)\.pinterest\.com(\.(au|mx))?/#i', 'https://www.pinterest.com/oembed.json'],
             ['#^https?://(www\.)?wolframcloud\.com/obj/#i', 'https://www.wolframcloud.com/oembed'],
             ['#^https?://bsky.app/profile/.*/post/#i', 'https://embed.bsky.app/oembed'],
+            ['#^https?://(www\.)?canal\-u\.tv/embed/#i', 'https://www.canal-u.tv/oembed'],
+            ['#^https?://(www\.)?canal\-u\.tv/chaines/#i', 'https://www.canal-u.tv/oembed'],
         ],
     ],
     'mail' => [


### PR DESCRIPTION
Hi

Wer'e working on the https://www.canal-u.tv/ website and some application provided by omeka wants to use our medias through the oembed process.

So we suggest a pull request to provide 2 news entries concerning Canal-u oembed provider.
It based from https://www.canal-u.tv/oembed-providers.json : 
```json
  {
    "provider_name": "Canal-U",
    "provider_url": "https://www.canal-u.tv",
    "endpoints": [
      {
        "schemes": [
          "https://www.canal-u.tv/embed/*",
          "https://www.canal-u.tv/chaines/*"
        ],
        "url": "https://www.canal-u.tv/oembed",
        "discovery": true
      }
    ]
  }
```

It is possible to include it for the next release ?
We will let you do code review.

Thank you for your help
Axel DEPRET / backend developer for Canal U at Axess