### PR TITLE
Replace isSiteRequest() guards with fallbackSetting()

### DIFF
--- a/application/Module.php
+++ b/application/Module.php
@@ -192,14 +192,7 @@ class Module extends AbstractModule
             function (LaminasEvent $event) {
                 $view = $event->getTarget();
                 // Get the favicon asset ID.
-                if ($view->status()->isSiteRequest()) {
-                    $faviconAssetId = $view->siteSetting('favicon');
-                    if (!is_numeric($faviconAssetId)) {
-                        $faviconAssetId = $view->setting('favicon');
-                    }
-                } else {
-                    $faviconAssetId = $view->setting('favicon');
-                }
+                $faviconAssetId = $view->fallbackSetting('favicon', ['site', 'global']);
                 // Get the favicon href.
                 if (is_numeric($faviconAssetId)) {
                     $faviconAsset = $view->api()->searchOne('assets', ['id' => $faviconAssetId])->getContent();

--- a/application/src/Media/Renderer/IiifPresentation.php
+++ b/application/src/Media/Renderer/IiifPresentation.php
@@ -9,20 +9,15 @@ class IiifPresentation implements RendererInterface
     public function render(PhpRenderer $view, MediaRepresentation $media, array $options = [])
     {
         $miradorConfig = [
-            'window.sideBarOpen' => false,
-            'selectedTheme' => 'light',
+            'window.sideBarOpen' => (bool) $view->fallbackSetting('iiif_viewer_sidebar', ['site'], false),
         ];
-        if ($view->status()->isSiteRequest()) {
-            // Respect site settings for the IIIF viewer.
-            $miradorConfig['window.sideBarOpen'] = (bool) $view->siteSetting('iiif_viewer_sidebar', false);
-            switch ($view->siteSetting('iiif_viewer_theme', 'light')) {
-                case 'dark':
-                    $miradorConfig['selectedTheme'] = 'dark';
-                    break;
-                case 'light':
-                default:
-                    $miradorConfig['selectedTheme'] = 'light';
-            }
+        switch ($view->fallbackSetting('iiif_viewer_theme', ['site'], 'light')) {
+            case 'dark':
+                $miradorConfig['selectedTheme'] = 'dark';
+                break;
+            case 'light':
+            default:
+                $miradorConfig['selectedTheme'] = 'light';
         }
         $query = [
             'url' => $media->source(),


### PR DESCRIPTION
Where code guards `siteSetting()` calls with `isSiteRequest()` solely to avoid a runtime exception, `fallbackSetting()` is a cleaner replacement -- it handles the missing-site-context case internally and expresses the fallback priority explicitly in the call itself.

Should fix #2099