### PR TITLE
Replace Laminas\Math and Laminas\Dom with native PHP

### DIFF
--- a/application/src/Entity/ApiKey.php
+++ b/application/src/Entity/ApiKey.php
@@ -2,7 +2,6 @@
 namespace Omeka\Entity;
 
 use DateTime;
-use Laminas\Math\Rand;
 
 /**
  * @Entity
@@ -162,8 +161,14 @@ class ApiKey extends AbstractEntity
         return $this->owner;
     }
 
+    // Generate a cryptographically random string for use as an API key identity or credential.
     protected function getString()
     {
-        return Rand::getString(self::STRING_LENGTH, self::STRING_CHARLIST, true);
+        $result = '';
+        $max = strlen(self::STRING_CHARLIST) - 1;
+        for ($i = 0; $i < self::STRING_LENGTH; $i++) {
+            $result .= self::STRING_CHARLIST[random_int(0, $max)];
+        }
+        return $result;
     }
 }

--- a/application/src/Entity/ApiKey.php
+++ b/application/src/Entity/ApiKey.php
@@ -161,7 +161,10 @@ class ApiKey extends AbstractEntity
         return $this->owner;
     }
 
-    // Generate a cryptographically random string for use as an API key identity or credential.
+    /**
+     * Generate a cryptographically random string for use as an API key identity 
+     * or credential.
+     */
     protected function getString()
     {
         $result = '';

--- a/application/src/Entity/ApiKey.php
+++ b/application/src/Entity/ApiKey.php
@@ -162,7 +162,7 @@ class ApiKey extends AbstractEntity
     }
 
     /**
-     * Generate a cryptographically random string for use as an API key identity 
+     * Generate a cryptographically random string for use as an API key identity
      * or credential.
      */
     protected function getString()

--- a/application/src/File/TempFile.php
+++ b/application/src/File/TempFile.php
@@ -8,7 +8,6 @@ use Omeka\File\Store\StoreInterface;
 use Omeka\Stdlib\ErrorStore;
 use Laminas\EventManager\Event;
 use Laminas\EventManager\EventManagerAwareTrait;
-use Laminas\Math\Rand;
 
 class TempFile
 {
@@ -190,7 +189,8 @@ class TempFile
         if (isset($this->storageId)) {
             return $this->storageId;
         }
-        $this->storageId = bin2hex(Rand::getBytes(20));
+        // Cryptographically random storage ID to prevent filename collisions and enumeration.
+        $this->storageId = bin2hex(random_bytes(20));
         return $this->storageId;
     }
 

--- a/application/src/Stdlib/Oembed.php
+++ b/application/src/Stdlib/Oembed.php
@@ -1,6 +1,9 @@
 <?php
 namespace Omeka\Stdlib;
 
+use DOMDocument;
+use DOMNodeList;
+use DOMXPath;
 use Laminas\Http\Client as HttpClient;
 use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\Uri\Http as HttpUri;
@@ -117,18 +120,18 @@ class Oembed
      * @param string $xpath
      * @return \DOMNodeList|false Returns false if the HTML cannot be loaded
      */
-    protected function queryXpath(string $html, string $xpath): \DOMNodeList|false
+    protected function queryXpath(string $html, string $xpath): DOMNodeList|false
     {
         // Suppress warnings from malformed HTML and discard any parse errors.
         libxml_use_internal_errors(true);
-        $doc = new \DOMDocument();
+        $doc = new DOMDocument();
         $success = $doc->loadHTML($html);
         libxml_clear_errors();
         libxml_use_internal_errors(false);
         if (!$success) {
             return false;
         }
-        return (new \DOMXPath($doc))->query($xpath);
+        return (new DOMXPath($doc))->query($xpath);
     }
 
     /**

--- a/application/src/Stdlib/Oembed.php
+++ b/application/src/Stdlib/Oembed.php
@@ -58,14 +58,11 @@ class Oembed
             if (!$response) {
                 return false;
             }
-            libxml_use_internal_errors(true);
-            $doc = new \DOMDocument();
-            $doc->loadHTML($response->getBody());
-            libxml_clear_errors();
-            libxml_use_internal_errors(false);
-            $xpath = new \DOMXPath($doc);
-            $oembedLinks = $xpath->query('//link[@rel="alternate" or @rel="alternative"][@type="application/json+oembed" or @type="text/json+oembed"]');
-            if (!$oembedLinks->length) {
+            $oembedLinks = $this->queryXpath(
+                $response->getBody(),
+                '//link[@rel="alternate" or @rel="alternative"][@type="application/json+oembed" or @type="text/json+oembed"]'
+            );
+            if (!$oembedLinks || !$oembedLinks->length) {
                 $errorStore->addError($errorKey, sprintf($this->translator->translate('oEmbed: links cannot be found at %s'), $url));
                 return false;
             }
@@ -111,6 +108,27 @@ class Oembed
             );
         }
         return false;
+    }
+
+    /**
+     * Query an HTML string using an XPath expression.
+     *
+     * @param string $html
+     * @param string $xpath
+     * @return \DOMNodeList|false Returns false if the HTML cannot be loaded
+     */
+    protected function queryXpath(string $html, string $xpath): \DOMNodeList|false
+    {
+        // Suppress warnings from malformed HTML and discard any parse errors.
+        libxml_use_internal_errors(true);
+        $doc = new \DOMDocument();
+        $success = $doc->loadHTML($html);
+        libxml_clear_errors();
+        libxml_use_internal_errors(false);
+        if (!$success) {
+            return false;
+        }
+        return (new \DOMXPath($doc))->query($xpath);
     }
 
     /**

--- a/application/src/Stdlib/Oembed.php
+++ b/application/src/Stdlib/Oembed.php
@@ -1,7 +1,6 @@
 <?php
 namespace Omeka\Stdlib;
 
-use Laminas\Dom\Query;
 use Laminas\Http\Client as HttpClient;
 use Laminas\I18n\Translator\TranslatorInterface;
 use Laminas\Uri\Http as HttpUri;
@@ -59,15 +58,19 @@ class Oembed
             if (!$response) {
                 return false;
             }
-            $dom = new Query($response->getBody());
-            $xpath = '//link[@rel="alternate" or @rel="alternative"][@type="application/json+oembed" or @type="text/json+oembed"]';
-            $oembedLinks = $dom->queryXpath($xpath);
-            if (!$oembedLinks->count()) {
+            libxml_use_internal_errors(true);
+            $doc = new \DOMDocument();
+            $doc->loadHTML($response->getBody());
+            libxml_clear_errors();
+            libxml_use_internal_errors(false);
+            $xpath = new \DOMXPath($doc);
+            $oembedLinks = $xpath->query('//link[@rel="alternate" or @rel="alternative"][@type="application/json+oembed" or @type="text/json+oembed"]');
+            if (!$oembedLinks->length) {
                 $errorStore->addError($errorKey, sprintf($this->translator->translate('oEmbed: links cannot be found at %s'), $url));
                 return false;
             }
             // Use the endpoint provided by the discovery link.
-            $oembedUrl = $oembedLinks->current()->getAttribute('href');
+            $oembedUrl = $oembedLinks->item(0)->getAttribute('href');
         }
 
         // Get the oEmbed response.


### PR DESCRIPTION
Replaces `Laminas\Math\Rand` and `Laminas\Dom\Query` with native PHP equivalents, reducing dependency on third-party packages.

- `Laminas\Math\Rand::getBytes()` and `::getString()` replaced with `random_bytes()` and `random_int()`, which provide identical cryptographic security guarantees
- `Laminas\Dom\Query` replaced with `DOMDocument` + `DOMXPath`, preserving identical parsing and query behavior

After merging, `laminas/laminas-math` and `laminas/laminas-dom` should be removed from `composer.json` if no longer pulled in transitively.