### PR TITLE
Add item count browse column for item sets

### DIFF
--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -581,6 +581,7 @@ return [
             'id' => ColumnType\Id::class,
             'is_open' => ColumnType\IsOpen::class,
             'is_public' => ColumnType\IsPublic::class,
+            'item_count' => ColumnType\ItemCount::class,
             'media_type' => ColumnType\MediaType::class,
             'modified' => ColumnType\Modified::class,
             'owner' => ColumnType\Owner::class,

--- a/application/src/ColumnType/ItemCount.php
+++ b/application/src/ColumnType/ItemCount.php
@@ -1,0 +1,44 @@
+<?php
+namespace Omeka\ColumnType;
+
+use Laminas\View\Renderer\PhpRenderer;
+use Omeka\Api\Representation\AbstractEntityRepresentation;
+
+class ItemCount implements ColumnTypeInterface
+{
+    public function getLabel(): string
+    {
+        return 'Item count'; // @translate
+    }
+
+    public function getResourceTypes(): array
+    {
+        return ['item_sets'];
+    }
+
+    public function getMaxColumns(): ?int
+    {
+        return 1;
+    }
+
+    public function renderDataForm(PhpRenderer $view, array $data): string
+    {
+        return '';
+    }
+
+    public function getSortBy(array $data): ?string
+    {
+        return 'item_count';
+    }
+
+    public function renderHeader(PhpRenderer $view, array $data): string
+    {
+        return $this->getLabel();
+    }
+
+    public function renderContent(PhpRenderer $view, AbstractEntityRepresentation $resource, array $data): ?string
+    {
+        $url = $view->url('admin/default', ['controller' => 'item', 'action' => 'browse'], ['query' => ['item_set_id' => $resource->id()]]);
+        return $view->hyperlink($resource->itemCount(), $url);
+    }
+}


### PR DESCRIPTION
Adds an "Item count" browse column for item sets, configurable in user settings. The column displays the number of items in each set as a link to the filtered items browse. Sortable by item count.

Note that adding this column will result in one additional COUNT query per item set on the browse page. Since this is an opt-in column, users can simply remove it if performance is a concern.

Fixes #2493 