### PR TITLE
Validate vocabulary prefix against allowed character pattern

### DIFF
--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -10,6 +10,7 @@ use Omeka\Api\Response;
 use Omeka\Db\QueryBuilder as OmekaQueryBuilder;
 use Omeka\Entity\User;
 use Omeka\Entity\EntityInterface;
+use Omeka\Entity\Vocabulary;
 use Omeka\Stdlib\ErrorStore;
 use Laminas\EventManager\Event;
 
@@ -787,7 +788,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
      */
     public function isTerm($term)
     {
-        return (bool) preg_match('/^[a-z0-9-_]+:[a-z0-9-_]+$/i', $term);
+        return (bool) preg_match(sprintf('/^%s:%s$/i', Vocabulary::PREFIX_PATTERN, Vocabulary::LOCAL_NAME_PATTERN), $term);
     }
 
     /**

--- a/application/src/Api/Adapter/AbstractEntityAdapter.php
+++ b/application/src/Api/Adapter/AbstractEntityAdapter.php
@@ -788,7 +788,7 @@ abstract class AbstractEntityAdapter extends AbstractAdapter implements EntityAd
      */
     public function isTerm($term)
     {
-        return (bool) preg_match(sprintf('/^%s:%s$/i', Vocabulary::PREFIX_PATTERN, Vocabulary::LOCAL_NAME_PATTERN), $term);
+        return (bool) preg_match(Vocabulary::TERM_REGEX, $term);
     }
 
     /**

--- a/application/src/Api/Adapter/VocabularyAdapter.php
+++ b/application/src/Api/Adapter/VocabularyAdapter.php
@@ -203,7 +203,7 @@ class VocabularyAdapter extends AbstractEntityAdapter
         if (false == $entity->getPrefix()) {
             $errorStore->addError('o:prefix', 'The prefix cannot be empty.'); // @translate
         }
-        if ($prefix && !preg_match(sprintf('/^%s$/i', Vocabulary::PREFIX_PATTERN), $prefix)) {
+        if ($prefix && !preg_match(Vocabulary::PREFIX_REGEX, $prefix)) {
             $errorStore->addError('o:prefix', 'The prefix may only contain letters, numbers, hyphens, and underscores.'); // @translate
         }
         if (!$this->isUnique($entity, ['prefix' => $prefix])) {

--- a/application/src/Api/Adapter/VocabularyAdapter.php
+++ b/application/src/Api/Adapter/VocabularyAdapter.php
@@ -4,6 +4,7 @@ namespace Omeka\Api\Adapter;
 use Doctrine\ORM\QueryBuilder;
 use Omeka\Api\Request;
 use Omeka\Entity\EntityInterface;
+use Omeka\Entity\Vocabulary;
 use Omeka\Stdlib\ErrorStore;
 use Omeka\Stdlib\Message;
 
@@ -201,6 +202,9 @@ class VocabularyAdapter extends AbstractEntityAdapter
         $prefix = $entity->getPrefix();
         if (false == $entity->getPrefix()) {
             $errorStore->addError('o:prefix', 'The prefix cannot be empty.'); // @translate
+        }
+        if ($prefix && !preg_match(sprintf('/^%s$/i', Vocabulary::PREFIX_PATTERN), $prefix)) {
+            $errorStore->addError('o:prefix', 'The prefix may only contain letters, numbers, hyphens, and underscores.'); // @translate
         }
         if (!$this->isUnique($entity, ['prefix' => $prefix])) {
             $errorStore->addError('o:prefix', new Message(

--- a/application/src/Entity/Vocabulary.php
+++ b/application/src/Entity/Vocabulary.php
@@ -12,8 +12,10 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class Vocabulary extends AbstractEntity
 {
-    const PREFIX_PATTERN = '[a-z0-9_-]+';
-    const LOCAL_NAME_PATTERN = '[a-z0-9_-]+';
+    /** Regex for a valid vocabulary prefix. */
+    const PREFIX_REGEX = '/^[a-z0-9_-]+$/i';
+    /** Regex for a valid JSON-LD term in prefix:localName form. */
+    const TERM_REGEX = '/^[a-z0-9_-]+:[a-z0-9_-]+$/i';
 
     /**
      * @Id

--- a/application/src/Entity/Vocabulary.php
+++ b/application/src/Entity/Vocabulary.php
@@ -12,6 +12,9 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class Vocabulary extends AbstractEntity
 {
+    const PREFIX_PATTERN = '[a-z0-9_-]+';
+    const LOCAL_NAME_PATTERN = '[a-z0-9_-]+';
+
     /**
      * @Id
      * @Column(type="integer")

--- a/application/src/Form/VocabularyForm.php
+++ b/application/src/Form/VocabularyForm.php
@@ -198,7 +198,7 @@ class VocabularyForm extends Form
                     [
                         'name' => 'Regex',
                         'options' => [
-                            'pattern' => sprintf('/^%s$/i', Vocabulary::PREFIX_PATTERN),
+                            'pattern' => Vocabulary::PREFIX_REGEX,
                             'messages' => [
                                 \Laminas\Validator\Regex::NOT_MATCH => 'The prefix may only contain letters, numbers, hyphens, and underscores.', // @translate
                             ],

--- a/application/src/Form/VocabularyForm.php
+++ b/application/src/Form/VocabularyForm.php
@@ -2,6 +2,7 @@
 namespace Omeka\Form;
 
 use Laminas\Form\Form;
+use Omeka\Entity\Vocabulary;
 
 class VocabularyForm extends Form
 {
@@ -190,6 +191,22 @@ class VocabularyForm extends Form
         ]);
 
         $inputFilter = $this->getInputFilter();
+        if (!$vocabulary) {
+            $inputFilter->get('vocabulary-info')->add([
+                'name' => 'o:prefix',
+                'validators' => [
+                    [
+                        'name' => 'Regex',
+                        'options' => [
+                            'pattern' => sprintf('/^%s$/i', Vocabulary::PREFIX_PATTERN),
+                            'messages' => [
+                                \Laminas\Validator\Regex::NOT_MATCH => 'The prefix may only contain letters, numbers, hyphens, and underscores.', // @translate
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+        }
         $inputFilter->get('vocabulary-file')->add([
             'name' => 'url',
             'required' => false,


### PR DESCRIPTION
The vocabulary prefix is user-supplied but was never validated against the character pattern that `isTerm()` already enforces. This meant a vocabulary could be created with an invalid prefix that would cause term lookups to silently fail.

This change adds prefix format validation at both the form level (for immediate user feedback) and the API adapter level (as a server-side guard for direct API writes). The allowed character pattern is centralized so it isn't duplicated across files.

A pre-existing bug in `isTerm()`'s regex is also fixed: the hyphen in `[a-z0-9-_]` was in an ambiguous position that caused it to match a broader range of characters than intended. It is moved to the end of the character class: `[a-z0-9_-]`.