### PR TITLE
Add Repeatable form element for multi-row structured input

### DIFF
--- a/application/asset/css/repeatable-form.css
+++ b/application/asset/css/repeatable-form.css
@@ -1,0 +1,48 @@
+.repeatable-form-element .repeatable-rows {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.repeatable-form-element .repeatable-rows > li {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+    padding-bottom: 0.5em;
+    border-bottom: 1px solid #dfdfdf;
+}
+
+.repeatable-form-element .repeatable-fields {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.25em 0.5em;
+    align-items: center;
+    flex: 1 1 auto;
+}
+
+.repeatable-form-element .repeatable-fields label {
+    display: contents;
+}
+
+.repeatable-form-element .repeatable-fields label input,
+.repeatable-form-element .repeatable-fields label select,
+.repeatable-form-element .repeatable-fields label textarea {
+    width: auto;
+    margin: 0;
+}
+
+.repeatable-form-element .sortable-handle {
+    align-self: center;
+    cursor: grab;
+}
+
+.repeatable-form-element .sortable-handle:active {
+    cursor: grabbing;
+}
+
+.repeatable-form-element .repeatable-add {
+    margin-top: 0.5em;
+}

--- a/application/asset/js/repeatable-form.js
+++ b/application/asset/js/repeatable-form.js
@@ -1,0 +1,55 @@
+$(document).ready(function () {
+    const serializeRows = function ($container) {
+        const rows = [];
+        $container.find('.repeatable-rows > li').each(function () {
+            const row = {};
+            $(this).find('[data-field-name]').each(function () {
+                row[$(this).data('fieldName')] = $(this).val();
+            });
+            rows.push(row);
+        });
+        $container.find('input[type="hidden"]').val(JSON.stringify(rows));
+    };
+
+    const updateButtons = function ($container) {
+        const minRows = $container.data('minRows') || 0;
+        const maxRows = $container.data('maxRows') || null;
+        const count = $container.find('.repeatable-rows > li').length;
+
+        $container.find('.repeatable-add').prop('disabled', maxRows !== null && count >= maxRows);
+        $container.find('.repeatable-remove').prop('disabled', count <= minRows);
+    };
+
+    $('.repeatable-form-element').each(function () {
+        const $container = $(this);
+        if ($container.is('[data-sortable]')) {
+            new Sortable($container.find('.repeatable-rows')[0], {
+                draggable: 'li',
+                handle: '.sortable-handle',
+                onEnd: function () {
+                    serializeRows($container);
+                },
+            });
+        }
+        updateButtons($container);
+    });
+
+    $('#content').on('click', '.repeatable-add', function () {
+        const $container = $(this).closest('.repeatable-form-element');
+        const template = $container.find('template.repeatable-row-template')[0];
+        $container.find('.repeatable-rows').append(document.importNode(template.content, true));
+        serializeRows($container);
+        updateButtons($container);
+    });
+
+    $('#content').on('click', '.repeatable-remove', function () {
+        const $container = $(this).closest('.repeatable-form-element');
+        $(this).closest('li').remove();
+        serializeRows($container);
+        updateButtons($container);
+    });
+
+    $('#content').on('input change', '[data-field-name]', function () {
+        serializeRows($(this).closest('.repeatable-form-element'));
+    });
+});

--- a/application/asset/js/repeatable-form.js
+++ b/application/asset/js/repeatable-form.js
@@ -36,6 +36,7 @@ $(document).ready(function () {
 
     $('#content').on('click', '.repeatable-add', function () {
         const $container = $(this).closest('.repeatable-form-element');
+        // template.content is a DocumentFragment, which jQuery cannot clone — importNode is required.
         const template = $container.find('template.repeatable-row-template')[0];
         $container.find('.repeatable-rows').append(document.importNode(template.content, true));
         serializeRows($container);

--- a/application/asset/js/repeatable-form.js
+++ b/application/asset/js/repeatable-form.js
@@ -26,9 +26,6 @@ $(document).ready(function () {
             new Sortable($container.find('.repeatable-rows')[0], {
                 draggable: 'li',
                 handle: '.sortable-handle',
-                onEnd: function () {
-                    serializeRows($container);
-                },
             });
         }
         updateButtons($container);
@@ -39,18 +36,19 @@ $(document).ready(function () {
         // template.content is a DocumentFragment, which jQuery cannot clone — importNode is required.
         const template = $container.find('template.repeatable-row-template')[0];
         $container.find('.repeatable-rows').append(document.importNode(template.content, true));
-        serializeRows($container);
         updateButtons($container);
     });
 
     $('#content').on('click', '.repeatable-remove', function () {
         const $container = $(this).closest('.repeatable-form-element');
         $(this).closest('li').remove();
-        serializeRows($container);
         updateButtons($container);
     });
 
-    $('#content').on('input change', '[data-field-name]', function () {
-        serializeRows($(this).closest('.repeatable-form-element'));
+    // Serialize all repeatable elements immediately before submit.
+    $('#content').on('submit', 'form', function () {
+        $(this).find('.repeatable-form-element').each(function () {
+            serializeRows($(this));
+        });
     });
 });

--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -457,6 +457,7 @@ return [
             'iiifViewer' => View\Helper\IiifViewer::class,
             'currentSite' => View\Helper\CurrentSite::class,
             'formSelectSort' => Form\View\Helper\FormSelectSort::class,
+            'formRepeatable' => Form\View\Helper\FormRepeatable::class,
         ],
         'factories' => [
             'api' => Service\ViewHelper\ApiFactory::class,

--- a/application/src/Form/Element/Repeatable.php
+++ b/application/src/Form/Element/Repeatable.php
@@ -1,0 +1,74 @@
+<?php
+namespace Omeka\Form\Element;
+
+use Laminas\Form\Element;
+use Laminas\InputFilter\InputProviderInterface;
+
+class Repeatable extends Element implements InputProviderInterface
+{
+    protected $value = [];
+
+    public function getFields(): array
+    {
+        return $this->options['fields'] ?? [];
+    }
+
+    public function isSortable(): bool
+    {
+        return (bool) ($this->options['sortable'] ?? false);
+    }
+
+    public function getMinRows(): int
+    {
+        return (int) ($this->options['min_rows'] ?? 0);
+    }
+
+    public function getMaxRows(): ?int
+    {
+        return isset($this->options['max_rows']) ? (int) $this->options['max_rows'] : null;
+    }
+
+    private function decodeJson(string $json): array
+    {
+        return json_decode($json, true) ?? [];
+    }
+
+    public function setValue($value)
+    {
+        if (is_array($value)) {
+            $this->value = $value;
+        } elseif (is_string($value) && $value !== '') {
+            $this->value = $this->decodeJson($value);
+        } else {
+            $this->value = [];
+        }
+        return $this;
+    }
+
+    public function getInputSpecification()
+    {
+        return [
+            'name' => $this->getName(),
+            'required' => (bool) ($this->options['required'] ?? false),
+            'allow_empty' => true,
+            'filters' => [
+                [
+                    'name' => \Laminas\Filter\Callback::class,
+                    'options' => [
+                        'callback' => function ($value) {
+                            $rows = is_string($value) ? $this->decodeJson($value) : [];
+                            return array_values(array_filter($rows, function ($row) {
+                                foreach ($row as $fieldValue) {
+                                    if ($fieldValue !== '') {
+                                        return true;
+                                    }
+                                }
+                                return false;
+                            }));
+                        },
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/application/src/Form/Element/Repeatable.php
+++ b/application/src/Form/Element/Repeatable.php
@@ -8,6 +8,13 @@ class Repeatable extends Element implements InputProviderInterface
 {
     protected $value = [];
 
+    /**
+     * Each field is keyed by field name and accepts:
+     *   type         string  text|url|email|number|tel|textarea|select (default: text)
+     *   label        string  Field label (defaults to field name)
+     *   empty_option string  Blank option label for select fields (default: Select…)
+     *   value_options array  Options for select fields, keyed by value
+     */
     public function getFields(): array
     {
         return $this->options['fields'] ?? [];
@@ -55,11 +62,12 @@ class Repeatable extends Element implements InputProviderInterface
                 [
                     'name' => \Laminas\Filter\Callback::class,
                     'options' => [
+                        // Decode the JSON string from the hidden input and strip all-empty rows.
                         'callback' => function ($value) {
                             $rows = is_string($value) ? $this->decodeJson($value) : [];
                             return array_values(array_filter($rows, function ($row) {
                                 foreach ($row as $fieldValue) {
-                                    if ($fieldValue !== '') {
+                                    if (trim($fieldValue) !== '') {
                                         return true;
                                     }
                                 }

--- a/application/src/Form/View/Helper/FormRepeatable.php
+++ b/application/src/Form/View/Helper/FormRepeatable.php
@@ -1,0 +1,20 @@
+<?php
+namespace Omeka\Form\View\Helper;
+
+use Laminas\Form\ElementInterface;
+use Laminas\Form\View\Helper\AbstractHelper;
+
+class FormRepeatable extends AbstractHelper
+{
+    public function __invoke(ElementInterface $element)
+    {
+        return $this->render($element);
+    }
+
+    public function render(ElementInterface $element)
+    {
+        return $this->getView()->partial('common/repeatable-form', [
+            'element' => $element,
+        ]);
+    }
+}

--- a/application/src/Service/Delegator/FormElementDelegatorFactory.php
+++ b/application/src/Service/Delegator/FormElementDelegatorFactory.php
@@ -23,6 +23,7 @@ class FormElementDelegatorFactory implements DelegatorFactoryInterface
         $formElement->addClass('Omeka\Form\Element\Columns', 'formColumns');
         $formElement->addClass('Omeka\Form\Element\BrowseDefaults', 'formBrowseDefaults');
         $formElement->addClass('Omeka\Form\Element\SelectSortInterface', 'formSelectSort');
+        $formElement->addClass('Omeka\Form\Element\Repeatable', 'formRepeatable');
         return $formElement;
     }
 }

--- a/application/view/common/repeatable-form-field.phtml
+++ b/application/view/common/repeatable-form-field.phtml
@@ -1,0 +1,17 @@
+<label>
+    <span><?php echo $this->translate($field['label'] ?? $fieldName); ?></span>
+    <?php if ($field['type'] === 'textarea'): ?>
+    <textarea data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"><?php echo $this->escapeHtml($fieldValue); ?></textarea>
+    <?php elseif ($field['type'] === 'select'): ?>
+    <select data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>">
+        <option value=""<?php echo $fieldValue === '' ? ' selected' : ''; ?>><?php echo $this->escapeHtml($this->translate($field['empty_option'] ?? 'Select…')); ?></option>
+        <?php foreach (($field['value_options'] ?? []) as $optVal => $optLabel): ?>
+        <option value="<?php echo $this->escapeHtmlAttr($optVal); ?>"<?php echo $fieldValue === (string) $optVal ? ' selected' : ''; ?>><?php echo $this->escapeHtml($this->translate($optLabel)); ?></option>
+        <?php endforeach; ?>
+    </select>
+    <?php else: ?>
+    <input type="<?php echo $field['type']; ?>"
+           data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"
+           value="<?php echo $this->escapeHtmlAttr($fieldValue); ?>">
+    <?php endif; ?>
+</label>

--- a/application/view/common/repeatable-form-field.phtml
+++ b/application/view/common/repeatable-form-field.phtml
@@ -9,6 +9,50 @@
         <option value="<?php echo $this->escapeHtmlAttr($optVal); ?>"<?php echo $fieldValue === (string) $optVal ? ' selected' : ''; ?>><?php echo $this->escapeHtml($this->translate($optLabel)); ?></option>
         <?php endforeach; ?>
     </select>
+    <?php elseif ($field['type'] === 'asset'): ?>
+    <?php
+    $asset = null;
+    if ($fieldValue !== '') {
+        try {
+            $asset = $this->api()->read('assets', $fieldValue)->getContent();
+        } catch (\Omeka\Api\Exception\NotFoundException $e) {
+            $fieldValue = '';
+        }
+    }
+    ?>
+    <div class="asset-form-element<?php echo !$asset ? ' empty' : ''; ?>">
+        <input type="hidden"
+               data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"
+               value="<?php echo $this->escapeHtmlAttr($fieldValue); ?>">
+        <?php if ($asset): ?>
+        <span class="selected-asset">
+            <img class="selected-asset-image" src="<?php echo $this->escapeHtml($asset->assetUrl()); ?>" alt="<?php echo $this->escapeHtml($asset->altText()); ?>">
+            <div class="selected-asset-name"><?php echo $this->escapeHtml($asset->name()); ?></div>
+        </span>
+        <?php else: ?>
+        <span class="selected-asset" style="display: none;">
+            <img class="selected-asset-image"><div class="selected-asset-name"></div>
+        </span>
+        <?php endif; ?>
+        <span class="no-selected-asset"><?php echo $this->translate('[No asset selected]'); ?></span>
+        <button type="button" class="asset-form-select"
+                data-sidebar-content-url="<?php echo $this->escapeHtml($this->url('admin/default', ['controller' => 'asset', 'action' => 'sidebar-select'])); ?>">
+            <?php echo $this->translate('Select'); ?>
+        </button>
+        <button type="button" class="asset-form-clear red button">
+            <?php echo $this->translate('Clear'); ?>
+        </button>
+    </div>
+    <?php elseif ($field['type'] === 'color_picker'): ?>
+    <div class="color-picker">
+        <input type="color_picker"
+               pattern="<?php echo $this->escapeHtmlAttr(\Omeka\Form\Element\ColorPicker::REGEX); ?>"
+               placeholder="<?php echo $this->escapeHtmlAttr($this->translate(\Omeka\Form\Element\ColorPicker::REGEX_EXPLANATION)); ?>"
+               title="<?php echo $this->escapeHtmlAttr($this->translate(\Omeka\Form\Element\ColorPicker::REGEX_EXPLANATION)); ?>"
+               data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"
+               value="<?php echo $this->escapeHtmlAttr($fieldValue); ?>">
+        <div class="color-picker-sample"></div>
+    </div>
     <?php else: ?>
     <input type="<?php echo $field['type']; ?>"
            data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"

--- a/application/view/common/repeatable-form.phtml
+++ b/application/view/common/repeatable-form.phtml
@@ -1,0 +1,102 @@
+<?php
+$this->headLink()->appendStylesheet($this->assetUrl('css/repeatable-form.css', 'Omeka'));
+$this->headScript()->appendFile($this->assetUrl('js/repeatable-form.js', 'Omeka'));
+
+$rows = $element->getValue();
+$fields = array_map(function ($field) {
+    if (!in_array($field['type'], ['textarea', 'select', 'text', 'url', 'email', 'number', 'tel'])) {
+        $field['type'] = 'text';
+    }
+    return $field;
+}, $element->getFields());
+$sortable = $element->isSortable();
+$minRows = $element->getMinRows();
+$maxRows = $element->getMaxRows();
+if ($sortable) {
+    $this->headScript()->appendFile($this->assetUrl('vendor/sortablejs/Sortable.min.js', 'Omeka'));
+}
+while (count($rows) < $minRows) {
+    $rows[] = [];
+}
+$rowCount = count($rows);
+?>
+<div class="repeatable-form-element"
+     data-min-rows="<?php echo $this->escapeHtmlAttr($minRows); ?>"
+     data-max-rows="<?php echo $this->escapeHtmlAttr($maxRows ?? ''); ?>"
+     <?php echo $sortable ? 'data-sortable' : ''; ?>>
+    <input type="hidden"
+           name="<?php echo $this->escapeHtmlAttr($element->getName()); ?>"
+           value="<?php echo $this->escapeHtmlAttr(json_encode($rows)); ?>">
+    <ul class="repeatable-rows">
+        <?php foreach ($rows as $row): ?>
+        <li>
+            <?php if ($sortable): ?>
+            <span class="sortable-handle" aria-hidden="true"></span>
+            <?php endif; ?>
+            <div class="repeatable-fields">
+                <?php foreach ($fields as $fieldName => $field): ?>
+                <label>
+                    <span><?php echo $this->translate($field['label'] ?? $fieldName); ?></span>
+                    <?php $fieldValue = $row[$fieldName] ?? ''; ?>
+                    <?php if ($field['type'] === 'textarea'): ?>
+                    <textarea data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"><?php echo $this->escapeHtml($fieldValue); ?></textarea>
+                    <?php elseif ($field['type'] === 'select'): ?>
+                    <select data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>">
+                        <option value=""><?php echo $this->translate('Select…'); ?></option>
+                        <?php foreach (($field['value_options'] ?? []) as $optVal => $optLabel): ?>
+                        <option value="<?php echo $this->escapeHtmlAttr($optVal); ?>"<?php echo $fieldValue === (string) $optVal ? ' selected' : ''; ?>><?php echo $this->escapeHtml($this->translate($optLabel)); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <?php else: ?>
+                    <input type="<?php echo $field['type']; ?>"
+                           data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"
+                           value="<?php echo $this->escapeHtmlAttr($fieldValue); ?>">
+                    <?php endif; ?>
+                </label>
+                <?php endforeach; ?>
+            </div>
+            <button type="button" class="repeatable-remove o-icon-delete"
+                    aria-label="<?php echo $this->translate('Remove'); ?>"
+                    title="<?php echo $this->translate('Remove'); ?>"
+                    <?php echo $rowCount === $minRows ? 'disabled' : ''; ?>></button>
+        </li>
+        <?php endforeach; ?>
+    </ul>
+    <template class="repeatable-row-template">
+        <li>
+            <?php if ($sortable): ?>
+            <span class="sortable-handle" aria-hidden="true"></span>
+            <?php endif; ?>
+            <div class="repeatable-fields">
+                <?php foreach ($fields as $fieldName => $field): ?>
+                <label>
+                    <span><?php echo $this->translate($field['label'] ?? $fieldName); ?></span>
+                    <?php if ($field['type'] === 'textarea'): ?>
+                    <textarea data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"></textarea>
+                    <?php elseif ($field['type'] === 'select'): ?>
+                    <select data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>">
+                        <option value="" selected><?php echo $this->translate('Select…'); ?></option>
+                        <?php foreach (($field['value_options'] ?? []) as $optVal => $optLabel): ?>
+                        <option value="<?php echo $this->escapeHtmlAttr($optVal); ?>"><?php echo $this->escapeHtml($this->translate($optLabel)); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                    <?php else: ?>
+                    <input type="<?php echo $field['type']; ?>"
+                           data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"
+                           value="">
+                    <?php endif; ?>
+                </label>
+                <?php endforeach; ?>
+            </div>
+            <button type="button" class="repeatable-remove o-icon-delete"
+                    aria-label="<?php echo $this->translate('Remove'); ?>"
+                    title="<?php echo $this->translate('Remove'); ?>"></button>
+        </li>
+    </template>
+    <button type="button" class="repeatable-add o-icon-add"
+            aria-label="<?php echo $this->translate('Add'); ?>"
+            title="<?php echo $this->translate('Add'); ?>"
+            <?php echo $maxRows !== null && $rowCount === $maxRows ? 'disabled' : ''; ?>>
+        <?php echo $this->translate('Add'); ?>
+    </button>
+</div>

--- a/application/view/common/repeatable-form.phtml
+++ b/application/view/common/repeatable-form.phtml
@@ -1,7 +1,7 @@
 <?php
 $rows = $element->getValue();
 $fields = array_map(function ($field) {
-    if (!in_array($field['type'], ['textarea', 'select', 'text', 'url', 'email', 'number', 'tel'])) {
+    if (!in_array($field['type'], ['textarea', 'select', 'text', 'url', 'email', 'number', 'tel', 'asset', 'color_picker'])) {
         $field['type'] = 'text';
     }
     return $field;
@@ -18,6 +18,14 @@ $this->headLink()->appendStylesheet($this->assetUrl('css/repeatable-form.css', '
 $this->headScript()->appendFile($this->assetUrl('js/repeatable-form.js', 'Omeka'));
 if ($sortable) {
     $this->headScript()->appendFile($this->assetUrl('vendor/sortablejs/Sortable.min.js', 'Omeka'));
+}
+$fieldTypes = array_column($fields, 'type');
+if (in_array('asset', $fieldTypes)) {
+    $this->headLink()->appendStylesheet($this->assetUrl('css/asset-form.css', 'Omeka'));
+    $this->headScript()->appendFile($this->assetUrl('js/asset-form.js', 'Omeka'));
+}
+if (in_array('color_picker', $fieldTypes)) {
+    $this->headScript()->appendFile($this->assetUrl('js/color-picker.js', 'Omeka'));
 }
 ?>
 <div class="repeatable-form-element"

--- a/application/view/common/repeatable-form.phtml
+++ b/application/view/common/repeatable-form.phtml
@@ -1,7 +1,4 @@
 <?php
-$this->headLink()->appendStylesheet($this->assetUrl('css/repeatable-form.css', 'Omeka'));
-$this->headScript()->appendFile($this->assetUrl('js/repeatable-form.js', 'Omeka'));
-
 $rows = $element->getValue();
 $fields = array_map(function ($field) {
     if (!in_array($field['type'], ['textarea', 'select', 'text', 'url', 'email', 'number', 'tel'])) {
@@ -12,13 +9,16 @@ $fields = array_map(function ($field) {
 $sortable = $element->isSortable();
 $minRows = $element->getMinRows();
 $maxRows = $element->getMaxRows();
-if ($sortable) {
-    $this->headScript()->appendFile($this->assetUrl('vendor/sortablejs/Sortable.min.js', 'Omeka'));
-}
 while (count($rows) < $minRows) {
     $rows[] = [];
 }
 $rowCount = count($rows);
+
+$this->headLink()->appendStylesheet($this->assetUrl('css/repeatable-form.css', 'Omeka'));
+$this->headScript()->appendFile($this->assetUrl('js/repeatable-form.js', 'Omeka'));
+if ($sortable) {
+    $this->headScript()->appendFile($this->assetUrl('vendor/sortablejs/Sortable.min.js', 'Omeka'));
+}
 ?>
 <div class="repeatable-form-element"
      data-min-rows="<?php echo $this->escapeHtmlAttr($minRows); ?>"
@@ -35,24 +35,11 @@ $rowCount = count($rows);
             <?php endif; ?>
             <div class="repeatable-fields">
                 <?php foreach ($fields as $fieldName => $field): ?>
-                <label>
-                    <span><?php echo $this->translate($field['label'] ?? $fieldName); ?></span>
-                    <?php $fieldValue = $row[$fieldName] ?? ''; ?>
-                    <?php if ($field['type'] === 'textarea'): ?>
-                    <textarea data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"><?php echo $this->escapeHtml($fieldValue); ?></textarea>
-                    <?php elseif ($field['type'] === 'select'): ?>
-                    <select data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>">
-                        <option value=""><?php echo $this->translate('Select…'); ?></option>
-                        <?php foreach (($field['value_options'] ?? []) as $optVal => $optLabel): ?>
-                        <option value="<?php echo $this->escapeHtmlAttr($optVal); ?>"<?php echo $fieldValue === (string) $optVal ? ' selected' : ''; ?>><?php echo $this->escapeHtml($this->translate($optLabel)); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                    <?php else: ?>
-                    <input type="<?php echo $field['type']; ?>"
-                           data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"
-                           value="<?php echo $this->escapeHtmlAttr($fieldValue); ?>">
-                    <?php endif; ?>
-                </label>
+                <?php echo $this->partial('common/repeatable-form-field', [
+                    'fieldName' => $fieldName,
+                    'field' => $field,
+                    'fieldValue' => $row[$fieldName] ?? '',
+                ]); ?>
                 <?php endforeach; ?>
             </div>
             <button type="button" class="repeatable-remove o-icon-delete"
@@ -69,23 +56,11 @@ $rowCount = count($rows);
             <?php endif; ?>
             <div class="repeatable-fields">
                 <?php foreach ($fields as $fieldName => $field): ?>
-                <label>
-                    <span><?php echo $this->translate($field['label'] ?? $fieldName); ?></span>
-                    <?php if ($field['type'] === 'textarea'): ?>
-                    <textarea data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"></textarea>
-                    <?php elseif ($field['type'] === 'select'): ?>
-                    <select data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>">
-                        <option value="" selected><?php echo $this->translate('Select…'); ?></option>
-                        <?php foreach (($field['value_options'] ?? []) as $optVal => $optLabel): ?>
-                        <option value="<?php echo $this->escapeHtmlAttr($optVal); ?>"><?php echo $this->escapeHtml($this->translate($optLabel)); ?></option>
-                        <?php endforeach; ?>
-                    </select>
-                    <?php else: ?>
-                    <input type="<?php echo $field['type']; ?>"
-                           data-field-name="<?php echo $this->escapeHtmlAttr($fieldName); ?>"
-                           value="">
-                    <?php endif; ?>
-                </label>
+                <?php echo $this->partial('common/repeatable-form-field', [
+                    'fieldName' => $fieldName,
+                    'field' => $field,
+                    'fieldValue' => '',
+                ]); ?>
                 <?php endforeach; ?>
             </div>
             <button type="button" class="repeatable-remove o-icon-delete"


### PR DESCRIPTION
Adds `Omeka\Form\Element\Repeatable`, a form element for managing a variable-length list of structured rows where each row contains one or more typed fields (`text`, `url`, `email`, `number`, `tel`, `textarea`, `select`, `asset`, `color_picker`). Rows can be added, removed, and optionally reordered by drag. The element is usable in any Omeka form and configurable from `theme.ini`, making it available to theme authors for settings like social links, featured layouts, or any other repeating structure.

## PHP form usage

```php
$this->add([
    'name' => 'social_links',
    'type' => \Omeka\Form\Element\Repeatable::class,
    'options' => [
        'label'    => 'Social Links',
        'required' => true,
        'sortable' => true,
        'min_rows' => 1,
        'max_rows' => 5,
        'fields'   => [
            'url'      => ['type' => 'url',    'label' => 'URL'],
            'label'    => ['type' => 'text',   'label' => 'Label'],
            'platform' => [
                'type' => 'select', 
                'label' => 'Platform', 
                'empty_option' => 'Choose a platform…', 
                'value_options' => [
                    'twitter'   => 'Twitter',
                    'instagram' => 'Instagram',
                    'facebook'  => 'Facebook',
            ]],
        ],
    ],
]);
```

`$form->getData()['social_links']` returns a PHP array of row arrays, with fully empty rows filtered out:

```php
[
    ['url' => 'https://twitter.com/x', 'label' => 'Twitter', 'platform' => 'twitter'],
    ['url' => 'https://instagram.com/y', 'label' => 'Instagram', 'platform' => 'instagram'],
]
```

## Theme INI usage

```ini
elements.social_links.name = "social_links"
elements.social_links.type = "Omeka\Form\Element\Repeatable"
elements.social_links.options.label = "Social Links"
elements.social_links.options.required = true
elements.social_links.options.sortable = true
elements.social_links.options.min_rows = 1
elements.social_links.options.max_rows = 5
elements.social_links.options.fields.url.type = "url"
elements.social_links.options.fields.url.label = "URL"
elements.social_links.options.fields.label.type = "text"
elements.social_links.options.fields.label.label = "Label"
elements.social_links.options.fields.platform.type = "select"
elements.social_links.options.fields.platform.label = "Platform"
elements.social_links.options.fields.platform.empty_option = "Choose a platform…"
elements.social_links.options.fields.platform.value_options.twitter = "Twitter"
elements.social_links.options.fields.platform.value_options.instagram = "Instagram"
elements.social_links.options.fields.platform.value_options.facebook = "Facebook"
```

A blank "Select…" option is always prepended to `select` fields automatically.

```ini
elements.hero.name = "hero"
elements.hero.type = "Omeka\Form\Element\Repeatable"
elements.hero.options.label = "Hero Images"
elements.hero.options.fields.image.type = "asset"
elements.hero.options.fields.image.label = "Image"
elements.hero.options.fields.caption.type = "text"
elements.hero.options.fields.caption.label = "Caption"
elements.hero.options.fields.accent.type = "color_picker"
elements.hero.options.fields.accent.label = "Accent Color"
```

Both types work with no extra initialization — asset-form.js and color-picker.js use event delegation, so dynamically added rows are handled automatically.

## Theme template usage

```php
<?php foreach ($this->themeSetting('social_links') ?? [] as $link): ?>
    <a href="<?= $this->escapeHtml($link['url']) ?>">
        <?= $this->escapeHtml($link['label']) ?>
    </a>
<?php endforeach; ?>
```