### PR TITLE
changed how $owner is found for Job/Dispatcher.php

### DIFF
--- a/application/src/Job/Dispatcher.php
+++ b/application/src/Job/Dispatcher.php
@@ -80,7 +80,11 @@ class Dispatcher
         $job->setStatus(Job::STATUS_STARTING);
         $job->setClass($class);
         $job->setArgs($args);
-        $owner = $this->auth->getIdentity(); if ($owner) { $owner = $this->entityManager->getReference(\Omeka\Entity\User::class, $owner->getId()); } $job->setOwner($owner);
+        $owner = $this->auth->getIdentity();
+        if ($owner) {
+            $owner = $this->entityManager->getReference(\Omeka\Entity\User::class, $owner->getId());
+        }
+        $job->setOwner($owner);
         $this->entityManager->persist($job);
         $this->entityManager->flush();
 

--- a/application/src/Job/Dispatcher.php
+++ b/application/src/Job/Dispatcher.php
@@ -80,7 +80,7 @@ class Dispatcher
         $job->setStatus(Job::STATUS_STARTING);
         $job->setClass($class);
         $job->setArgs($args);
-        $job->setOwner($this->auth->getIdentity());
+        $owner = $this->auth->getIdentity(); if ($owner) { $owner = $this->entityManager->getReference(\Omeka\Entity\User::class, $owner->getId()); } $job->setOwner($owner);
         $this->entityManager->persist($job);
         $this->entityManager->flush();
 


### PR DESCRIPTION
This change is intended to resolve this error when running an AdvancedSearch\Job\IndexSearch.

In the GUI, I navigate to /admin/search-manager then click "ReIndex" on my Search Engine: "solr".  Here are my module versions pinned in a Dockerfile:  https://github.com/uncw-library/omeka-s.git

The error:

2026-08-21T15:55:21+00:00 ERR (3): Doctrine\ORM\ORMInvalidArgumentException: A new entity was found through the relationship 'Omeka\Entity\Job#owner' that was not configured to cascade persist operations for entity: DoctrineProxies_CG_\Omeka\Entity\User@1071. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example #[ORM\ManyToOne(..., cascade: ['persist'])]. If you cannot find out which entity causes the problem implement 'Omeka\Entity\User#__toString()' to get a clue. in /var/www/html/vendor/doctrine/orm/src/ORMInvalidArgumentException.php:103


This pull request resolves that error.
Please let me know of any thoughts or questions,
Garrett Armstrong


Full error message:
2026-08-21T17:56:49+00:00 DEBUG (7): Process done with the main entity manager {"referenceId":"search/index/job_969"}
2026-08-21T17:56:49+00:00 NOTICE (5): Search index #2 ("solr"): start of indexing {"referenceId":"search/index/job_969"}
2026-08-21T17:56:53+00:00 INFO (6): Search index #2 ("solr"): end of indexing. item_sets: 9 indexed; items: 266 indexed. Execution time: 4 seconds. Failed indexed resources should be checked manually. {"referenceId":"search/index/job_969"}
2026-08-21T17:56:53+00:00 INFO (6): End of indexing. Execution time: 4 seconds. Max memory: 46137344. Failed indexed resources should be checked manually. {"referenceId":"search/index/job_969"}
2026-08-21T17:56:53+00:00 ERR (3): Doctrine\ORM\ORMInvalidArgumentException: A new entity was found through the relationship 'Omeka\Entity\Job#owner' that was not configured to cascade persist operations for entity: DoctrineProxies\__CG__\Omeka\Entity\User@1071. To solve this issue: Either explicitly call EntityManager#persist() on this unknown entity or configure cascade persist this association in the mapping for example #[ORM\ManyToOne(..., cascade: ['persist'])]. If you cannot find out which entity causes the problem implement 'Omeka\Entity\User#__toString()' to get a clue. in /var/www/html/vendor/doctrine/orm/src/ORMInvalidArgumentException.php:103
Stack trace:
#0 /var/www/html/vendor/doctrine/orm/src/UnitOfWork.php(3864): Doctrine\ORM\ORMInvalidArgumentException::newEntitiesFoundThroughRelationships()
#1 /var/www/html/vendor/doctrine/orm/src/UnitOfWork.php(418): Doctrine\ORM\UnitOfWork->assertThatThereAreNoUnintentionallyNonPersistedAssociations()
#2 /var/www/html/vendor/doctrine/orm/src/EntityManager.php(414): Doctrine\ORM\UnitOfWork->commit()
#3 /var/www/html/application/src/Job/Dispatcher.php(85): Doctrine\ORM\EntityManager->flush()
#4 /var/www/html/modules/AdvancedSearch/src/Job/IndexSearch.php(776): Omeka\Job\Dispatcher->dispatch()
#5 /var/www/html/modules/AdvancedSearch/src/Job/IndexSearch.php(303): AdvancedSearch\Job\IndexSearch->reindexSuggesters()
#6 /var/www/html/application/src/Job/DispatchStrategy/Synchronous.php(34): AdvancedSearch\Job\IndexSearch->perform()
#7 /var/www/html/modules/Common/src/Job/Dispatcher.php(27): Omeka\Job\DispatchStrategy\Synchronous->send()
#8 /var/www/html/application/data/scripts/perform-job.php(66): Common\Job\Dispatcher->send()
#9 {main} {"referenceId":"search/index/job_969"}