### PR TITLE
Add mbstring as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See the [user manual](https://omeka.org/s/docs/user-manual) for more information
 * Linux
 * [Apache](https://www.apache.org/) (with [AllowOverride](https://httpd.apache.org/docs/2.4/mod/core.html#allowoverride) set to "All" and [mod_rewrite](http://httpd.apache.org/docs/current/mod/mod_rewrite.html) enabled)
 * [MySQL](https://www.mysql.com/) 5.7.9+ (or [MariaDB](https://mariadb.org/) 10.2.6+)
-* [PHP](https://www.php.net/) 8.1+ (latest stable version preferred, with [PDO](http://php.net/manual/en/intro.pdo.php), [pdo_mysql](http://php.net/manual/en/ref.pdo-mysql.php), and [xml](http://php.net/manual/en/intro.xml.php) extensions installed)
+* [PHP](https://www.php.net/) 8.1+ (latest stable version preferred, with [mbstring](https://www.php.net/manual/en/book.mbstring.php), [PDO](https://www.php.net/manual/en/book.pdo.php), [pdo_mysql](https://www.php.net/manual/en/ref.pdo-mysql.php), and [xml](https://www.php.net/manual/en/book.xml.php) extensions installed)
 
 ### Generating thumbnails
 * The default library for generating thumbnails is [ImageMagick](https://imagemagick.org/index.php), at least version 6.7.5. Older versions will not correctly produce thumbnails. For alternative thumbnail options, see the [user manual](https://omeka.org/s/docs/user-manual/configuration/#thumbnails).


### PR DESCRIPTION
And update links.

During installation Omeka S will complain:

Omeka requires the PHP extension mbstring, but it is not loaded.

So better to make this clear in the README.