### PR TITLE
Fix N+1 queries in primaryMedia() on browse pages

### DIFF
--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -33,9 +33,6 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
      */
     protected $values;
 
-    // false = unresolved; null = no media; MediaRepresentation = resolved
-    protected $primaryMediaCache = false;
-
     /**
      * Get the internal members of this resource entity.
      *

--- a/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
+++ b/application/src/Api/Representation/AbstractResourceEntityRepresentation.php
@@ -33,6 +33,9 @@ abstract class AbstractResourceEntityRepresentation extends AbstractEntityRepres
      */
     protected $values;
 
+    // false = unresolved; null = no media; MediaRepresentation = resolved
+    protected $primaryMediaCache = false;
+
     /**
      * Get the internal members of this resource entity.
      *

--- a/application/src/Api/Representation/ItemRepresentation.php
+++ b/application/src/Api/Representation/ItemRepresentation.php
@@ -83,6 +83,9 @@ class ItemRepresentation extends AbstractResourceEntityRepresentation
 
     public function primaryMedia()
     {
+        if ($this->primaryMediaCache !== false) {
+            return $this->primaryMediaCache;
+        }
         // Return the primary media if one is set.
         $primaryMedia = $this->resource->getPrimaryMedia();
         if ($primaryMedia) {
@@ -95,11 +98,11 @@ class ItemRepresentation extends AbstractResourceEntityRepresentation
                 ->get('Omeka\EntityManager')
                 ->getRepository('Omeka\Entity\Media')
                 ->findOneBy(['id' => $primaryMedia->getId()]);
-            return $this->getAdapter('media')->getRepresentation($primaryMedia);
+            return $this->primaryMediaCache = $this->getAdapter('media')->getRepresentation($primaryMedia);
         }
         // Return the first media if one exists.
         $media = $this->media();
-        return $media ? $media[0] : null;
+        return $this->primaryMediaCache = $media ? $media[0] : null;
     }
 
     public function siteUrl($siteSlug = null, $canonical = false)

--- a/application/src/Api/Representation/ItemRepresentation.php
+++ b/application/src/Api/Representation/ItemRepresentation.php
@@ -3,6 +3,9 @@ namespace Omeka\Api\Representation;
 
 class ItemRepresentation extends AbstractResourceEntityRepresentation
 {
+    // false = unresolved; null = no media; MediaRepresentation = resolved
+    protected $primaryMediaCache = false;
+
     public function getControllerName()
     {
         return 'item';

--- a/application/src/Api/Representation/ItemRepresentation.php
+++ b/application/src/Api/Representation/ItemRepresentation.php
@@ -101,11 +101,13 @@ class ItemRepresentation extends AbstractResourceEntityRepresentation
                 ->get('Omeka\EntityManager')
                 ->getRepository('Omeka\Entity\Media')
                 ->findOneBy(['id' => $primaryMedia->getId()]);
-            return $this->primaryMediaCache = $this->getAdapter('media')->getRepresentation($primaryMedia);
+            $this->primaryMediaCache = $this->getAdapter('media')->getRepresentation($primaryMedia);
+        } else {
+            // Return the first media if one exists.
+            $media = $this->media();
+            $this->primaryMediaCache = $media ? $media[0] : null;
         }
-        // Return the first media if one exists.
-        $media = $this->media();
-        return $this->primaryMediaCache = $media ? $media[0] : null;
+        return $this->primaryMediaCache;
     }
 
     public function siteUrl($siteSlug = null, $canonical = false)

--- a/application/src/Api/Representation/ItemSetRepresentation.php
+++ b/application/src/Api/Representation/ItemSetRepresentation.php
@@ -3,6 +3,9 @@ namespace Omeka\Api\Representation;
 
 class ItemSetRepresentation extends AbstractResourceEntityRepresentation
 {
+    // false = unresolved; null = no media; MediaRepresentation = resolved
+    protected $primaryMediaCache = false;
+
     public function getControllerName()
     {
         return 'item-set';

--- a/application/src/Api/Representation/ItemSetRepresentation.php
+++ b/application/src/Api/Representation/ItemSetRepresentation.php
@@ -62,13 +62,16 @@ class ItemSetRepresentation extends AbstractResourceEntityRepresentation
      */
     public function primaryMedia()
     {
-        $itemEntities = $this->resource->getItems();
-        if ($itemEntities->isEmpty()) {
-            return null;
+        if ($this->primaryMediaCache !== false) {
+            return $this->primaryMediaCache;
         }
-        $item = $this->getAdapter('items')
-            ->getRepresentation($itemEntities->slice(0, 1)[0]);
-        return $item->primaryMedia();
+        $items = $this->resource->getItems()->slice(0, 1);
+        if (!$items) {
+            return $this->primaryMediaCache = null;
+        }
+        return $this->primaryMediaCache = $this->getAdapter('items')
+            ->getRepresentation($items[0])
+            ->primaryMedia();
     }
 
     public function siteUrl($siteSlug = null, $canonical = false)

--- a/application/src/Api/Representation/ItemSetRepresentation.php
+++ b/application/src/Api/Representation/ItemSetRepresentation.php
@@ -68,13 +68,12 @@ class ItemSetRepresentation extends AbstractResourceEntityRepresentation
         if ($this->primaryMediaCache !== false) {
             return $this->primaryMediaCache;
         }
+        $this->primaryMediaCache = null;
         $items = $this->resource->getItems()->slice(0, 1);
-        if (!$items) {
-            return $this->primaryMediaCache = null;
+        if ($items) {
+            $this->primaryMediaCache = $this->getAdapter('items')->getRepresentation($items[0])->primaryMedia();
         }
-        return $this->primaryMediaCache = $this->getAdapter('items')
-            ->getRepresentation($items[0])
-            ->primaryMedia();
+        return $this->primaryMediaCache;
     }
 
     public function siteUrl($siteSlug = null, $canonical = false)


### PR DESCRIPTION
On item set and item browse pages, `primaryMedia()` is called up to 5 times per representation instance during a browse page render:

| # | Caller | Path |
|---|--------|------|
| 1 | `thumbnailDisplayUrl()` | `linkPretty()` → thumbnail helper |
| 2 | `thumbnailAltText()` | `linkPretty()` → thumbnail helper |
| 3–5 | `thumbnailDisplayUrls()` (large, medium, square) | `embeddedJsonLd()` → `getJsonLd()` |

Without caching, every call re-queried the database. For item sets, the check for whether the set had any items at all also issued a `COUNT` query before each fetch, meaning a 25-row browse page could generate nearly 250 queries just to resolve thumbnails.

### Root cause of the `COUNT` queries (item sets only)

In `ItemSetRepresentation::primaryMedia()`, `isEmpty()` was called on the `items` collection before calling `slice(0, 1)`. Because the collection is configured as `EXTRA_LAZY`, Doctrine translates `isEmpty()` to a `SELECT COUNT(*)` rather than loading the collection.

### Root cause of the repeated queries (item sets and items)

Neither `ItemSetRepresentation` nor `ItemRepresentation` cached the result of `primaryMedia()`, so every one of the 5 call sites re-queried the database. For items, this meant the same media record was fetched repeatedly via `findOneBy`.

### Fix

The `COUNT` queries are eliminated by replacing `isEmpty()` + `slice()` with a single `slice(0, 1)`, which Doctrine handles with a single `LIMIT 1` query. The repeated queries are eliminated by caching the result of `primaryMedia()` on the representation instance, so all subsequent calls within the same request are served from memory without touching the database.

### Benchmarks

Each scenario was measured by loading the admin item set browse page and counting queries against the `item_item_set` table in the SQL log.

| Scenario | COUNT | LIMIT | Total |
|---|---|---|---|
| Original (`isEmpty()`, no cache) | 125 | 123 | 248 |
| Slice fix only (no `isEmpty()`, no cache) | 0 | 124 | 124 |
| Cache only (`isEmpty()`, cache) | 27 | 27 | 54 |
| Both fixes (current) | 0 | 27 | 27 |

The slice fix alone cuts queries in half by eliminating all COUNT queries. The cache alone reduces queries by ~78% by collapsing 5 calls into 1 per instance. Together they reduce queries by ~89%, from 248 down to 27.

Should fix #2464