### PR TITLE
Drop the dead show_title line in the IIIF block layouts

### DIFF
--- a/application/src/Site/BlockLayout/IiifImage.php
+++ b/application/src/Site/BlockLayout/IiifImage.php
@@ -70,7 +70,6 @@ class IiifImage extends AbstractBlockLayout
         $blockData['title'] = is_string($blockData['title'])
             ? trim($blockData['title'])
             : $this->defaultBlockData['title'];
-        $blockData['show_title'] = $blockData['show_title'];
         $block->setData($blockData);
     }
 

--- a/application/src/Site/BlockLayout/IiifPresentation.php
+++ b/application/src/Site/BlockLayout/IiifPresentation.php
@@ -70,7 +70,6 @@ class IiifPresentation extends AbstractBlockLayout
         $blockData['title'] = is_string($blockData['title'])
             ? trim($blockData['title'])
             : $this->defaultBlockData['title'];
-        $blockData['show_title'] = $blockData['show_title'];
         $block->setData($blockData);
     }
 


### PR DESCRIPTION
Both IIIF block layouts end their "Sanitize user data" section with `$blockData['show_title'] = $blockData['show_title'];`, which assigns the key to itself and does nothing. The two lines above it do real work, falling back to `defaultBlockData` when the value is not a string.

I dropped the line rather than giving it a sanitizer, because `show_title` does not need one the way `image_url` and `title` do: it comes from a checkbox and `render()` reads it as `(bool) $block->dataValue('show_title')`, so whatever is stored is already coerced at the point of use. Adding a cast in `onHydrate` would change what sits in the database for existing blocks, and that is a bigger decision than this line deserves.

Same line in both files, so both get the same removal.
