### PR TITLE
Add linkAttribs option to ThumbnailRenderer

### DIFF
--- a/application/src/Media/FileRenderer/ThumbnailRenderer.php
+++ b/application/src/Media/FileRenderer/ThumbnailRenderer.php
@@ -22,8 +22,10 @@ class ThumbnailRenderer extends AbstractRenderer
             return $img;
         }
 
-        $title = $media->displayTitle();
-
-        return sprintf('<a href="%s" title="%s">%s</a>', $view->escapeHtml($url), $view->escapeHtml($title), $img);
+        $linkAttribs = $options['linkAttribs'] ?? [];
+        if (!array_key_exists('title', $linkAttribs)) {
+            $linkAttribs['title'] = $media->displayTitle();
+        }
+        return $view->plugin('hyperlink')->raw($img, $url, $linkAttribs);
     }
 }


### PR DESCRIPTION
Adds a `linkAttribs` option to `ThumbnailRenderer`, parallel to the existing `thumbnailAttribs`, allowing themes and modules to pass custom HTML attributes to the `<a>` element wrapping thumbnail images.

Themes can pass attributes via the `render()` call, and modules can inject them via the existing `view_helper.media.render_options event`. Fixes #2492.