### PR TITLE
Check media ownership on item update and media create

### DIFF
--- a/application/src/Api/Adapter/ItemAdapter.php
+++ b/application/src/Api/Adapter/ItemAdapter.php
@@ -174,10 +174,18 @@ class ItemAdapter extends AbstractResourceEntityAdapter
         $append = $isPartial && 'append' === $request->getOption('collectionAction');
         $remove = $isPartial && 'remove' === $request->getOption('collectionAction');
 
+        // Media that already belong to this item, keyed by ID.
+        $itemMedia = $entity->getMedia()->toArray();
+
         if ($this->shouldHydrate($request, 'o:primary_media')) {
             $primaryMedia = $request->getValue('o:primary_media');
             if (isset($primaryMedia['o:id']) && is_numeric($primaryMedia['o:id'])) {
-                $entity->setPrimaryMedia($this->getAdapter('media')->findEntity($primaryMedia['o:id']));
+                $media = $itemMedia[$primaryMedia['o:id']] ?? null;
+                if ($media) {
+                    $entity->setPrimaryMedia($media);
+                } else {
+                    $errorStore->addError('o:primary_media', 'Primary media must belong to this item.'); // @translate
+                }
             } else {
                 $entity->setPrimaryMedia(null);
             }
@@ -291,12 +299,18 @@ class ItemAdapter extends AbstractResourceEntityAdapter
             foreach ($mediasData as $mediaData) {
                 $subErrorStore = new ErrorStore;
                 if (isset($mediaData['o:id'])) {
-                    $media = $adapter->findEntity($mediaData['o:id']);
-                    $media->setPosition($position);
-                    if (isset($mediaData['o:is_public'])) {
-                        $media->setIsPublic($mediaData['o:is_public']);
+                    $media = is_numeric($mediaData['o:id'])
+                        ? ($itemMedia[$mediaData['o:id']] ?? null)
+                        : null;
+                    if ($media) {
+                        $media->setPosition($position);
+                        if (isset($mediaData['o:is_public'])) {
+                            $media->setIsPublic($mediaData['o:is_public']);
+                        }
+                        $retainMedia[] = $media;
+                    } else {
+                        $errorStore->addError('o:media', 'Media must belong to this item.'); // @translate
                     }
-                    $retainMedia[] = $media;
                 } else {
                     // Create a new media.
                     $media = new $class;

--- a/application/src/Api/Adapter/MediaAdapter.php
+++ b/application/src/Api/Adapter/MediaAdapter.php
@@ -142,6 +142,7 @@ class MediaAdapter extends AbstractResourceEntityAdapter
             if (isset($data['o:item']['o:id'])) {
                 $item = $this->getAdapter('items')
                     ->findEntity($data['o:item']['o:id']);
+                $this->authorize($item, 'update');
                 $entity->setItem($item);
             }
             if (isset($data['data'])) {


### PR DESCRIPTION
Item update accepted any media ID in `o:media` and `o:primary_media` without checking it belonged to the item, so a user could reorder another user's media or change its public flag. They could also point their own item's primary media at media they do not own. Media create accepted any `o:item` without a permission check, and `hydrateOwner()` then assigned the new media to that item's owner.

Item update now accepts only media the item already has. Media create requires `update` on the target item. No functionality is lost: media could never be moved between items at all.

`findEntity()` is gone because it resolves an ID against every media in the installation, which is what made the bug possible. One decision worth flagging in the replacement: media are resolved from a `toArray()` snapshot taken up front, rather than by calling `getMedia()->get()` at each lookup. New media get appended under integer keys that can collide with real IDs, so a live `get()` can return an unsaved media. That check is skipped, and the item's real media are deleted as missing from the request.

Removing `findEntity()` also removes one query per media named in the request. The snapshot that replaces it is free: the item's media collection is loaded either way (`saveFulltext` walks it after every item write).