### PR TITLE
Move Welcome page creation to event listener, add to navigation

### DIFF
--- a/application/Module.php
+++ b/application/Module.php
@@ -115,6 +115,12 @@ class Module extends AbstractModule
         );
 
         $sharedEventManager->attach(
+            'Omeka\Api\Adapter\SiteAdapter',
+            'api.create.post',
+            [$this, 'addSiteWelcomePage']
+        );
+
+        $sharedEventManager->attach(
             '*',
             'api.context',
             [$this, 'addTermDefinitionsToContext']
@@ -518,6 +524,84 @@ class Module extends AbstractModule
             );
         }
         $qb->andWhere($expression);
+    }
+
+    public function addSiteWelcomePage(LaminasEvent $event)
+    {
+        $services = $this->getServiceLocator();
+        $api = $services->get('Omeka\ApiManager');
+        $translator = $services->get('MvcTranslator');
+
+        $site = $event->getParam('response')->getContent();
+
+        $page = $api->create('site_pages', [
+            'o:site' => ['o:id' => $site->getId()],
+            'o:title' => $translator->translate('Welcome'),
+            'o:slug' => 'welcome',
+            'o:block' => $this->getWelcomePageBlocks(),
+        ])->getContent();
+
+        $navigation = $site->getNavigation();
+        $navigation[] = [
+            'type' => 'page',
+            'links' => [],
+            'data' => ['id' => $page->id(), 'label' => null],
+        ];
+        $site->setNavigation($navigation);
+        $services->get('Omeka\EntityManager')->flush();
+    }
+
+    private function getWelcomePageBlocks()
+    {
+        $translator = $this->getServiceLocator()->get('MvcTranslator');
+        return [
+            [
+                'o:layout' => 'html',
+                'o:data' => ['html' => $translator->translate(<<<EOT
+                    <p>Welcome to your new site. This is an example page.</p>
+                    <ul>
+                        <li>This is a bullet list.</li>
+                        <li>Second entry.</li>
+                    </ul>
+                    <p>Back to normal again.</p>
+                    <ol>
+                        <li>This is an ordered list.</li>
+                        <li>Second entry.</li>
+                    </ol>
+                    <p>Back to normal again.</p>
+                    <blockquote>This is a blockquote.</blockquote>
+                    <p>Back to normal again.</p>
+                    <div><a href="#">This text is a link, which currently points to nothing.</a></div>
+                    <p><strong>This text is bold, in a &lt;strong&gt; tag.</strong></p>
+                    <p><em>This text is italicized, in an &lt;em&gt; tag.</em></p>
+                    <p><u>This text is underlined, in a &lt;u&gt; tag.</u></p>
+                    <p><s>This text has a strikethrough, in a &lt;s&gt; tag.</s></p>
+                    <p>This text is <sub>subscript</sub> and <sup>superscript</sup> using &lt;sub&gt; and &lt;sup&gt;, which can be used for adding notes and citations.</p>
+                    <hr>
+                    <h1>This is an H1 title. It is bigger than the Page Title, which is rendered in H2.</h1>
+                    <h2>This is an H2 header, the same size as the Page Title.</h2>
+                    <h3>This is an H3 subheader.</h3>
+                    <h4>This is an H4 subheader.</h4>
+                    <h5>This is an H5 subheader.</h5>
+                    <h6>This is an H6 subheader.</h6>
+                EOT)],
+            ],
+            [
+                'o:layout' => 'lineBreak',
+                'o:data' => ['break_type' => 'opaque'],
+            ],
+            [
+                'o:layout' => 'html',
+                'o:data' => ['html' => $translator->translate(<<<EOT
+                    <h2 style="font-style:italic;">This is the &quot;Italic Title&quot; block style.</h2>
+                    <div style="background:#eeeeee;border:1px solid #cccccc;padding:5px 10px;">This is the &quot;Special Container&quot; block style.</div>
+                    <p><span class="marker">This is the &quot;Marker&quot; inline style. </span></p>
+                    <p><small>This text is inside a &quot;small&quot; inline style.</small> This is normal text.</p>
+                    <p><code>This is the &quot;Computer Code&quot; inline style.</code></p>
+                    <p><span dir="rtl" lang="ar">لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار النشوة وتمجيد الألم يعرض هذا النص من اليمين إلى اليسار.</span></p>
+                EOT)],
+            ],
+        ];
     }
 
     public function batchUpdatePostUser(LaminasEvent $event)

--- a/application/src/Api/Adapter/SiteAdapter.php
+++ b/application/src/Api/Adapter/SiteAdapter.php
@@ -3,7 +3,6 @@ namespace Omeka\Api\Adapter;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\QueryBuilder;
-use Omeka\Api\Exception\ValidationException;
 use Omeka\Api\Request;
 use Omeka\Entity\EntityInterface;
 use Omeka\Entity\SitePermission;
@@ -142,40 +141,6 @@ class SiteAdapter extends AbstractEntityAdapter
                 }
             }
 
-            if ($request->getOperation() === Request::CREATE) {
-                $class = $adapter->getEntityClass();
-                $page = new $class;
-                $page->setSite($entity);
-                $translator = $this->getServiceLocator()->get('MvcTranslator');
-                $subErrorStore = new ErrorStore;
-                $subrequest = new Request(Request::CREATE, 'site_pages');
-                $subrequest->setContent(
-                    [
-                        'o:title' => $translator->translate('Welcome'),
-                        'o:slug' => 'welcome',
-                        'o:block' => [
-                            [
-                                'o:layout' => 'html',
-                                'o:data' => ['html' => $this->getFirstPageContent()],
-                            ],
-                            [
-                                'o:layout' => 'lineBreak',
-                                'o:data' => ['break_type' => 'opaque'],
-                            ],
-                            [
-                                'o:layout' => 'html',
-                                'o:data' => ['html' => $this->getSecondPageContent()],
-                            ],
-                        ],
-                    ]
-                );
-                try {
-                    $adapter->hydrateEntity($subrequest, $page, $subErrorStore);
-                } catch (ValidationException $e) {
-                    $errorStore->mergeErrors($e->getErrorStore(), 'o:page');
-                }
-                $pages->add($page);
-            }
         }
 
         $sitePermissionsData = $request->getValue('o:site_permission');
@@ -434,49 +399,4 @@ class SiteAdapter extends AbstractEntityAdapter
         ];
     }
 
-    protected function getFirstPageContent()
-    {
-        $translator = $this->getServiceLocator()->get('MvcTranslator');
-        return $translator->translate(<<<EOT
-            <p>Welcome to your new site. This is an example page.</p>
-            <ul>
-                <li>This is a bullet list.</li>
-                <li>Second entry.</li>
-            </ul>
-            <p>Back to normal again.</p>
-            <ol>
-                <li>This is an ordered list.</li>
-                <li>Second entry.</li>
-            </ol>
-            <p>Back to normal again.</p>
-            <blockquote>This is a blockquote.</blockquote>
-            <p>Back to normal again.</p>
-            <div><a href="#">This text is a link, which currently points to nothing.</a></div>
-            <p><strong>This text is bold, in a &lt;strong&gt; tag.</strong></p>
-            <p><em>This text is italicized, in an &lt;em&gt; tag.</em></p>
-            <p><u>This text is underlined, in a &lt;u&gt; tag.</u></p>
-            <p><s>This text has a strikethrough, in a &lt;s&gt; tag.</s></p>
-            <p>This text is <sub>subscript</sub> and <sup>superscript</sup> using &lt;sub&gt; and &lt;sup&gt;, which can be used for adding notes and citations.</p>
-            <hr>
-            <h1>This is an H1 title. It is bigger than the Page Title, which is rendered in H2.</h1>
-            <h2>This is an H2 header, the same size as the Page Title.</h2>
-            <h3>This is an H3 subheader.</h3>
-            <h4>This is an H4 subheader.</h4>
-            <h5>This is an H5 subheader.</h5>
-            <h6>This is an H6 subheader.</h6>
-        EOT);
-    }
-
-    protected function getSecondPageContent()
-    {
-        $translator = $this->getServiceLocator()->get('MvcTranslator');
-        return $translator->translate(<<<EOT
-            <h2 style="font-style:italic;">This is the &quot;Italic Title&quot; block style.</h2>
-            <div style="background:#eeeeee;border:1px solid #cccccc;padding:5px 10px;">This is the &quot;Special Container&quot; block style.</div>
-            <p><span class="marker">This is the &quot;Marker&quot; inline style. </span></p>
-            <p><small>This text is inside a &quot;small&quot; inline style.</small> This is normal text.</p>
-            <p><code>This is the &quot;Computer Code&quot; inline style.</code></p>
-            <p><span dir="rtl" lang="ar">لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار النشوة وتمجيد الألم يعرض هذا النص من اليمين إلى اليسار.</span></p>
-        EOT);
-    }
 }


### PR DESCRIPTION
New sites include a Welcome page but it was never added to navigation, requiring manual assignment. This moves Welcome page creation out of `SiteAdapter::hydrate()` and into an `api.create.post` event listener, where the page ID is available after flush. The listener creates the page and adds it to navigation in one step.