### PR TITLE
Fix has_media=1 returning items with only private media

### DIFF
--- a/application/src/Api/Adapter/ItemAdapter.php
+++ b/application/src/Api/Adapter/ItemAdapter.php
@@ -137,6 +137,15 @@ class ItemAdapter extends AbstractResourceEntityAdapter
             $mediaAlias = $qb->createAlias();
             if ($query['has_media']) {
                 $qb->innerJoin('omeka_root.media', $mediaAlias);
+                $services = $this->getServiceLocator();
+                $acl = $services->get('Omeka\Acl');
+                if (!$acl->userIsAllowed('Omeka\Entity\Resource', 'view-all')) {
+                    $identity = $services->get('Omeka\AuthenticationService')->getIdentity();
+                    $qb->andWhere($qb->expr()->orX(
+                        $qb->expr()->eq("$mediaAlias.isPublic", '1'),
+                        $qb->expr()->eq("$mediaAlias.owner", $qb->createNamedParameter($identity))
+                    ));
+                }
             } else {
                 $qb->leftJoin('omeka_root.media', $mediaAlias);
                 $qb->andWhere($qb->expr()->isNull($mediaAlias));

--- a/application/src/Api/Adapter/ItemAdapter.php
+++ b/application/src/Api/Adapter/ItemAdapter.php
@@ -137,15 +137,9 @@ class ItemAdapter extends AbstractResourceEntityAdapter
             $mediaAlias = $qb->createAlias();
             if ($query['has_media']) {
                 $qb->innerJoin('omeka_root.media', $mediaAlias);
-                $services = $this->getServiceLocator();
-                $acl = $services->get('Omeka\Acl');
-                if (!$acl->userIsAllowed('Omeka\Entity\Resource', 'view-all')) {
-                    $identity = $services->get('Omeka\AuthenticationService')->getIdentity();
-                    $qb->andWhere($qb->expr()->orX(
-                        $qb->expr()->eq("$mediaAlias.isPublic", '1'),
-                        $qb->expr()->eq("$mediaAlias.owner", $qb->createNamedParameter($identity))
-                    ));
-                }
+                // The SQL visibility filter joins the resource table as a LEFT JOIN, making
+                // the alias NULL for private media. isNotNull enforces visibility here.
+                $qb->andWhere($qb->expr()->isNotNull($mediaAlias));
             } else {
                 $qb->leftJoin('omeka_root.media', $mediaAlias);
                 $qb->andWhere($qb->expr()->isNull($mediaAlias));


### PR DESCRIPTION
Querying items with `has_media=1` was returning items whose only media were private. The SQL visibility filter alone is not sufficient here, so a WHERE clause is added to enforce it. `has_media=0` is unaffected and already handles private media correctly.

Fixes #2494