### PR TITLE
Use browse defaults for sort, replace hardcoded 'created'

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -672,7 +672,7 @@ return [
         ],
         'public' => [
             'items' => [
-                'sort_by' => 'created',
+                'sort_by' => 'id',
                 'sort_order' => 'desc',
             ],
         ],

--- a/application/src/Controller/Admin/ItemController.php
+++ b/application/src/Controller/Admin/ItemController.php
@@ -93,7 +93,7 @@ class ItemController extends AbstractActionController
 
     public function sidebarSelectAction()
     {
-        $this->setBrowseDefaults('created');
+        $this->browse()->setDefaults('items');
         $response = $this->api()->search('items', $this->params()->fromQuery());
         $this->paginator($response->getTotalResults());
 

--- a/application/src/Controller/Admin/ItemSetController.php
+++ b/application/src/Controller/Admin/ItemSetController.php
@@ -137,7 +137,7 @@ class ItemSetController extends AbstractActionController
 
     public function sidebarSelectAction()
     {
-        $this->setBrowseDefaults('created');
+        $this->browse()->setDefaults('item_sets');
         $response = $this->api()->search('item_sets', $this->params()->fromQuery());
         $this->paginator($response->getTotalResults());
 

--- a/application/src/Controller/Admin/MediaController.php
+++ b/application/src/Controller/Admin/MediaController.php
@@ -144,7 +144,7 @@ class MediaController extends AbstractActionController
 
     public function sidebarSelectAction()
     {
-        $this->setBrowseDefaults('created');
+        $this->browse()->setDefaults('media');
         $response = $this->api()->search('media', $this->params()->fromQuery());
         $this->paginator($response->getTotalResults());
 

--- a/application/src/Controller/Admin/QueryController.php
+++ b/application/src/Controller/Admin/QueryController.php
@@ -39,7 +39,7 @@ class QueryController extends AbstractActionController
             default:
                 $resourceType = 'items';
         }
-        $this->setBrowseDefaults('created');
+        $this->browse()->setDefaults($resourceType);
 
         $previewAppendQuery = json_decode($this->params()->fromQuery('query_preview_append_query'), true);
         $query = array_merge($this->params()->fromQuery(), $previewAppendQuery);

--- a/application/src/Controller/Admin/UserController.php
+++ b/application/src/Controller/Admin/UserController.php
@@ -79,7 +79,7 @@ class UserController extends AbstractActionController
 
     public function sidebarSelectAction()
     {
-        $this->setBrowseDefaults('created');
+        $this->browse()->setDefaults('users');
         $response = $this->api()->search('users', $this->params()->fromQuery());
         $this->paginator($response->getTotalResults());
 

--- a/application/src/Controller/SearchController.php
+++ b/application/src/Controller/SearchController.php
@@ -30,7 +30,8 @@ class SearchController extends AbstractActionController
 
     public function sitePagesAction()
     {
-        $this->setBrowseDefaults('created');
+        // Cannot use browse()->setDefaults() — this route has no admin or site context.
+        $this->setBrowseDefaults('id');
         $response = $this->api()->search('site_pages', $this->params()->fromQuery());
         $this->paginator($response->getTotalResults());
         $view = new ViewModel;
@@ -40,7 +41,8 @@ class SearchController extends AbstractActionController
 
     public function itemsAction()
     {
-        $this->setBrowseDefaults('created');
+        // Cannot use browse()->setDefaults() — this route has no admin or site context.
+        $this->setBrowseDefaults('id');
         $query = array_merge($this->params()->fromQuery(), ['in_sites' => true]);
         $response = $this->api()->search('items', $query);
         $this->paginator($response->getTotalResults());
@@ -51,7 +53,8 @@ class SearchController extends AbstractActionController
 
     public function itemSetsAction()
     {
-        $this->setBrowseDefaults('created');
+        // Cannot use browse()->setDefaults() — this route has no admin or site context.
+        $this->setBrowseDefaults('id');
         $query = array_merge($this->params()->fromQuery(), ['in_sites' => true]);
         $response = $this->api()->search('item_sets', $query);
         $this->paginator($response->getTotalResults());

--- a/application/src/Controller/Site/CrossSiteSearchController.php
+++ b/application/src/Controller/Site/CrossSiteSearchController.php
@@ -74,7 +74,7 @@ class CrossSiteSearchController extends AbstractActionController
 
     public function sitePagesAction()
     {
-        $this->setBrowseDefaults('created');
+        $this->browse()->setDefaults('site_pages');
         $response = $this->api()->search('site_pages', $this->params()->fromQuery());
         $this->paginator($response->getTotalResults());
         $view = new ViewModel;
@@ -85,7 +85,7 @@ class CrossSiteSearchController extends AbstractActionController
 
     public function itemsAction()
     {
-        $this->setBrowseDefaults('created');
+        $this->browse()->setDefaults('items');
         $query = array_merge($this->params()->fromQuery(), ['in_sites' => true]);
         $response = $this->api()->search('items', $query);
         $this->paginator($response->getTotalResults());
@@ -97,7 +97,7 @@ class CrossSiteSearchController extends AbstractActionController
 
     public function itemSetsAction()
     {
-        $this->setBrowseDefaults('created');
+        $this->browse()->setDefaults('item_sets');
         $query = array_merge($this->params()->fromQuery(), ['in_sites' => true]);
         $response = $this->api()->search('item_sets', $query);
         $this->paginator($response->getTotalResults());

--- a/application/src/Controller/Site/PageController.php
+++ b/application/src/Controller/Site/PageController.php
@@ -16,7 +16,7 @@ class PageController extends AbstractActionController
 
     public function browseAction()
     {
-        $this->setBrowseDefaults('created');
+        $this->browse()->setDefaults('site_pages');
         $query = $this->params()->fromQuery();
         $query['site_id'] = $this->currentSite()->id();
 

--- a/application/src/Controller/SiteAdmin/IndexController.php
+++ b/application/src/Controller/SiteAdmin/IndexController.php
@@ -538,7 +538,7 @@ class IndexController extends AbstractActionController
 
     public function sidebarItemSelectAction()
     {
-        $this->setBrowseDefaults('created');
+        $this->browse()->setDefaults('items');
         $site = $this->currentSite();
 
         $query = $this->params()->fromQuery();


### PR DESCRIPTION
## Summary

- Replaces `setBrowseDefaults('created')` with `browse()->setDefaults($resourceType)` in sidebar select and search controllers so sort behavior defers to configured browse defaults rather than ignoring them
- Updates the public items browse default from `created` to `id` in `module.config.php`, consistent with the admin default set in 278fbaa8c but missed at the time
- `SearchController` is the one exception — it uses `setBrowseDefaults('id')` directly because the `/search` route has no admin or site context, making `browse()->setDefaults()` unsafe (would call `SiteSettings::get()` without a target ID)

## Affected controllers

| Controller | Action | New default |
|---|---|---|
| Admin\ItemController | sidebarSelectAction | id/desc |
| Admin\MediaController | sidebarSelectAction | id/desc |
| Admin\ItemSetController | sidebarSelectAction | id/desc |
| Admin\UserController | sidebarSelectAction | id/desc |
| Admin\QueryController | sidebarPreviewAction | id/desc |
| SiteAdmin\IndexController | sidebarItemSelectAction | id/desc |
| Site\PageController | browseAction | id/desc |
| SearchController | sitePagesAction, itemsAction, itemSetsAction | id/desc |
| Site\CrossSiteSearchController | sitePagesAction, itemsAction, itemSetsAction | per browse defaults |

Should fix #2410