### PR TITLE
Set Download parameter for ThumbnailRenderer file link

### DIFF
--- a/application/src/Media/FileRenderer/ThumbnailRenderer.php
+++ b/application/src/Media/FileRenderer/ThumbnailRenderer.php
@@ -23,7 +23,14 @@ class ThumbnailRenderer extends AbstractRenderer
         }
 
         $title = $media->displayTitle();
+        $source = $media->source();
 
-        return sprintf('<a href="%s" title="%s">%s</a>', $view->escapeHtml($url), $view->escapeHtml($title), $img);
+        return sprintf(
+            '<a href="%s" download="%s" title="%s">%s</a>',
+            $view->escapeHtml($url),
+            $view->escapeHtml($source),
+            $view->escapeHtml($title),
+            $img,
+        );
     }
 }


### PR DESCRIPTION
This resolves issue  #2396 by setting the download tag on the ThumbnailRenderer file link, so the file download uses the original file name and not the internal media resource ID.