### PR TITLE
Add a secret key in the config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 .DS_Store
 /application/language/debug.*
 /static/
+/config/secret_key.php

--- a/application/Module.php
+++ b/application/Module.php
@@ -25,7 +25,7 @@ class Module extends AbstractModule
     /**
      * This Omeka version.
      */
-    const VERSION = '4.3.0-alpha';
+    const VERSION = '4.3.0-alpha.1';
 
     /**
      * The vocabulary IRI used to define Omeka application data.

--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -260,6 +260,7 @@ return [
             'Omeka\ApiAdapterManager' => Service\ApiAdapterManagerFactory::class,
             'Omeka\ApiManager' => Service\ApiManagerFactory::class,
             'Omeka\AuthenticationService' => Service\AuthenticationServiceFactory::class,
+            'Omeka\Cipher' => Service\Stdlib\CipherFactory::class,
             'Omeka\EntityManager' => Service\EntityManagerFactory::class,
             'Omeka\Installer' => Service\InstallerFactory::class,
             'Omeka\Logger' => Service\LoggerFactory::class,

--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -447,6 +447,7 @@ return [
             'formAsset' => Form\View\Helper\FormAsset::class,
             'formQuery' => Form\View\Helper\FormQuery::class,
             'formColumns' => Form\View\Helper\FormColumns::class,
+            'formSecret' => Form\View\Helper\FormSecret::class,
             'formBrowseDefaults' => Form\View\Helper\FormBrowseDefaults::class,
             'themeSettingAsset' => View\Helper\ThemeSettingAsset::class,
             'themeSettingAssetUrl' => View\Helper\ThemeSettingAssetUrl::class,
@@ -530,6 +531,9 @@ return [
         'initializers' => [
             Form\Initializer\Csrf::class,
             Form\Initializer\EventManager::class,
+        ],
+        'invokables' => [
+            'Omeka\Form\Element\Secret' => Form\Element\Secret::class,
         ],
         'factories' => [
             'Omeka\Form\ResourceForm' => Service\Form\ResourceFormFactory::class,

--- a/application/config/module.config.php
+++ b/application/config/module.config.php
@@ -190,6 +190,7 @@ return [
             Installation\Task\InstallDefaultTemplatesTask::class,
             Installation\Task\CreateFirstUserTask::class,
             Installation\Task\AddDefaultSettingsTask::class,
+            Installation\Task\CreateSecretKeyTask::class,
         ],
     ],
     'translator' => [

--- a/application/data/migrations/20260706000000_CreateSecretKey.php
+++ b/application/data/migrations/20260706000000_CreateSecretKey.php
@@ -35,7 +35,7 @@ class CreateSecretKey implements ConstructedMigrationInterface
 
     public function up(Connection $conn)
     {
-        if (SecretKey::resolve() !== null) {
+        if (SecretKey::resolve()) {
             return;
         }
 

--- a/application/data/migrations/20260706000000_CreateSecretKey.php
+++ b/application/data/migrations/20260706000000_CreateSecretKey.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Omeka\Db\Migrations;
+
+use Doctrine\DBAL\Connection;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Omeka\Db\Migration\ConstructedMigrationInterface;
+use Omeka\Stdlib\SecretKey;
+
+class CreateSecretKey implements ConstructedMigrationInterface
+{
+    /**
+     * @var \Laminas\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \Omeka\Mvc\Controller\Plugin\Messenger
+     */
+    private $messenger;
+
+    public static function create(ServiceLocatorInterface $services)
+    {
+        return new self(
+            $services->get('Omeka\Logger'),
+            $services->get('ControllerPluginManager')->get('messenger')
+        );
+    }
+
+    public function __construct($logger, $messenger)
+    {
+        $this->logger = $logger;
+        $this->messenger = $messenger;
+    }
+
+    public function up(Connection $conn)
+    {
+        if (SecretKey::resolve() !== null) {
+            return;
+        }
+
+        if (SecretKey::store(SecretKey::generate())) {
+            $this->logger->info('A secret key was generated in config/secret_key.php to encrypt secrets.'); // @translate
+            return;
+        }
+
+        $message = 'The secret key could not be created: set it manually in config/secret_key.php or set the environment variable "OMEKA_SECRET_KEY" to encrypt secrets (module api keys, etc.).'; // @translate
+        $this->logger->warn($message);
+        $this->messenger->addWarning($message);
+    }
+}

--- a/application/src/Form/Element/Secret.php
+++ b/application/src/Form/Element/Secret.php
@@ -11,7 +11,8 @@ use Laminas\Form\Element\Password;
  * - empty means that a value is already set (a placeholder may be set);
  * - an empty submission keep the current value.
  *
- * Rendered as a masked password input, excluded from browser autofill.
+ * Rendered as a text input with a lock icon, excluded from browser autofill;
+ * set option "masked" to true to render a password input instead.
  * @see \Omeka\Form\View\Helper\FormSecret
  */
 class Secret extends Password

--- a/application/src/Form/Element/Secret.php
+++ b/application/src/Form/Element/Secret.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Omeka\Form\Element;
+
+use Laminas\Form\Element\Password;
+
+/**
+ * A setting field holding a secret (API key, password) encrypted at rest.
+ *
+ * The stored value is never rendered back to the browser:
+ * - empty means that a value is already set (a placeholder may be set);
+ * - an empty submission keep the current value.
+ *
+ * Rendered as a masked password input, excluded from browser autofill.
+ * @see \Omeka\Form\View\Helper\FormSecret
+ */
+class Secret extends Password
+{
+}

--- a/application/src/Form/View/Helper/FormSecret.php
+++ b/application/src/Form/View/Helper/FormSecret.php
@@ -6,11 +6,14 @@ use Laminas\Form\ElementInterface;
 use Laminas\Form\View\Helper\AbstractHelper;
 
 /**
- * Render a secret input with a clear control as a single element.
+ * Render a secret input with a lock icon and an optional remove control.
  *
  * The stored value is never rendered back to the browser:
  * - empty means that a value is already set (a placeholder may be set);
  * - an empty submission keep the current value.
+ *
+ * The input is a plain text field by default. Set option "masked" to true to
+ * render a password input instead.
  */
 class FormSecret extends AbstractHelper
 {
@@ -30,18 +33,51 @@ class FormSecret extends AbstractHelper
 
         // Never echo the stored secret back to the browser.
         $element->setValue('');
-        $input = $view->formPassword($element);
-
-        if (!$element->getOption('has_value')) {
-            return $this->style() . $input;
+        if (!$element->getAttribute('autocomplete')) {
+            $element->setAttribute('autocomplete', 'off');
         }
 
-        $remove = $view->escapeHtmlAttr($element->getName() . '_remove');
+        // When a value is saved, replace any placeholder with a hint that an
+        // empty submission keeps the current value, so the placeholder does not
+        // look like a missing value.
+        $hasValue = (bool) $element->getOption('has_value');
+        if ($hasValue) {
+            $element->setAttribute('placeholder', $view->translate('Leave empty to keep the current value')); // @translate
+        }
+
+        // Render a masked password if requested.
+        $input = $element->getOption('masked')
+            ? $view->formPassword($element)
+            : $view->formText($element);
+
+        // A lock icon is displayed to mark field as a secret (gray or green).
+        $iconTitle = $view->escapeHtmlAttr($hasValue
+            ? $view->translate('A value is already saved') // @translate
+            : $view->translate('This value is secret')); // @translate
+        $iconClass = $hasValue
+            ? 'secret-element-icon secret-element-icon--set'
+            : 'secret-element-icon';
+        $field = <<<HTML
+            <span class="secret-element-field">
+                $input
+                <span class="$iconClass o-icon-lock" role="img" title="$iconTitle" aria-label="$iconTitle"></span>
+            </span>
+            HTML;
+
+        if (!$hasValue) {
+            return $this->style() . $field;
+        }
+
+        // When a value is saved, add a checkbox to remove it.
+        $name = $element->getName();
+        $remove = $view->escapeHtmlAttr(substr($name, -1) === ']'
+            ? substr($name, 0, -1) . '_remove]'
+            : $name . '_remove');
         $label = $view->escapeHtml($view->translate('Remove the saved value')); // @translate
         return $this->style()
             . <<<HTML
                 <span class="secret-element">
-                    $input
+                    $field
                     <label class="secret-element-remove">
                         <input type="checkbox" name="$remove" value="1">
                         $label
@@ -60,8 +96,12 @@ class FormSecret extends AbstractHelper
 
         return <<<'HTML'
             <style>
-                .secret-element { display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; }
-                .secret-element-remove { font-weight:normal; font-size:.9em; color:#6c757d; }
+                .secret-element { display:flex; flex-wrap:nowrap; align-items:center; gap:.5rem; width:100%; }
+                .secret-element-field { position:relative; flex:1 1 auto; min-width:0; }
+                .secret-element-field input { width:100%; box-sizing:border-box; padding-inline-end:1.9rem; }
+                .secret-element-icon { position:absolute; inset-inline-end:.5rem; top:50%; transform:translateY(-50%); display:inline-flex; color:#6c757d; pointer-events:none; }
+                .secret-element-icon--set { color:#198754; }
+                .secret-element .secret-element-remove { flex:none; width:auto; margin:0; white-space:nowrap; font-weight:normal; font-size:.9em; color:#6c757d; }
             </style>
             HTML;
     }

--- a/application/src/Form/View/Helper/FormSecret.php
+++ b/application/src/Form/View/Helper/FormSecret.php
@@ -1,0 +1,67 @@
+<?php
+namespace Omeka\Form\View\Helper;
+
+use Laminas\Form\ElementInterface;
+use Laminas\Form\View\Helper\AbstractHelper;
+
+/**
+ * Render a secret input with a clear control as a single element.
+ *
+ * The stored value is never rendered back to the browser:
+ * - empty means that a value is already set (a placeholder may be set);
+ * - an empty submission keep the current value.
+ */
+class FormSecret extends AbstractHelper
+{
+    /**
+     * @var bool Avoid to copy multiple times the inline style.
+     */
+    private static $styleEmitted = false;
+
+    public function __invoke(ElementInterface $element)
+    {
+        return $this->render($element);
+    }
+
+    public function render(ElementInterface $element)
+    {
+        $view = $this->getView();
+
+        // Never echo the stored secret back to the browser.
+        $element->setValue('');
+        $input = $view->formPassword($element);
+
+        if (!$element->getOption('has_value')) {
+            return $this->style() . $input;
+        }
+
+        $remove = $view->escapeHtmlAttr($element->getName() . '_remove');
+        $label = $view->escapeHtml($view->translate('Remove the saved value')); // @translate
+        return $this->style()
+            . <<<HTML
+                <span class="secret-element">
+                    $input
+                    <label class="secret-element-remove">
+                        <input type="checkbox" name="$remove" value="1">
+                        $label
+                    </label>
+                </span>
+                HTML;
+    }
+
+    protected function style()
+    {
+        if (self::$styleEmitted) {
+            return '';
+        }
+
+        self::$styleEmitted = true;
+
+        return <<<'HTML'
+            <style>
+                .secret-element { display:flex; flex-wrap:wrap; align-items:center; gap:.5rem; }
+                .secret-element-remove { font-weight:normal; font-size:.9em; color:#6c757d; }
+            </style>
+            HTML;
+    }
+}

--- a/application/src/Form/View/Helper/FormSecret.php
+++ b/application/src/Form/View/Helper/FormSecret.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace Omeka\Form\View\Helper;
 
 use Laminas\Form\ElementInterface;

--- a/application/src/Installation/Task/CreateSecretKeyTask.php
+++ b/application/src/Installation/Task/CreateSecretKeyTask.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Omeka\Installation\Task;
+
+use Omeka\Installation\Installer;
+use Omeka\Stdlib\SecretKey;
+
+/**
+ * Generate the application secret key on install.
+ *
+ * When a key is already resolved (environment or file) nothing is done.
+ */
+class CreateSecretKeyTask implements TaskInterface
+{
+    public function perform(Installer $installer)
+    {
+        $services = $installer->getServiceLocator();
+        if (SecretKey::resolve() !== null) {
+            return;
+        }
+
+        $logger = $services->get('Omeka\Logger');
+        if (SecretKey::store(SecretKey::generate())) {
+            $logger->info('A secret key was generated in config/secret_key.php to encrypt secrets.'); // @translate
+            return;
+        }
+
+        $message = 'The secret key could not be created: set it manually in config/secret_key.php or set the environment variable "OMEKA_SECRET_KEY" to encrypt secrets (module api keys, etc.).'; // @translate
+        $logger->warn($message);
+        $services->get('ControllerPluginManager')->get('messenger')->addWarning($message);
+    }
+}

--- a/application/src/Installation/Task/CreateSecretKeyTask.php
+++ b/application/src/Installation/Task/CreateSecretKeyTask.php
@@ -15,7 +15,7 @@ class CreateSecretKeyTask implements TaskInterface
     public function perform(Installer $installer)
     {
         $services = $installer->getServiceLocator();
-        if (SecretKey::resolve() !== null) {
+        if (SecretKey::resolve()) {
             return;
         }
 

--- a/application/src/Service/Delegator/FormElementDelegatorFactory.php
+++ b/application/src/Service/Delegator/FormElementDelegatorFactory.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace Omeka\Service\Delegator;
 
 use Interop\Container\ContainerInterface;

--- a/application/src/Service/Delegator/FormElementDelegatorFactory.php
+++ b/application/src/Service/Delegator/FormElementDelegatorFactory.php
@@ -23,6 +23,7 @@ class FormElementDelegatorFactory implements DelegatorFactoryInterface
         $formElement->addClass('Omeka\Form\Element\Columns', 'formColumns');
         $formElement->addClass('Omeka\Form\Element\BrowseDefaults', 'formBrowseDefaults');
         $formElement->addClass('Omeka\Form\Element\SelectSortInterface', 'formSelectSort');
+        $formElement->addClass('Omeka\Form\Element\Secret', 'formSecret');
         return $formElement;
     }
 }

--- a/application/src/Service/Stdlib/CipherFactory.php
+++ b/application/src/Service/Stdlib/CipherFactory.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Omeka\Service\Stdlib;
+
+use Laminas\ServiceManager\Factory\FactoryInterface;
+use Omeka\Stdlib\Cipher;
+use Omeka\Stdlib\SecretKey;
+use Psr\Container\ContainerInterface;
+
+class CipherFactory implements FactoryInterface
+{
+    /**
+     * Create the Cipher service from the resolved secret key.
+     *
+     * @return Cipher
+     */
+    public function __invoke(ContainerInterface $services, $requestedName, ?array $options = null)
+    {
+        return new Cipher(SecretKey::resolve());
+    }
+}

--- a/application/src/Stdlib/Cipher.php
+++ b/application/src/Stdlib/Cipher.php
@@ -50,8 +50,18 @@ final class Cipher
      */
     public function encrypt(string $value): string
     {
-        if ($value === '' || $this->keys === [] || strncmp($value, self::PREFIX, strlen(self::PREFIX)) === 0) {
+        if ($value === '' || $this->keys === []) {
             return $value;
+        }
+
+        // Skip a value already encrypted, but only when the prefix is followed
+        // by a valid ciphertext (avoid rare issue where prefix is sodium:).
+        if (strncmp($value, self::PREFIX, strlen(self::PREFIX)) === 0) {
+            $raw = base64_decode(substr($value, strlen(self::PREFIX)), true);
+            $min = SODIUM_CRYPTO_SECRETBOX_NONCEBYTES + SODIUM_CRYPTO_SECRETBOX_MACBYTES;
+            if ($raw !== false && strlen($raw) >= $min) {
+                return $value;
+            }
         }
 
         $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);

--- a/application/src/Stdlib/Cipher.php
+++ b/application/src/Stdlib/Cipher.php
@@ -5,8 +5,12 @@ namespace Omeka\Stdlib;
 /**
  * Minimal symmetric encryption for secrets stored in the database.
  *
- * A dedicated encryption subkey is derived from the configured master key to
- * serve various purposes without reusing master key.
+ * A dedicated encryption subkey is derived from each configured master key to
+ * serve various purposes without reusing the master key.
+ *
+ * Multiple keys support rotation: values are encrypted with the current (first)
+ * key, and decrypted by trying each key in turn (current, then previous ones),
+ * so old values stay readable until they are re-encrypted.
  *
  * When no valid key is configured, encryption is disabled and values are kept
  * in clear (opt-in and backward compatible via the prefix `sodium:`).
@@ -16,21 +20,29 @@ final class Cipher
     const PREFIX = 'sodium:';
 
     /**
-     * @var string|null Encryption subkey (32 bytes), or null when disabled.
+     * @var string[] Encryption subkeys (32 bytes); the first is the current one
+     * used to encrypt.
      */
-    private $key;
+    private $keys = [];
 
-    public function __construct(?string $base64MasterKey)
+    /**
+     * @param string[]|string|null $masterKeys One or more base64 master keys.
+     */
+    public function __construct($masterKeys)
     {
-        $master = $base64MasterKey ? base64_decode($base64MasterKey, true) : false;
-        $this->key = ($master !== false && strlen($master) >= SODIUM_CRYPTO_SECRETBOX_KEYBYTES)
-            ? hash_hkdf('sha256', $master, SODIUM_CRYPTO_SECRETBOX_KEYBYTES, 'omeka:cipher:v1')
-            : null;
+        foreach ((array) $masterKeys as $base64MasterKey) {
+            $master = is_string($base64MasterKey) && $base64MasterKey !== ''
+                ? base64_decode($base64MasterKey, true)
+                : false;
+            if ($master !== false && strlen($master) >= SODIUM_CRYPTO_SECRETBOX_KEYBYTES) {
+                $this->keys[] = hash_hkdf('sha256', $master, SODIUM_CRYPTO_SECRETBOX_KEYBYTES, 'omeka:cipher:v1');
+            }
+        }
     }
 
     public function isEnabled(): bool
     {
-        return $this->key !== null;
+        return $this->keys !== [];
     }
 
     /**
@@ -38,19 +50,19 @@ final class Cipher
      */
     public function encrypt(string $value): string
     {
-        if ($value === '' || $this->key === null || strncmp($value, self::PREFIX, strlen(self::PREFIX)) === 0) {
+        if ($value === '' || $this->keys === [] || strncmp($value, self::PREFIX, strlen(self::PREFIX)) === 0) {
             return $value;
         }
 
         $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
-        return self::PREFIX . base64_encode($nonce . sodium_crypto_secretbox($value, $nonce, $this->key));
+        return self::PREFIX . base64_encode($nonce . sodium_crypto_secretbox($value, $nonce, $this->keys[0]));
     }
 
     /**
      * Decrypt a value, or return it unchanged when it is a legacy clear value.
      *
      * @return string The decrypted value, or an empty string for fail, when the
-     * value is encrypted but cannot be decrypted.
+     * value is encrypted but cannot be decrypted with any key.
      */
     public function decrypt(string $value): string
     {
@@ -58,7 +70,7 @@ final class Cipher
             return $value;
         }
 
-        if ($this->key === null) {
+        if ($this->keys === []) {
             return '';
         }
 
@@ -70,7 +82,13 @@ final class Cipher
 
         $nonce = substr($raw, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
         $cipher = substr($raw, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
-        $plain = sodium_crypto_secretbox_open($cipher, $nonce, $this->key);
-        return $plain === false ? '' : $plain;
+        foreach ($this->keys as $key) {
+            $plain = sodium_crypto_secretbox_open($cipher, $nonce, $key);
+            if ($plain !== false) {
+                return $plain;
+            }
+        }
+
+        return '';
     }
 }

--- a/application/src/Stdlib/Cipher.php
+++ b/application/src/Stdlib/Cipher.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace Omeka\Stdlib;
+
+/**
+ * Minimal symmetric encryption for secrets stored in the database.
+ *
+ * A dedicated encryption subkey is derived from the configured master key to
+ * serve various purposes without reusing master key.
+ *
+ * When no valid key is configured, encryption is disabled and values are kept
+ * in clear (opt-in and backward compatible via the prefix `sodium:`).
+ */
+final class Cipher
+{
+    const PREFIX = 'sodium:';
+
+    /**
+     * @var string|null Encryption subkey (32 bytes), or null when disabled.
+     */
+    private $key;
+
+    public function __construct(?string $base64MasterKey)
+    {
+        $master = $base64MasterKey ? base64_decode($base64MasterKey, true) : false;
+        $this->key = ($master !== false && strlen($master) >= SODIUM_CRYPTO_SECRETBOX_KEYBYTES)
+            ? hash_hkdf('sha256', $master, SODIUM_CRYPTO_SECRETBOX_KEYBYTES, 'omeka:cipher:v1')
+            : null;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->key !== null;
+    }
+
+    /**
+     * Get encrypted value, or unchanged if empty, already encrypted, or no key.
+     */
+    public function encrypt(string $value): string
+    {
+        if ($value === '' || $this->key === null || strncmp($value, self::PREFIX, strlen(self::PREFIX)) === 0) {
+            return $value;
+        }
+
+        $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        return self::PREFIX . base64_encode($nonce . sodium_crypto_secretbox($value, $nonce, $this->key));
+    }
+
+    /**
+     * Decrypt a value, or return it unchanged when it is a legacy clear value.
+     *
+     * @return string The decrypted value, or an empty string for fail, when the
+     * value is encrypted but cannot be decrypted.
+     */
+    public function decrypt(string $value): string
+    {
+        if (strncmp($value, self::PREFIX, strlen(self::PREFIX)) !== 0) {
+            return $value;
+        }
+
+        if ($this->key === null) {
+            return '';
+        }
+
+        $raw = base64_decode(substr($value, strlen(self::PREFIX)), true);
+        $min = SODIUM_CRYPTO_SECRETBOX_NONCEBYTES + SODIUM_CRYPTO_SECRETBOX_MACBYTES;
+        if ($raw === false || strlen($raw) < $min) {
+            return '';
+        }
+
+        $nonce = substr($raw, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $cipher = substr($raw, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+        $plain = sodium_crypto_secretbox_open($cipher, $nonce, $this->key);
+        return $plain === false ? '' : $plain;
+    }
+}

--- a/application/src/Stdlib/SecretKey.php
+++ b/application/src/Stdlib/SecretKey.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace Omeka\Stdlib;
+
+/**
+ * Resolve and persist the application secret key used to encrypt secrets.
+ *
+ * The key is kept out of the database for security and for privacy.
+ *
+ * The key is resolved from:
+ * 1. config/secret_key.php, a generated file created during install;
+ * 2. environment variable  `OMEKA_SECRET_KEY`, for hosts where the config
+ *    directory is not writeable (containers or managed hosting).
+ *
+ * The config directory is OMEKA_PATH . '/config/' and can be overridden mainly
+ * for testing.
+ */
+final class SecretKey
+{
+    const FILE = 'secret_key.php';
+
+    const ENV = 'OMEKA_SECRET_KEY';
+
+    /**
+     * Resolve the secret key, or null when none is set.
+     */
+    public static function resolve(?string $configDir = null): ?string
+    {
+        $file = self::filePath($configDir);
+        if (is_readable($file)) {
+            $key = include $file;
+            if (is_string($key) && $key !== '') {
+                return $key;
+            }
+        }
+
+        $env = getenv(self::ENV);
+        if (is_string($env) && $env !== '') {
+            return $env;
+        }
+
+        return null;
+    }
+
+    /**
+     * Generate a new secret key, a base64 string of 32 random bytes.
+     */
+    public static function generate(): string
+    {
+        return base64_encode(random_bytes(32));
+    }
+
+    /**
+     * Store a generated key in the config directory.
+     *
+     * @return bool False when the file could not be written.
+     */
+    public static function store(string $base64Key, ?string $configDir = null): bool
+    {
+        $file = self::filePath($configDir);
+        $content = "<?php\nreturn " . var_export($base64Key, true) . ";\n";
+        if (@file_put_contents($file, $content, LOCK_EX) === false) {
+            return false;
+        }
+
+        @chmod($file, 0600);
+        return true;
+    }
+
+    private static function filePath(?string $configDir): string
+    {
+        return ($configDir ?? OMEKA_PATH . '/config') . '/' . self::FILE;
+    }
+}

--- a/application/src/Stdlib/SecretKey.php
+++ b/application/src/Stdlib/SecretKey.php
@@ -3,14 +3,17 @@
 namespace Omeka\Stdlib;
 
 /**
- * Resolve and persist the application secret key used to encrypt secrets.
+ * Resolve and persist the application secret keys used to encrypt secrets.
  *
- * The key is kept out of the database for security and for privacy.
+ * The keys are kept out of the database for security and for privacy.
  *
- * The key is resolved from:
- * 1. config/secret_key.php, a generated file created during install;
- * 2. environment variable  `OMEKA_SECRET_KEY`, for hosts where the config
+ * The keys are resolved from:
+ * 1. config/secret_key.php, a generated file returning the keys as an array;
+ * 2. environment variable `OMEKA_SECRET_KEY`, for hosts where the config
  *    directory is not writeable (containers or managed hosting).
+ *
+ * Multiple keys enable rotation: the first is the current key (used to
+ * encrypt), the next ones are previous keys kept to decrypt older values.
  *
  * The config directory is OMEKA_PATH . '/config/' and can be overridden mainly
  * for testing.
@@ -22,24 +25,21 @@ final class SecretKey
     const ENV = 'OMEKA_SECRET_KEY';
 
     /**
-     * Resolve the secret key, or null when none is set.
+     * Resolve the secret keys (the first is current), or an empty array.
+     *
+     * @return string[]
      */
-    public static function resolve(?string $configDir = null): ?string
+    public static function resolve(?string $configDir = null): array
     {
         $file = self::filePath($configDir);
         if (is_readable($file)) {
-            $key = include $file;
-            if (is_string($key) && $key !== '') {
-                return $key;
+            $keys = self::normalize(include $file);
+            if ($keys !== []) {
+                return $keys;
             }
         }
 
-        $env = getenv(self::ENV);
-        if (is_string($env) && $env !== '') {
-            return $env;
-        }
-
-        return null;
+        return self::normalize(getenv(self::ENV));
     }
 
     /**
@@ -51,20 +51,44 @@ final class SecretKey
     }
 
     /**
-     * Store a generated key in the config directory.
+     * Store a key in the config directory, as an array to allow rotation.
      *
      * @return bool False when the file could not be written.
      */
     public static function store(string $base64Key, ?string $configDir = null): bool
     {
         $file = self::filePath($configDir);
-        $content = "<?php\nreturn " . var_export($base64Key, true) . ";\n";
+        $exportKey = var_export($base64Key, true);
+        $content = <<<PHP
+            <?php
+            // Application secret keys.
+            // The first is the current key (used to encrypt).
+            // Add previous keys after it to keep decrypting old values during rotation.
+            return [
+                $exportKey,
+            ];
+
+            PHP;
         if (@file_put_contents($file, $content, LOCK_EX) === false) {
             return false;
         }
-
         @chmod($file, 0600);
         return true;
+    }
+
+    /**
+     * @param string[]|string|false $value
+     * @return string[]
+     */
+    private static function normalize($value): array
+    {
+        $keys = [];
+        foreach ((array) $value as $key) {
+            if (is_string($key) && $key !== '') {
+                $keys[] = $key;
+            }
+        }
+        return $keys;
     }
 
     private static function filePath(?string $configDir): string

--- a/application/test/OmekaTest/Form/View/Helper/FormSecretTest.php
+++ b/application/test/OmekaTest/Form/View/Helper/FormSecretTest.php
@@ -11,15 +11,17 @@ class FormSecretTest extends TestCase
 {
     private function helper()
     {
-        // Stub the renderer helpers used by FormSecret: formPassword echoes the
-        // element name and value, the escapers and translator are identity.
+        // Stub the renderer helpers used by FormSecret: formText/formPassword
+        // echo the element name, type and value, the escapers and translator
+        // are identity.
         $view = $this->getMockBuilder(PhpRenderer::class)
             ->onlyMethods(['__call'])
             ->getMock();
         $view->method('__call')->willReturnCallback(function ($name, $args) {
-            if ($name === 'formPassword') {
+            if ($name === 'formText' || $name === 'formPassword') {
                 $element = $args[0];
-                return sprintf('<input type="password" name="%s" value="%s">', $element->getName(), $element->getValue());
+                $type = $name === 'formPassword' ? 'password' : 'text';
+                return sprintf('<input type="%s" name="%s" value="%s">', $type, $element->getName(), $element->getValue());
             }
             return $args[0];
         });
@@ -34,6 +36,19 @@ class FormSecretTest extends TestCase
         $element->setValue('super-secret');
         $output = $this->helper()->render($element);
         $this->assertStringNotContainsString('super-secret', $output);
+    }
+
+    public function testRendersATextInputByDefault()
+    {
+        $output = $this->helper()->render(new Secret('api_key'));
+        $this->assertStringContainsString('type="text"', $output);
+    }
+
+    public function testRendersAPasswordInputWhenMasked()
+    {
+        $element = new Secret('api_key');
+        $element->setOption('masked', true);
+        $output = $this->helper()->render($element);
         $this->assertStringContainsString('type="password"', $output);
     }
 

--- a/application/test/OmekaTest/Form/View/Helper/FormSecretTest.php
+++ b/application/test/OmekaTest/Form/View/Helper/FormSecretTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+namespace OmekaTest\Form\View\Helper;
+
+use Omeka\Form\Element\Secret;
+use Omeka\Form\View\Helper\FormSecret;
+use Omeka\Test\TestCase;
+use Laminas\View\Renderer\PhpRenderer;
+
+class FormSecretTest extends TestCase
+{
+    private function helper()
+    {
+        // Stub the renderer helpers used by FormSecret: formPassword echoes the
+        // element name and value, the escapers and translator are identity.
+        $view = $this->getMockBuilder(PhpRenderer::class)
+            ->onlyMethods(['__call'])
+            ->getMock();
+        $view->method('__call')->willReturnCallback(function ($name, $args) {
+            if ($name === 'formPassword') {
+                $element = $args[0];
+                return sprintf('<input type="password" name="%s" value="%s">', $element->getName(), $element->getValue());
+            }
+            return $args[0];
+        });
+        $helper = new FormSecret();
+        $helper->setView($view);
+        return $helper;
+    }
+
+    public function testNeverRendersTheStoredValue()
+    {
+        $element = new Secret('api_key');
+        $element->setValue('super-secret');
+        $output = $this->helper()->render($element);
+        $this->assertStringNotContainsString('super-secret', $output);
+        $this->assertStringContainsString('type="password"', $output);
+    }
+
+    public function testNoRemoveControlWhenNoValueIsStored()
+    {
+        $output = $this->helper()->render(new Secret('api_key'));
+        $this->assertStringNotContainsString('api_key_remove', $output);
+    }
+
+    public function testRemoveControlWhenAValueIsStored()
+    {
+        $element = new Secret('api_key');
+        $element->setOption('has_value', true);
+        $output = $this->helper()->render($element);
+        $this->assertStringContainsString('name="api_key_remove"', $output);
+        $this->assertStringContainsString('type="checkbox"', $output);
+    }
+}

--- a/application/test/OmekaTest/Stdlib/CipherTest.php
+++ b/application/test/OmekaTest/Stdlib/CipherTest.php
@@ -60,6 +60,15 @@ class CipherTest extends TestCase
         $this->assertSame('', $cipher->encrypt(''));
     }
 
+    public function testCleartextStartingWithPrefixIsEncrypted()
+    {
+        $cipher = new Cipher($this->key());
+        $value = Cipher::PREFIX . 'not-a-real-ciphertext';
+        $encrypted = $cipher->encrypt($value);
+        $this->assertNotSame($value, $encrypted);
+        $this->assertSame($value, $cipher->decrypt($encrypted));
+    }
+
     public function testLegacyClearValueIsReturnedAsIs()
     {
         $cipher = new Cipher($this->key());

--- a/application/test/OmekaTest/Stdlib/CipherTest.php
+++ b/application/test/OmekaTest/Stdlib/CipherTest.php
@@ -1,0 +1,87 @@
+<?php
+namespace OmekaTest\Stdlib;
+
+use Omeka\Stdlib\Cipher;
+use Omeka\Test\TestCase;
+
+class CipherTest extends TestCase
+{
+    private function key($byte = "\x01")
+    {
+        return base64_encode(str_repeat($byte, SODIUM_CRYPTO_SECRETBOX_KEYBYTES));
+    }
+
+    public function testRoundTrip()
+    {
+        $cipher = new Cipher($this->key());
+        $this->assertTrue($cipher->isEnabled());
+        $encrypted = $cipher->encrypt('secret-value');
+        $this->assertStringStartsWith(Cipher::PREFIX, $encrypted);
+        $this->assertSame('secret-value', $cipher->decrypt($encrypted));
+    }
+
+    public function testEncryptionIsNonDeterministic()
+    {
+        $cipher = new Cipher($this->key());
+        $this->assertNotSame($cipher->encrypt('x'), $cipher->encrypt('x'));
+    }
+
+    public function testEncryptIsIdempotentOnCiphertext()
+    {
+        $cipher = new Cipher($this->key());
+        $encrypted = $cipher->encrypt('x');
+        $this->assertSame($encrypted, $cipher->encrypt($encrypted));
+    }
+
+    public function testEmptyValueIsNotEncrypted()
+    {
+        $cipher = new Cipher($this->key());
+        $this->assertSame('', $cipher->encrypt(''));
+    }
+
+    public function testLegacyClearValueIsReturnedAsIs()
+    {
+        $cipher = new Cipher($this->key());
+        $this->assertSame('plain-legacy', $cipher->decrypt('plain-legacy'));
+    }
+
+    /**
+     * @dataProvider invalidKeyProvider
+     */
+    public function testDisabledWithoutValidKey($invalidKey)
+    {
+        $cipher = new Cipher($invalidKey);
+        $this->assertFalse($cipher->isEnabled());
+        $this->assertSame('x', $cipher->encrypt('x'));
+        $this->assertSame('plain', $cipher->decrypt('plain'));
+    }
+
+    public function invalidKeyProvider()
+    {
+        return [
+            'null' => [null],
+            'empty' => [''],
+            'not base64' => ['not base64 !!!'],
+            'too short' => [base64_encode('short')],
+        ];
+    }
+
+    public function testDisabledCipherCannotReadCiphertext()
+    {
+        $encrypted = (new Cipher($this->key()))->encrypt('x');
+        $this->assertSame('', (new Cipher(null))->decrypt($encrypted));
+    }
+
+    public function testWrongKeyFailsToDecrypt()
+    {
+        $encrypted = (new Cipher($this->key("\x01")))->encrypt('x');
+        $this->assertSame('', (new Cipher($this->key("\x02")))->decrypt($encrypted));
+    }
+
+    public function testTamperedCiphertextFailsToDecrypt()
+    {
+        $cipher = new Cipher($this->key());
+        $this->assertSame('', $cipher->decrypt(Cipher::PREFIX . base64_encode('too-short')));
+        $this->assertSame('', $cipher->decrypt(Cipher::PREFIX . 'not-base64-!!'));
+    }
+}

--- a/application/test/OmekaTest/Stdlib/CipherTest.php
+++ b/application/test/OmekaTest/Stdlib/CipherTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace OmekaTest\Stdlib;
 
 use Omeka\Stdlib\Cipher;
@@ -18,6 +19,26 @@ class CipherTest extends TestCase
         $encrypted = $cipher->encrypt('secret-value');
         $this->assertStringStartsWith(Cipher::PREFIX, $encrypted);
         $this->assertSame('secret-value', $cipher->decrypt($encrypted));
+    }
+
+    public function testDecryptsAValueEncryptedWithAPreviousKey()
+    {
+        $old = $this->key("\x01");
+        $new = $this->key("\x02");
+        $encrypted = (new Cipher($old))->encrypt('secret-value');
+        // Current key first, previous key next: the old value is still
+        // readable.
+        $this->assertSame('secret-value', (new Cipher([$new, $old]))->decrypt($encrypted));
+    }
+
+    public function testEncryptsWithTheCurrentKey()
+    {
+        $old = $this->key("\x01");
+        $new = $this->key("\x02");
+        $encrypted = (new Cipher([$new, $old]))->encrypt('secret-value');
+        // Encrypted with the current key: readable by it, not by the old one.
+        $this->assertSame('secret-value', (new Cipher($new))->decrypt($encrypted));
+        $this->assertSame('', (new Cipher($old))->decrypt($encrypted));
     }
 
     public function testEncryptionIsNonDeterministic()

--- a/application/test/OmekaTest/Stdlib/SecretKeyTest.php
+++ b/application/test/OmekaTest/Stdlib/SecretKeyTest.php
@@ -1,0 +1,62 @@
+<?php
+namespace OmekaTest\Stdlib;
+
+use Omeka\Stdlib\SecretKey;
+use Omeka\Test\TestCase;
+
+class SecretKeyTest extends TestCase
+{
+    private $dir;
+
+    public function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/omeka-secretkey-' . uniqid();
+        mkdir($this->dir);
+        putenv(SecretKey::ENV);
+    }
+
+    public function tearDown(): void
+    {
+        @unlink($this->dir . '/' . SecretKey::FILE);
+        @rmdir($this->dir);
+        putenv(SecretKey::ENV);
+    }
+
+    public function testGenerateIsBase64Of32RandomBytes()
+    {
+        $key = SecretKey::generate();
+        $this->assertSame(32, strlen((string) base64_decode($key, true)));
+        $this->assertNotSame(SecretKey::generate(), SecretKey::generate());
+    }
+
+    public function testResolveReturnsNullWhenNothingIsSet()
+    {
+        $this->assertNull(SecretKey::resolve($this->dir));
+    }
+
+    public function testStoreThenResolveRoundTrip()
+    {
+        $key = SecretKey::generate();
+        $this->assertTrue(SecretKey::store($key, $this->dir));
+        $this->assertSame($key, SecretKey::resolve($this->dir));
+    }
+
+    public function testFileTakesPrecedenceOverEnvironment()
+    {
+        $fileKey = SecretKey::generate();
+        SecretKey::store($fileKey, $this->dir);
+        putenv(SecretKey::ENV . '=env-key');
+        $this->assertSame($fileKey, SecretKey::resolve($this->dir));
+    }
+
+    public function testEnvironmentIsUsedWhenThereIsNoFile()
+    {
+        putenv(SecretKey::ENV . '=env-key');
+        $this->assertSame('env-key', SecretKey::resolve($this->dir));
+    }
+
+    public function testStoreReturnsFalseWhenDirectoryIsNotWritable()
+    {
+        $this->assertFalse(SecretKey::store(SecretKey::generate(), $this->dir . '/missing'));
+    }
+}

--- a/application/test/OmekaTest/Stdlib/SecretKeyTest.php
+++ b/application/test/OmekaTest/Stdlib/SecretKeyTest.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 namespace OmekaTest\Stdlib;
 
 use Omeka\Stdlib\SecretKey;
@@ -29,16 +30,28 @@ class SecretKeyTest extends TestCase
         $this->assertNotSame(SecretKey::generate(), SecretKey::generate());
     }
 
-    public function testResolveReturnsNullWhenNothingIsSet()
+    public function testResolveReturnsEmptyArrayWhenNothingIsSet()
     {
-        $this->assertNull(SecretKey::resolve($this->dir));
+        $this->assertSame([], SecretKey::resolve($this->dir));
     }
 
     public function testStoreThenResolveRoundTrip()
     {
         $key = SecretKey::generate();
         $this->assertTrue(SecretKey::store($key, $this->dir));
-        $this->assertSame($key, SecretKey::resolve($this->dir));
+        $this->assertSame([$key], SecretKey::resolve($this->dir));
+    }
+
+    public function testResolveReturnsAllKeysFromFileInOrder()
+    {
+        file_put_contents($this->dir . '/' . SecretKey::FILE, "<?php return ['current', 'previous'];");
+        $this->assertSame(['current', 'previous'], SecretKey::resolve($this->dir));
+    }
+
+    public function testResolveNormalizesALegacyStringFile()
+    {
+        file_put_contents($this->dir . '/' . SecretKey::FILE, "<?php return 'legacy';");
+        $this->assertSame(['legacy'], SecretKey::resolve($this->dir));
     }
 
     public function testFileTakesPrecedenceOverEnvironment()
@@ -46,13 +59,13 @@ class SecretKeyTest extends TestCase
         $fileKey = SecretKey::generate();
         SecretKey::store($fileKey, $this->dir);
         putenv(SecretKey::ENV . '=env-key');
-        $this->assertSame($fileKey, SecretKey::resolve($this->dir));
+        $this->assertSame([$fileKey], SecretKey::resolve($this->dir));
     }
 
     public function testEnvironmentIsUsedWhenThereIsNoFile()
     {
         putenv(SecretKey::ENV . '=env-key');
-        $this->assertSame('env-key', SecretKey::resolve($this->dir));
+        $this->assertSame(['env-key'], SecretKey::resolve($this->dir));
     }
 
     public function testStoreReturnsFalseWhenDirectoryIsNotWritable()

--- a/config/local.config.php.dist
+++ b/config/local.config.php.dist
@@ -1,4 +1,11 @@
 <?php
+
+// The secret key used to encrypt sensitive data is set automatically on
+// install or upgrade in config/secret_key.php. When config/ is unwriteable,
+// it can be set via environment variable OMEKA_SECRET_KEY.
+// An empty key makes secrets stored in clear. Losing it makes encrypted
+// values unrecoverable.
+
 return [
     'logger' => [
         'log' => false,


### PR DESCRIPTION
All cms have one or multiple random encrypt keys, for example to protect a api key (in particular modules AiGenerator and Translator or a module that will follow more strictly the grpd). 
So this pr adds it in omeka (config/secret_key.php and env) and a form element to use it.

I disabled copilot on pr, but i'm not sure i can because it seems to be enabled even if it is disabled, so it is a check for that too.