### PR TITLE
Use IIIF sizes array to select thumbnail download size

### DIFF
--- a/application/src/Media/Ingester/IIIF.php
+++ b/application/src/Media/Ingester/IIIF.php
@@ -22,10 +22,16 @@ class IIIF implements IngesterInterface
      */
     protected $downloader;
 
-    public function __construct(HttpClient $httpClient, Downloader $downloader)
+    /**
+     * @var int
+     */
+    protected $maxConstraint;
+
+    public function __construct(HttpClient $httpClient, Downloader $downloader, int $maxConstraint)
     {
         $this->httpClient = $httpClient;
         $this->downloader = $downloader;
+        $this->maxConstraint = $maxConstraint;
     }
 
     public function getLabel()
@@ -81,23 +87,49 @@ class IIIF implements IngesterInterface
         // Check API version and generate a thumbnail
         if (isset($IIIFData['@context']) && $IIIFData['@context'] == 'http://iiif.io/api/image/3/context.json') {
             // Version 3.0.
-            $URLString = '/full/max/0/default.jpg';
             $id = $IIIFData['id'];
+            $defaultSize = 'max';
+            $quality = 'default';
         } elseif (isset($IIIFData['@context']) && $IIIFData['@context'] == 'http://iiif.io/api/image/2/context.json') {
             // Version 2.0.
-            $URLString = '/full/full/0/default.jpg';
             $id = $IIIFData['@id'];
+            $defaultSize = 'full'; // 'full' was removed as a size param in v3 in favour of 'max'
+            $quality = 'default';
         } else {
             // Earlier versions
-            $URLString = '/full/full/0/native.jpg';
             $id = $IIIFData['@id'] ?? null;
+            $defaultSize = 'full';
+            $quality = 'native'; // 'native' quality was replaced by 'default' in v2
         }
+        // Prefer a pre-computed size over full resolution to minimise the download.
+        $size = $this->selectSize($IIIFData['sizes'] ?? []) ?? $defaultSize;
+        $URLString = sprintf('/full/%s/0/%s.jpg', $size, $quality);
         if ($id) {
             $tempFile = $this->downloader->download($id . $URLString);
             if ($tempFile) {
                 $tempFile->mediaIngestFile($media, $request, $errorStore, false);
             }
         }
+    }
+
+    protected function selectSize(array $sizes): ?string
+    {
+        $best = array_reduce($sizes, function ($best, $candidate) {
+            if (!isset($candidate['width'], $candidate['height'])) {
+                return $best;
+            }
+            // Both dimensions must meet the constraint to ensure the image is large
+            // enough to produce the required thumbnail regardless of aspect ratio.
+            if (($candidate['width'] < $this->maxConstraint) || ($candidate['height'] < $this->maxConstraint)) {
+                return $best;
+            }
+            // Prefer the smallest sufficient size to minimize the download.
+            if ($best === null || ($candidate['width'] * $candidate['height']) < ($best['width'] * $best['height'])) {
+                return $candidate;
+            }
+            return $best;
+        });
+        return $best ? sprintf('%s,%s', $best['width'], $best['height']) : null;
     }
 
     public function form(PhpRenderer $view, array $options = [])

--- a/application/src/Service/Media/Ingester/IIIFFactory.php
+++ b/application/src/Service/Media/Ingester/IIIFFactory.php
@@ -14,9 +14,14 @@ class IIIFFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $services, $requestedName, ?array $options = null)
     {
+        $config = $services->get('Config');
+        // The largest thumbnail constraint is the minimum size needed for thumbnail generation.
+        $constraints = array_column($config['thumbnails']['types'] ?? [], 'constraint');
+        $maxConstraint = $constraints ? max($constraints) : 800;
         return new IIIF(
             $services->get('Omeka\HttpClient'),
-            $services->get('Omeka\File\Downloader')
+            $services->get('Omeka\File\Downloader'),
+            $maxConstraint
         );
     }
 }


### PR DESCRIPTION
See #2508

The IIIF image ingester previously always downloaded the full/max resolution image for thumbnail generation. This change checks the `sizes` array in the IIIF info.json response and downloads the smallest pre-computed size that meets the maximum thumbnail constraint, falling back to full/max when no suitable size exists.
