### PR TITLE
Drop laminas/laminas-json dependency

### DIFF
--- a/application/Module.php
+++ b/application/Module.php
@@ -14,7 +14,6 @@ use Omeka\Module\AbstractModule;
 use Laminas\EventManager\Event as LaminasEvent;
 use Laminas\EventManager\SharedEventManagerInterface;
 use Laminas\Form\Element;
-use Laminas\Json\Json;
 use Laminas\View\Renderer\PhpRenderer;
 
 /**
@@ -855,11 +854,6 @@ class Module extends AbstractModule
             $output = $args['jsonLd'];
         }
 
-        if (null !== $model->getOption('pretty_print')) {
-            // Pretty print the JSON.
-            $output = Json::prettyPrint($output);
-        }
-
         $jsonpCallback = (string) $model->getOption('callback');
         if (!empty($jsonpCallback)) {
             // Wrap the JSON in a JSONP callback. Normally this would be done
@@ -891,7 +885,7 @@ class Module extends AbstractModule
 
         $serializeRdf = function ($jsonLd) use ($format) {
             $graph = new Graph;
-            $graph->parse(Json::encode($jsonLd), 'jsonld');
+            $graph->parse(json_encode($jsonLd), 'jsonld');
             return $graph->serialise($format);
         };
 
@@ -904,7 +898,7 @@ class Module extends AbstractModule
                 $eventManager->trigger('api.context', null, $args);
                 $context = $args['context'];
             }
-            $jsonLd = Json::decode(Json::encode($representation), true);
+            $jsonLd = json_decode(json_encode($representation), true);
             $jsonLd['@context'] = $context;
             return $jsonLd;
         };

--- a/application/src/View/Model/ApiJsonModel.php
+++ b/application/src/View/Model/ApiJsonModel.php
@@ -2,13 +2,15 @@
 
 namespace Omeka\View\Model;
 
-use Laminas\View\Model\JsonModel;
+use Laminas\View\Model\ViewModel;
 
 /**
  * View model for JSON responses from the API.
  */
-class ApiJsonModel extends JsonModel
+class ApiJsonModel extends ViewModel
 {
+    protected $terminate = true;
+
     /**
      * Key that stores the API response in the view variables
      */

--- a/application/src/View/Model/ApiJsonModel.php
+++ b/application/src/View/Model/ApiJsonModel.php
@@ -2,13 +2,20 @@
 
 namespace Omeka\View\Model;
 
+use Exception;
 use Laminas\View\Model\ViewModel;
 
 /**
  * View model for JSON responses from the API.
+ *
+ * Carries the API response object and any thrown exception through the
+ * view layer to the renderer. Set as terminal to prevent layout wrapping.
  */
 class ApiJsonModel extends ViewModel
 {
+    /**
+     * Terminate rendering after this model to prevent layout wrapping.
+     */
     protected $terminate = true;
 
     /**
@@ -27,7 +34,7 @@ class ApiJsonModel extends ViewModel
      * The API response object can be passed here directly as the first
      * argument.
      *
-     * @param \Omeka\Api\Response $apiResponse API response object
+     * @param \Omeka\Api\Response|array|null $apiResponse API response object
      * @param array|\Traversable $options
      */
     public function __construct($apiResponse = null, $options = null)
@@ -39,7 +46,7 @@ class ApiJsonModel extends ViewModel
     /**
      * Get the API response object stored on the model.
      *
-     * @return \Omeka\Api\Response
+     * @return \Omeka\Api\Response|array|null
      */
     public function getApiResponse()
     {
@@ -49,29 +56,25 @@ class ApiJsonModel extends ViewModel
     /**
      * Set the API response object on this model.
      *
-     * @param \Omeka\Api\Response $apiResponse
+     * @param \Omeka\Api\Response|array|null $apiResponse
      */
-    public function setApiResponse($apiResponse)
+    public function setApiResponse($apiResponse): void
     {
         $this->setVariable(self::API_RESPONSE_KEY, $apiResponse);
     }
 
     /**
      * Get the exception stored on the model.
-     *
-     * @return \Exception|null
      */
-    public function getException()
+    public function getException(): ?Exception
     {
         return $this->getVariable(self::EXCEPTION_KEY);
     }
 
     /**
      * Set the exception on this model.
-     *
-     * @param \Exception $exception
      */
-    public function setException(\Exception $exception)
+    public function setException(Exception $exception): void
     {
         $this->setVariable(self::EXCEPTION_KEY, $exception);
     }

--- a/application/src/View/Renderer/ApiJsonRenderer.php
+++ b/application/src/View/Renderer/ApiJsonRenderer.php
@@ -4,13 +4,11 @@ namespace Omeka\View\Renderer;
 use Omeka\Api\Exception\ValidationException;
 use Omeka\Api\Response;
 use Laminas\EventManager\EventManager;
-use Laminas\Json\Json;
-use Laminas\View\Renderer\JsonRenderer;
+use Laminas\View\Renderer\RendererInterface;
+use Laminas\View\Renderer\TreeRendererInterface;
+use Laminas\View\Resolver\ResolverInterface;
 
-/**
- * JSON renderer for API responses.
- */
-class ApiJsonRenderer extends JsonRenderer
+class ApiJsonRenderer implements RendererInterface, TreeRendererInterface
 {
     /**
      * @var bool
@@ -27,6 +25,20 @@ class ApiJsonRenderer extends JsonRenderer
     public function __construct(EventManager $eventManager)
     {
         $this->eventManager = $eventManager;
+    }
+
+    public function getEngine()
+    {
+        return $this;
+    }
+
+    public function setResolver(ResolverInterface $resolver)
+    {
+    }
+
+    public function canRenderTrees()
+    {
+        return true;
     }
 
     /**
@@ -68,7 +80,12 @@ class ApiJsonRenderer extends JsonRenderer
             return null;
         }
 
-        $output = parent::render($payload);
+        // HEX flags preserved from the previous Laminas\Json\Json::encode() path for output compatibility.
+        $flags = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP;
+        if ($model->getOption('pretty_print')) {
+            $flags |= JSON_PRETTY_PRINT;
+        }
+        $output = json_encode($payload, $flags);
 
         // Allow modules to return custom output.
         $args = $this->eventManager->prepareArgs([

--- a/application/src/View/Renderer/ApiJsonRenderer.php
+++ b/application/src/View/Renderer/ApiJsonRenderer.php
@@ -1,6 +1,7 @@
 <?php
 namespace Omeka\View\Renderer;
 
+use Exception;
 use Omeka\Api\Exception\ValidationException;
 use Omeka\Api\Response;
 use Laminas\EventManager\EventManager;
@@ -8,6 +9,13 @@ use Laminas\View\Renderer\RendererInterface;
 use Laminas\View\Renderer\TreeRendererInterface;
 use Laminas\View\Resolver\ResolverInterface;
 
+/**
+ * JSON renderer for API responses.
+ *
+ * Encodes the API response payload as JSON and fires the
+ * api.output.serialize event, allowing modules to provide custom output
+ * for alternate formats such as RDF serializations.
+ */
 class ApiJsonRenderer implements RendererInterface, TreeRendererInterface
 {
     /**
@@ -47,19 +55,25 @@ class ApiJsonRenderer implements RendererInterface, TreeRendererInterface
      * The view strategy checks this to decide what Content-Type to send, and
      * we need to provide a different implementation to preserve that signal
      * since we're handling JSONP manually here.
-     *
-     * @return bool
      */
-    public function hasJsonpCallback()
+    public function hasJsonpCallback(): bool
     {
         return $this->hasJsonpCallback;
     }
 
-    public function setHasJsonpCallback(bool $hasJsonpCallback)
+    public function setHasJsonpCallback(bool $hasJsonpCallback): void
     {
         $this->hasJsonpCallback = $hasJsonpCallback;
     }
 
+    /**
+     * Render an API response as JSON.
+     *
+     * Returns null for empty (204 No Content) responses.
+     *
+     * @param \Omeka\View\Model\ApiJsonModel $model
+     * @return string|null
+     */
     public function render($model, $values = null)
     {
         $response = $model->getApiResponse();
@@ -70,7 +84,7 @@ class ApiJsonRenderer implements RendererInterface, TreeRendererInterface
         } elseif ($exception instanceof ValidationException) {
             $errors = $exception->getErrorStore()->getErrors();
             $payload = ['errors' => $errors];
-        } elseif ($exception instanceof \Exception) {
+        } elseif ($exception instanceof Exception) {
             $payload = ['errors' => ['error' => $exception->getMessage()]];
         } else {
             $payload = $response;
@@ -100,10 +114,8 @@ class ApiJsonRenderer implements RendererInterface, TreeRendererInterface
 
     /**
      * Set an alternate output format.
-     *
-     * @param string $format
      */
-    public function setFormat($format)
+    public function setFormat(string $format): void
     {
         $this->format = $format;
     }

--- a/application/src/View/Strategy/ApiJsonStrategy.php
+++ b/application/src/View/Strategy/ApiJsonStrategy.php
@@ -84,7 +84,11 @@ class ApiJsonStrategy extends AbstractListenerAggregate
         $e->getResponse()->getHeaders()->addHeaderLine('Omeka-S-Version', Module::VERSION);
 
         // Add the correct Content-Type header for the output format.
-        $e->getResponse()->getHeaders()->addHeaderLine('Content-Type', $this->formats[$this->getFormat($model)]);
+        if ($this->renderer->hasJsonpCallback()) {
+            $e->getResponse()->getHeaders()->addHeaderLine('Content-Type', 'text/javascript');
+        } else {
+            $e->getResponse()->getHeaders()->addHeaderLine('Content-Type', $this->formats[$this->getFormat($model)]);
+        }
     }
 
     /**

--- a/application/src/View/Strategy/ApiJsonStrategy.php
+++ b/application/src/View/Strategy/ApiJsonStrategy.php
@@ -8,15 +8,17 @@ use Omeka\Module;
 use Omeka\Mvc\Exception as MvcException;
 use Omeka\View\Model\ApiJsonModel;
 use Omeka\View\Renderer\ApiJsonRenderer;
+use Laminas\EventManager\AbstractListenerAggregate;
 use Laminas\EventManager\EventManager;
-use Laminas\View\Strategy\JsonStrategy;
+use Laminas\EventManager\EventManagerInterface;
 use Laminas\View\ViewEvent;
 
 /**
  * View strategy for returning JSON from the API.
  */
-class ApiJsonStrategy extends JsonStrategy
+class ApiJsonStrategy extends AbstractListenerAggregate
 {
+    protected $renderer;
     /**
      * Output formats and their media types.
      */
@@ -40,6 +42,12 @@ class ApiJsonStrategy extends JsonStrategy
     {
         $this->renderer = $renderer;
         $this->eventManager = $eventManager;
+    }
+
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $this->listeners[] = $events->attach(ViewEvent::EVENT_RENDERER, [$this, 'selectRenderer'], $priority);
+        $this->listeners[] = $events->attach(ViewEvent::EVENT_RESPONSE, [$this, 'injectResponse'], $priority);
     }
 
     public function selectRenderer(ViewEvent $e)
@@ -66,7 +74,10 @@ class ApiJsonStrategy extends JsonStrategy
             return;
         }
 
-        parent::injectResponse($e);
+        $result = $e->getResult();
+        if (is_string($result)) {
+            $e->getResponse()->setContent($result);
+        }
 
         $model = $e->getModel();
         $e->getResponse()->setStatusCode($this->getResponseStatusCode($model));

--- a/application/src/View/Strategy/ApiJsonStrategy.php
+++ b/application/src/View/Strategy/ApiJsonStrategy.php
@@ -8,6 +8,7 @@ use Omeka\Module;
 use Omeka\Mvc\Exception as MvcException;
 use Omeka\View\Model\ApiJsonModel;
 use Omeka\View\Renderer\ApiJsonRenderer;
+use Exception;
 use Laminas\EventManager\AbstractListenerAggregate;
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerInterface;
@@ -15,6 +16,10 @@ use Laminas\View\ViewEvent;
 
 /**
  * View strategy for returning JSON from the API.
+ *
+ * Selects the renderer for ApiJsonModel requests and injects the response
+ * with the rendered content, HTTP status code, Omeka-S-Version header,
+ * and the correct Content-Type for the output format.
  */
 class ApiJsonStrategy extends AbstractListenerAggregate
 {
@@ -34,9 +39,6 @@ class ApiJsonStrategy extends AbstractListenerAggregate
 
     /**
      * Constructor, sets the renderer object
-     *
-     * @param ApiJsonRenderer
-     * @param EventManager
      */
     public function __construct(ApiJsonRenderer $renderer, EventManager $eventManager)
     {
@@ -44,12 +46,18 @@ class ApiJsonStrategy extends AbstractListenerAggregate
         $this->eventManager = $eventManager;
     }
 
+    /**
+     * Attach listeners for renderer selection and response injection.
+     */
     public function attach(EventManagerInterface $events, $priority = 1)
     {
         $this->listeners[] = $events->attach(ViewEvent::EVENT_RENDERER, [$this, 'selectRenderer'], $priority);
         $this->listeners[] = $events->attach(ViewEvent::EVENT_RESPONSE, [$this, 'injectResponse'], $priority);
     }
 
+    /**
+     * Return our renderer if the model is an ApiJsonModel, otherwise do nothing.
+     */
     public function selectRenderer(ViewEvent $e)
     {
         $model = $e->getModel();
@@ -64,6 +72,9 @@ class ApiJsonStrategy extends AbstractListenerAggregate
         return $this->renderer;
     }
 
+    /**
+     * Inject the response with content, status code, and headers.
+     */
     public function injectResponse(ViewEvent $e)
     {
         // Test this again here to avoid running our extra code for non-API
@@ -75,29 +86,29 @@ class ApiJsonStrategy extends AbstractListenerAggregate
         }
 
         $result = $e->getResult();
+        $response = $e->getResponse();
+        $headers = $response->getHeaders();
+
         if (is_string($result)) {
-            $e->getResponse()->setContent($result);
+            $response->setContent($result);
         }
 
         $model = $e->getModel();
-        $e->getResponse()->setStatusCode($this->getResponseStatusCode($model));
-        $e->getResponse()->getHeaders()->addHeaderLine('Omeka-S-Version', Module::VERSION);
+        $response->setStatusCode($this->getResponseStatusCode($model));
+        $headers->addHeaderLine('Omeka-S-Version', Module::VERSION);
 
         // Add the correct Content-Type header for the output format.
         if ($this->renderer->hasJsonpCallback()) {
-            $e->getResponse()->getHeaders()->addHeaderLine('Content-Type', 'text/javascript');
+            $headers->addHeaderLine('Content-Type', 'text/javascript');
         } else {
-            $e->getResponse()->getHeaders()->addHeaderLine('Content-Type', $this->formats[$this->getFormat($model)]);
+            $headers->addHeaderLine('Content-Type', $this->formats[$this->getFormat($model)]);
         }
     }
 
     /**
      * Get the HTTP status code for an API response.
-     *
-     * @param \Omeka\View\Model\ApiJsonModel $response
-     * @return int
      */
-    protected function getResponseStatusCode(ApiJsonModel $model)
+    protected function getResponseStatusCode(ApiJsonModel $model): int
     {
         $response = $model->getApiResponse();
         $exception = $model->getException();
@@ -107,7 +118,7 @@ class ApiJsonStrategy extends AbstractListenerAggregate
                 return 204; // No Content
             }
             return 200; // OK
-        } elseif ($exception instanceof \Exception) {
+        } elseif ($exception instanceof Exception) {
             return $this->getStatusCodeForException($exception);
         } else {
             return 200;
@@ -116,11 +127,8 @@ class ApiJsonStrategy extends AbstractListenerAggregate
 
     /**
      * Get a status code based on the type of an exception (or lack thereof).
-     *
-     * @param \Exception|null $exception
-     * @return int
      */
-    protected function getStatusCodeForException(?\Exception $exception = null)
+    protected function getStatusCodeForException(?Exception $exception = null): int
     {
         if ($exception instanceof MvcException\InvalidJsonException) {
             return 400; // Bad Request
@@ -142,11 +150,8 @@ class ApiJsonStrategy extends AbstractListenerAggregate
 
     /**
      * Get the recognized output format.
-     *
-     * @param ApiJsonModel $model
-     * @return string|null
      */
-    protected function getFormat(ApiJsonModel $model)
+    protected function getFormat(ApiJsonModel $model): string
     {
         // Allow modules to register formats.
         $args = $this->eventManager->prepareArgs(['formats' => $this->formats]);

--- a/application/test/OmekaTest/View/Renderer/ApiJsonRendererTest.php
+++ b/application/test/OmekaTest/View/Renderer/ApiJsonRendererTest.php
@@ -3,7 +3,6 @@ namespace OmekaTest\View\Renderer;
 
 use Omeka\Api\Exception\ValidationException;
 use Omeka\View\Renderer\ApiJsonRenderer;
-use Laminas\Json\Json;
 use Omeka\Stdlib\ErrorStore;
 use Omeka\Test\TestCase;
 
@@ -35,7 +34,7 @@ class ApiJsonRendererTest extends TestCase
               ->will($this->returnValue($response));
 
         $renderer = new ApiJsonRenderer($this->eventManager);
-        $this->assertEquals(Json::encode($testValue), $renderer->render($model));
+        $this->assertEquals(json_encode($testValue, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP), $renderer->render($model));
     }
 
     public function testRendererPassesOnNullResponse()
@@ -70,6 +69,6 @@ class ApiJsonRendererTest extends TestCase
               ->will($this->returnValue($exception));
 
         $renderer = new ApiJsonRenderer($this->eventManager);
-        $this->assertEquals(Json::encode(['errors' => ['foo' => ['bar']]]), $renderer->render($model));
+        $this->assertEquals(json_encode(['errors' => ['foo' => ['bar']]], JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP), $renderer->render($model));
     }
 }

--- a/application/test/OmekaTest/View/Strategy/ApiJsonStrategyTest.php
+++ b/application/test/OmekaTest/View/Strategy/ApiJsonStrategyTest.php
@@ -112,4 +112,25 @@ class ApiJsonStrategyTest extends TestCase
         $expectedContentType = 'application/ld+json';
         $this->assertEquals($expectedContentType, $headers->get('Content-Type')->getFieldValue());
     }
+
+    public function testStrategySetsJsonpContentType()
+    {
+        $apiResponse = $this->createMock('Omeka\Api\Response');
+
+        $model = $this->createMock('Omeka\View\Model\ApiJsonModel');
+        $model->expects($this->once())
+              ->method('getApiResponse')
+              ->will($this->returnValue($apiResponse));
+
+        $this->renderer->expects($this->any())
+                       ->method('hasJsonpCallback')
+                       ->will($this->returnValue(true));
+
+        $this->event->setModel($model);
+        $this->event->setRenderer($this->renderer);
+        $this->strategy->injectResponse($this->event);
+
+        $headers = $this->event->getResponse()->getHeaders();
+        $this->assertEquals('text/javascript', $headers->get('Content-Type')->getFieldValue());
+    }
 }

--- a/application/test/OmekaTest/View/Strategy/ApiJsonStrategyTest.php
+++ b/application/test/OmekaTest/View/Strategy/ApiJsonStrategyTest.php
@@ -109,7 +109,7 @@ class ApiJsonStrategyTest extends TestCase
         $this->strategy->injectResponse($this->event);
 
         $headers = $this->event->getResponse()->getHeaders();
-        $expectedContentType = 'application/json; charset=utf-8';
+        $expectedContentType = 'application/ld+json';
         $this->assertEquals($expectedContentType, $headers->get('Content-Type')->getFieldValue());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "laminas/laminas-i18n": "^2.7.3",
         "laminas/laminas-i18n-resources": "^2.5.2",
         "laminas/laminas-inputfilter": "^2.7.2",
-        "laminas/laminas-json": "^3.0",
         "laminas/laminas-math": "^3.0",
         "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-mvc-i18n": "^1.0",


### PR DESCRIPTION
The package is abandoned upstream. The laminas-view JSON classes that Omeka's API pipeline depended on were removed in laminas-view 3.0. Making the pipeline freestanding removes all direct Omeka S references to the package and clears a blocker for an eventual upgrade to laminas-view 3.0.

See #2500 